### PR TITLE
Added missing  for the TracingLayer

### DIFF
--- a/rust/telemetry-sink/src/tracing_interop.rs
+++ b/rust/telemetry-sink/src/tracing_interop.rs
@@ -30,7 +30,10 @@ impl Visit for FieldFormatVisitor<'_> {
     }
 }
 
-struct TracingCaptureLayer {
+/// A tracing layer compatible with `tracing_subscriber`.
+///
+/// Setting-up this layer still requires the proper initialization of a `TelemetryGuard`.
+pub struct TracingCaptureLayer {
     pub max_level: LevelFilter,
 }
 


### PR DESCRIPTION
This PR adds some documentation and exposes publicly the `TracingCaptureLayer`.