### PR TITLE
divide jit partitions into segments

### DIFF
--- a/rust/analytics/src/lakehouse/log_view.rs
+++ b/rust/analytics/src/lakehouse/log_view.rs
@@ -1,7 +1,7 @@
 use super::{
     batch_update::PartitionCreationStrategy,
     block_partition_spec::BlockPartitionSpec,
-    jit_partitions::write_partition_from_blocks,
+    jit_partitions::{write_partition_from_blocks, JitPartitionConfig},
     log_block_processor::LogBlockProcessor,
     partition_cache::PartitionCache,
     partition_source_data::fetch_partition_source_data,
@@ -138,9 +138,9 @@ impl View for LogView {
         let mut all_partitions = vec![];
         for stream in streams {
             let mut partitions = generate_jit_partitions(
+                &JitPartitionConfig::default(),
                 &lake.db_pool,
-                query_range.begin,
-                query_range.end,
+                &query_range,
                 Arc::new(stream),
                 process.clone(),
                 &convert_ticks,

--- a/rust/analytics/src/lakehouse/metrics_view.rs
+++ b/rust/analytics/src/lakehouse/metrics_view.rs
@@ -9,6 +9,7 @@ use super::{
     block_partition_spec::BlockPartitionSpec,
     jit_partitions::{
         generate_jit_partitions, is_jit_partition_up_to_date, write_partition_from_blocks,
+        JitPartitionConfig,
     },
     metrics_block_processor::MetricsBlockProcessor,
     partition_cache::PartitionCache,
@@ -145,9 +146,9 @@ impl View for MetricsView {
         let mut all_partitions = vec![];
         for stream in streams {
             let mut partitions = generate_jit_partitions(
+                &JitPartitionConfig::default(),
                 &lake.db_pool,
-                query_range.begin,
-                query_range.end,
+                &query_range,
                 Arc::new(stream),
                 process.clone(),
                 &convert_ticks,

--- a/rust/analytics/src/lakehouse/thread_spans_view.rs
+++ b/rust/analytics/src/lakehouse/thread_spans_view.rs
@@ -1,5 +1,5 @@
 use super::{
-    jit_partitions::{generate_jit_partitions, is_jit_partition_up_to_date},
+    jit_partitions::{generate_jit_partitions, is_jit_partition_up_to_date, JitPartitionConfig},
     partition_cache::PartitionCache,
     partition_source_data::{hash_to_object_count, PartitionSourceDataBlocks},
     view::{PartitionSpec, View, ViewMetadata},
@@ -231,9 +231,9 @@ impl View for ThreadSpansView {
         );
         let convert_ticks = make_time_converter_from_db(&lake.db_pool, &process).await?;
         let partitions = generate_jit_partitions(
+            &JitPartitionConfig::default(),
             &lake.db_pool,
-            query_range.begin,
-            query_range.end,
+            &query_range,
             stream.clone(),
             process.clone(),
             &convert_ticks,


### PR DESCRIPTION
when requesting a small portion of the log entries of a long-running process we should not need to consider all the blocks