### PR TITLE
Exposed retry logic to request decorator implementors

### DIFF
--- a/rust/telemetry-sink/src/request_decorator.rs
+++ b/rust/telemetry-sink/src/request_decorator.rs
@@ -1,5 +1,53 @@
-use anyhow::Result;
+use std::fmt::Display;
+
 use async_trait::async_trait;
+
+/// An error that can occur when decorating a request.
+///
+/// Depending on the type of error, the request may be retried at a later time.
+#[derive(Debug)]
+pub enum RequestDecoratorError {
+    /// A permanent error occurred while decorating the request.
+    ///
+    /// No further attempts to decorate the request should be made.
+    Permanent(String),
+
+    /// A transient error occurred while decorating the request.
+    ///
+    /// The request may be retried at a later time.
+    Transient(String),
+}
+
+impl Display for RequestDecoratorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RequestDecoratorError::Permanent(msg) => {
+                write!(f, "failed to decorate request: permanent error: {msg}")
+            }
+            RequestDecoratorError::Transient(msg) => {
+                write!(f, "failed to decorate request: transient error: {msg}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RequestDecoratorError {}
+
+impl From<RequestDecoratorError> for tokio_retry2::RetryError<anyhow::Error> {
+    fn from(value: RequestDecoratorError) -> Self {
+        match value {
+            RequestDecoratorError::Permanent(msg) => tokio_retry2::RetryError::permanent(
+                anyhow::anyhow!("failed to decorate request: {msg}"),
+            ),
+            RequestDecoratorError::Transient(msg) => tokio_retry2::RetryError::transient(
+                anyhow::anyhow!("failed to decorate request: {msg}"),
+            ),
+        }
+    }
+}
+
+/// A result type for request decorators.
+type Result<T> = std::result::Result<T, RequestDecoratorError>;
 
 #[async_trait] // otherwise we get: cannot be made into an object
 pub trait RequestDecorator: Send {


### PR DESCRIPTION
This PR does several little things around the `RequestDecorator` trait.

1. It changes the `Result` type to **not** depend on `anyhow`.
2. It adds the ability for `RequestDecorator` implementers to express whether a request decoration error can be retried or not by the underlying MicroMegas logic. (The previous behavior was to **always** retry).
3. It auto-implements `RequestDecorator` on all `Arc<T: RequestDecorator + Sync>` which allows some non-clonable types to directly implement `RequestDecorator` without having to wrap them.