### PR TITLE
Send system_total_memory at every interval

### DIFF
--- a/rust/telemetry-sink/src/system_monitor.rs
+++ b/rust/telemetry-sink/src/system_monitor.rs
@@ -6,12 +6,13 @@ pub fn send_system_metrics_forever() {
         .with_cpu(CpuRefreshKind::nothing().with_cpu_usage())
         .with_memory(MemoryRefreshKind::nothing().with_ram());
     let mut system = System::new_with_specifics(what_to_refresh);
-    imetric!("total_memory", "bytes", system.total_memory());
+    let system_total_memory = system.total_memory();
     loop {
         std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
         system.refresh_specifics(what_to_refresh);
         imetric!("used_memory", "bytes", system.used_memory());
         imetric!("free_memory", "bytes", system.free_memory());
+        imetric!("total_memory", "bytes", system_total_memory);
         fmetric!("cpu_usage", "percent", system.global_cpu_usage() as f64);
     }
 }


### PR DESCRIPTION
Currently to get the total memory of the process we need to query the metric since its beginning. This would enable us to have this information at any time.