### PR TITLE
log interop with tracing crate

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -64,6 +64,9 @@ tokio = { version = "1.33", features = ["macros","rt-multi-thread","tracing"]}
 tokio-retry = "0.3"
 tower = "0.4"
 tower-http = { version = "0.5.2", features = ["limit"] }
+tracing = "0.1.40"
+tracing-core = "0.1.32"
+tracing-subscriber = "0.3.18"
 url = "2.5.0"
 uuid = { version = "1.8", features = ["v4", "serde"] }
 whoami = "1.2"

--- a/rust/telemetry-sink/Cargo.toml
+++ b/rust/telemetry-sink/Cargo.toml
@@ -30,6 +30,9 @@ serde_json.workspace = true
 time = {workspace = true, optional = true}
 tokio-retry.workspace = true
 tokio.workspace = true
+tracing-subscriber.workspace = true
+tracing-core.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 
 [features]

--- a/rust/telemetry-sink/src/tracing_interop.rs
+++ b/rust/telemetry-sink/src/tracing_interop.rs
@@ -1,0 +1,82 @@
+use micromegas_tracing::{
+    dispatch::log_interop,
+    levels::LevelFilter,
+    logs::{LogMetadata, FILTER_LEVEL_UNSET_VALUE},
+};
+use std::sync::atomic::AtomicU32;
+use tracing_subscriber::{layer::Context, prelude::*};
+
+use std::fmt::{self, Write};
+use tracing::field::{Field, Visit};
+pub struct FieldFormatVisitor<'a> {
+    pub buffer: &'a mut String,
+}
+
+impl<'a> Visit for FieldFormatVisitor<'a> {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if field.name() == "message" {
+            write!(self.buffer, "{:?} ", value).unwrap();
+        } else {
+            write!(self.buffer, "{}={:?} ", field.name(), value).unwrap();
+        }
+    }
+}
+
+struct TracingCaptureLayer {
+    pub max_level: LevelFilter,
+}
+
+impl<S> tracing_subscriber::Layer<S> for TracingCaptureLayer
+where
+    S: tracing::Subscriber,
+{
+    fn enabled(&self, metadata: &tracing::Metadata<'_>, _ctx: Context<'_, S>) -> bool {
+        let level = tracing_level_to_mm_level(metadata.level());
+        level <= self.max_level
+    }
+
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let level = tracing_level_to_mm_level(event.metadata().level());
+        if level > self.max_level {
+            return;
+        }
+        let log_desc = LogMetadata {
+            level,
+            level_filter: AtomicU32::new(FILTER_LEVEL_UNSET_VALUE),
+            fmt_str: "{}",
+            target: event.metadata().target(),
+            module_path: event.metadata().module_path().unwrap_or_default(),
+            file: "",
+            line: 0,
+        };
+        let mut buffer = String::new();
+        let mut formatter = FieldFormatVisitor {
+            buffer: &mut buffer,
+        };
+        event.record(&mut formatter);
+        log_interop(&log_desc, format_args!("{}", &buffer));
+    }
+}
+
+pub fn install_tracing_interop(interop_max_level_override: Option<LevelFilter>) {
+    let max_level = interop_max_level_override.unwrap_or(micromegas_tracing::levels::max_level());
+
+    tracing_subscriber::registry()
+        .with(TracingCaptureLayer { max_level })
+        .init();
+    tracing::debug!("installed tracing interop");
+}
+
+fn tracing_level_to_mm_level(level: &tracing_core::Level) -> micromegas_tracing::levels::Level {
+    match *level {
+        tracing_core::Level::ERROR => micromegas_tracing::levels::Level::Error,
+        tracing_core::Level::WARN => micromegas_tracing::levels::Level::Warn,
+        tracing_core::Level::INFO => micromegas_tracing::levels::Level::Info,
+        tracing_core::Level::DEBUG => micromegas_tracing::levels::Level::Debug,
+        tracing_core::Level::TRACE => micromegas_tracing::levels::Level::Trace,
+    }
+}

--- a/rust/tracing/src/dispatch.rs
+++ b/rust/tracing/src/dispatch.rs
@@ -1,4 +1,5 @@
 pub use crate::errors::{Error, Result};
+use crate::intern_string::intern_string;
 use crate::prelude::*;
 use crate::{
     event::{EventSink, NullEventSink, TracingBlock},
@@ -488,14 +489,14 @@ impl Dispatch {
             log_stream.get_events_mut().push(LogStaticStrInteropEvent {
                 time,
                 level: desc.level as u32,
-                target: desc.target.into(),
+                target: intern_string(desc.target).into(),
                 msg: msg.into(),
             });
         } else {
             log_stream.get_events_mut().push(LogStringInteropEvent {
                 time,
                 level: desc.level as u32,
-                target: desc.target.into(),
+                target: intern_string(desc.target).into(),
                 msg: micromegas_transit::DynString(args.to_string()),
             });
         }

--- a/rust/tracing/src/intern_string.rs
+++ b/rust/tracing/src/intern_string.rs
@@ -1,0 +1,16 @@
+use std::{collections::HashSet, sync::Mutex};
+
+lazy_static! {
+    static ref LOCKED_HASH: Mutex<HashSet<String>> = Mutex::new(HashSet::new());
+}
+
+pub fn intern_string(input: &str) -> &'static str {
+    let mut lock = LOCKED_HASH.lock().unwrap();
+    if let Some(val) = lock.get(input) {
+        unsafe { std::mem::transmute::<&str, &'static str>(val) }
+    } else {
+        lock.insert(input.to_string());
+        let interned = lock.get(input).unwrap();
+        unsafe { std::mem::transmute::<&str, &'static str>(interned) }
+    }
+}

--- a/rust/tracing/src/lib.rs
+++ b/rust/tracing/src/lib.rs
@@ -63,7 +63,11 @@ pub mod string_id;
 pub mod time;
 
 #[macro_use]
+extern crate lazy_static;
+
+#[macro_use]
 mod macros;
+pub mod intern_string;
 
 pub mod prelude {
     pub use crate::levels::*;

--- a/rust/tracing/src/logs/events.rs
+++ b/rust/tracing/src/logs/events.rs
@@ -3,13 +3,13 @@ use micromegas_transit::prelude::*;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 #[derive(Debug)]
-pub struct LogMetadata {
+pub struct LogMetadata<'a> {
     pub level: Level,
     pub level_filter: AtomicU32,
-    pub fmt_str: &'static str,
-    pub target: &'static str,
-    pub module_path: &'static str,
-    pub file: &'static str,
+    pub fmt_str: &'a str,
+    pub target: &'a str,
+    pub module_path: &'a str,
+    pub file: &'a str,
     pub line: u32,
 }
 
@@ -25,7 +25,7 @@ pub enum FilterState {
     Set(LevelFilter),
 }
 
-impl LogMetadata {
+impl LogMetadata<'_> {
     /// This is a way to efficiency implement finer grade filtering by amortizing its
     /// cost. An atomic is used to store a level filter and a 16 bit generation.
     /// Allowing a config update to be applied to the level filter multiple times during
@@ -88,7 +88,7 @@ impl LogMetadata {
 
 #[derive(Debug, TransitReflect)]
 pub struct LogStaticStrEvent {
-    pub desc: &'static LogMetadata,
+    pub desc: &'static LogMetadata<'static>,
     pub time: i64,
 }
 
@@ -96,7 +96,7 @@ impl InProcSerialize for LogStaticStrEvent {}
 
 #[derive(Debug)]
 pub struct LogStringEvent {
-    pub desc: &'static LogMetadata,
+    pub desc: &'static LogMetadata<'static>,
     pub time: i64,
     pub dyn_str: DynString,
 }


### PR DESCRIPTION
- optional log & tracing capture in TelemetryGuardBuilder
- moved intern_string to tracing crate
- LogMetadata string lifetimes