### PR TITLE
restrict ingestion server to public interface

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,7 +21,7 @@ micromegas-telemetry = { path = "telemetry", version = "0.1.1" }
 micromegas-telemetry-sink = { path = "telemetry-sink", version = "0.1.1" }
 micromegas-tracing = { path = "tracing", version = "0.1.1" }
 micromegas-transit = { path = "transit", version = "0.1.1" }
-public = { path = "public" }
+micromegas = { path = "public" }
 
 anyhow = "1.0"
 async-recursion = "1"

--- a/rust/public/Cargo.toml
+++ b/rust/public/Cargo.toml
@@ -13,5 +13,7 @@ authors.workspace = true
 [dependencies]
 micromegas-ingestion.workspace = true
 micromegas-telemetry.workspace = true
+micromegas-telemetry-sink.workspace = true
+micromegas-tracing.workspace = true
 
 object_store.workspace = true

--- a/rust/public/src/lib.rs
+++ b/rust/public/src/lib.rs
@@ -6,6 +6,14 @@ pub mod telemetry {
     pub use micromegas_telemetry::*;
 }
 
+pub mod telemetry_sink {
+    pub use micromegas_telemetry_sink::*;
+}
+
+pub mod tracing {
+    pub use micromegas_tracing::*;
+}
+
 pub mod ingestion {
     pub use micromegas_ingestion::*;
 }

--- a/rust/telemetry-ingestion-srv/Cargo.toml
+++ b/rust/telemetry-ingestion-srv/Cargo.toml
@@ -11,11 +11,7 @@ authors.workspace = true
 default-run = "telemetry-ingestion-srv"
 
 [dependencies]
-
-micromegas-ingestion.workspace = true
-micromegas-telemetry-sink.workspace = true
-micromegas-telemetry.workspace = true
-micromegas-tracing.workspace = true
+micromegas.workspace = true
 
 anyhow.workspace = true
 axum.workspace = true

--- a/rust/telemetry-ingestion-srv/src/main.rs
+++ b/rust/telemetry-ingestion-srv/src/main.rs
@@ -17,12 +17,12 @@ use axum::Extension;
 use axum::Json;
 use axum::Router;
 use clap::Parser;
-use micromegas_ingestion::data_lake_connection::DataLakeConnection;
-use micromegas_ingestion::remote_data_lake::connect_to_remote_data_lake;
-use micromegas_ingestion::web_ingestion_service::WebIngestionService;
-use micromegas_telemetry::stream_info::StreamInfo;
-use micromegas_telemetry_sink::TelemetryGuardBuilder;
-use micromegas_tracing::prelude::*;
+use micromegas::ingestion::data_lake_connection::DataLakeConnection;
+use micromegas::ingestion::remote_data_lake::connect_to_remote_data_lake;
+use micromegas::ingestion::web_ingestion_service::WebIngestionService;
+use micromegas::telemetry::stream_info::StreamInfo;
+use micromegas::telemetry_sink::TelemetryGuardBuilder;
+use micromegas::tracing::prelude::*;
 use std::net::SocketAddr;
 use tower_http::limit::RequestBodyLimitLayer;
 

--- a/rust/telemetry-ingestion-srv/test/generator.rs
+++ b/rust/telemetry-ingestion-srv/test/generator.rs
@@ -1,7 +1,7 @@
 //! Generator test
 
-use micromegas_telemetry_sink::TelemetryGuard;
-use micromegas_tracing::prelude::*;
+use micromegas::telemetry_sink::TelemetryGuard;
+use micromegas::tracing::prelude::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
making tracing & sink modules public