### PR TITLE
query_request

### DIFF
--- a/python/micromegas/micromegas/client.py
+++ b/python/micromegas/micromegas/client.py
@@ -132,6 +132,15 @@ class Client:
             headers=self.headers,
         )
 
+    def query(self, sql):
+        return request.request(
+            self.analytics_base_url + "query",
+            {
+                "sql": sql,
+            },
+            headers=self.headers,
+        )
+    
     def query_partitions(self):
         args = {}
         return request.request(

--- a/python/micromegas/tests/test_log.py
+++ b/python/micromegas/tests/test_log.py
@@ -18,3 +18,9 @@ def test_whole_log_query():
     sql = "select count(*) from log_entries;"
     rows = client.query_view("log_entries", "global", begin=None, end=None, sql=sql)
     print(rows)
+
+def test_implicit_log_query():
+    # query with no specified time range
+    rows = client.query("SELECT COUNT(*) FROM log_entries;")
+    print(rows)
+    

--- a/rust/analytics-srv/src/main.rs
+++ b/rust/analytics-srv/src/main.rs
@@ -12,7 +12,7 @@ use axum::{Extension, Router};
 use clap::Parser;
 use micromegas::analytics::analytics_service::AnalyticsService;
 use micromegas::analytics::lakehouse::migration::migrate_lakehouse;
-use micromegas::analytics::lakehouse::view_factory::ViewFactory;
+use micromegas::analytics::lakehouse::view_factory::{default_view_factory, ViewFactory};
 use micromegas::axum_utils::observability_middleware;
 use micromegas::ingestion::data_lake_connection::{connect_to_data_lake, DataLakeConnection};
 use micromegas::servers::analytics::register_routes;
@@ -64,7 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     migrate_lakehouse(data_lake.db_pool.clone())
         .await
         .with_context(|| "migrate_lakehouse")?;
-    let view_factory = ViewFactory::default();
+    let view_factory = default_view_factory()?;
     serve_http(&args, Arc::new(data_lake), Arc::new(view_factory)).await?;
     Ok(())
 }

--- a/rust/public/src/servers/analytics.rs
+++ b/rust/public/src/servers/analytics.rs
@@ -137,6 +137,13 @@ pub async fn query_view_request(
     bytes_response(service.query_view(body).await.with_context(|| "query_view"))
 }
 
+pub async fn query_request(
+    Extension(service): Extension<Arc<AnalyticsService>>,
+    body: bytes::Bytes,
+) -> Response {
+    bytes_response(service.query(body).await.with_context(|| "query"))
+}
+
 pub async fn query_partitions_request(
     Extension(service): Extension<Arc<AnalyticsService>>,
 ) -> Response {
@@ -186,6 +193,7 @@ pub fn register_routes(router: Router) -> Router {
         )
         .route("/analytics/query_metrics", post(query_metrics_request))
         .route("/analytics/query_view", post(query_view_request))
+        .route("/analytics/query", post(query_request))
         .route(
             "/analytics/query_thread_events",
             post(query_thread_events_request),

--- a/rust/telemetry-admin-cli/src/telemetry_admin.rs
+++ b/rust/telemetry-admin-cli/src/telemetry_admin.rs
@@ -8,7 +8,7 @@ use micromegas::analytics::lakehouse::batch_update::materialize_partition_range;
 use micromegas::analytics::lakehouse::migration::migrate_lakehouse;
 use micromegas::analytics::lakehouse::partition_cache::PartitionCache;
 use micromegas::analytics::lakehouse::temp::delete_expired_temporary_files;
-use micromegas::analytics::lakehouse::view_factory::ViewFactory;
+use micromegas::analytics::lakehouse::view_factory::default_view_factory;
 use micromegas::analytics::lakehouse::write_partition::retire_partitions;
 use micromegas::analytics::response_writer::ResponseWriter;
 use micromegas::chrono::DateTime;
@@ -76,7 +76,7 @@ async fn main() -> Result<()> {
     migrate_lakehouse(data_lake.db_pool.clone())
         .await
         .with_context(|| "migrate_lakehouse")?;
-    let view_factory = ViewFactory::default();
+    let view_factory = default_view_factory()?;
     let null_response_writer = Arc::new(ResponseWriter::new(None));
     match args.command {
         Commands::DeleteOldData { min_days_old } => {


### PR DESCRIPTION
log_entries and measures are implicitly available to sql queries using client.query