### PR TITLE
query_partitions

### DIFF
--- a/rust/analytics/src/lakehouse/batch_update.rs
+++ b/rust/analytics/src/lakehouse/batch_update.rs
@@ -125,6 +125,9 @@ async fn materialize_partition(
         )
         .await
         .with_context(|| "make_batch_partition_spec")?;
+    if partition_spec.is_empty() {
+        return Ok(());
+    }
     let view_instance_id = view.get_view_instance_id();
     let strategy = verify_overlapping_partitions(
         &existing_partitions,

--- a/rust/analytics/src/lakehouse/block_partition_spec.rs
+++ b/rust/analytics/src/lakehouse/block_partition_spec.rs
@@ -37,6 +37,10 @@ pub struct BlockPartitionSpec {
 
 #[async_trait]
 impl PartitionSpec for BlockPartitionSpec {
+    fn is_empty(&self) -> bool {
+        self.source_data.blocks.is_empty()
+    }
+
     fn get_source_data_hash(&self) -> Vec<u8> {
         self.source_data.block_ids_hash.clone()
     }

--- a/rust/analytics/src/lakehouse/blocks_view.rs
+++ b/rust/analytics/src/lakehouse/blocks_view.rs
@@ -112,7 +112,6 @@ impl View for BlocksView {
         anyhow::bail!("not supported");
     }
 
-    // fetch_partition_source_data relies on this filter being on insert_time
     fn make_time_filter(&self, begin: DateTime<Utc>, end: DateTime<Utc>) -> Result<Vec<Expr>> {
         let utc: Arc<str> = Arc::from("+00:00");
         Ok(vec![Expr::Between(Between::new(

--- a/rust/analytics/src/lakehouse/metadata_partition_spec.rs
+++ b/rust/analytics/src/lakehouse/metadata_partition_spec.rs
@@ -58,6 +58,10 @@ pub async fn fetch_metadata_partition_spec(
 
 #[async_trait]
 impl PartitionSpec for MetadataPartitionSpec {
+    fn is_empty(&self) -> bool {
+        self.record_count < 1
+    }
+
     fn get_source_data_hash(&self) -> Vec<u8> {
         self.record_count.to_le_bytes().to_vec()
     }

--- a/rust/analytics/src/lakehouse/sql_partition_spec.rs
+++ b/rust/analytics/src/lakehouse/sql_partition_spec.rs
@@ -56,6 +56,10 @@ impl SqlPartitionSpec {
 
 #[async_trait]
 impl PartitionSpec for SqlPartitionSpec {
+    fn is_empty(&self) -> bool {
+        self.record_count < 1
+    }
+
     fn get_source_data_hash(&self) -> Vec<u8> {
         self.record_count.to_le_bytes().to_vec()
     }

--- a/rust/analytics/src/lakehouse/view.rs
+++ b/rust/analytics/src/lakehouse/view.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 #[async_trait]
 pub trait PartitionSpec: Send + Sync {
+    fn is_empty(&self) -> bool;
     fn get_source_data_hash(&self) -> Vec<u8>;
     async fn write(&self, lake: Arc<DataLakeConnection>, logger: Arc<dyn Logger>) -> Result<()>;
 }

--- a/rust/analytics/src/lakehouse/write_partition.rs
+++ b/rust/analytics/src/lakehouse/write_partition.rs
@@ -91,7 +91,7 @@ pub async fn retire_partitions(
     // where a bigger one existed
     // its gets tricky in the jit case where a partition can have only one block and begin_insert == end_insert
 
-    //todo: use PartitionCache here, add filter_contained
+    //todo: use DELETE+RETURNING
     let old_partitions = sqlx::query(
         "SELECT file_path, file_size
          FROM lakehouse_partitions

--- a/rust/analytics/tests/sql_view_test.rs
+++ b/rust/analytics/tests/sql_view_test.rs
@@ -88,12 +88,17 @@ pub async fn materialize_range(
     partition_time_delta: TimeDelta,
     logger: Arc<dyn Logger>,
 ) -> Result<()> {
-    let mut partitions = Arc::new(
-        // todo: query only the blocks partitions for this call
-        PartitionCache::fetch_overlapping_insert_range(&lake.db_pool, begin_range, end_range)
-            .await?,
-    );
     let blocks_view = Arc::new(BlocksView::new()?);
+    let mut partitions = Arc::new(
+        PartitionCache::fetch_overlapping_insert_range_for_view(
+            &lake.db_pool,
+            blocks_view.get_view_set_name(),
+            blocks_view.get_view_instance_id(),
+            begin_range,
+            end_range,
+        )
+        .await?,
+    );
     materialize_partition_range(
         partitions.clone(),
         lake.clone(),

--- a/rust/public/src/servers/maintenance.rs
+++ b/rust/public/src/servers/maintenance.rs
@@ -86,9 +86,14 @@ pub async fn materialize_all_views(
     let end_range = now.duration_trunc(partition_time_delta)?;
     let begin_range = end_range - (partition_time_delta * nb_partitions);
     let mut partitions = Arc::new(
-        // todo: query only the blocks partitions for this call
-        PartitionCache::fetch_overlapping_insert_range(&lake.db_pool, begin_range, end_range)
-            .await?,
+        PartitionCache::fetch_overlapping_insert_range_for_view(
+            &lake.db_pool,
+            blocks_view.get_view_set_name(),
+            blocks_view.get_view_instance_id(),
+            begin_range,
+            end_range,
+        )
+        .await?,
     );
     let null_response_writer = Arc::new(ResponseWriter::new(None));
     materialize_partition_range(


### PR DESCRIPTION
Run a SQL query on a known set of parquet files without going through the more flexible query_view API