### PR TITLE
feat: Add GitHub Pages permissions to publish-rust-docs workflow

### DIFF
--- a/.github/workflows/publish-rust-docs.yml
+++ b/.github/workflows/publish-rust-docs.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-and-deploy-docs:
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
This commit adds the necessary `pages: write` and `id-token: write` permissions to the `publish-rust-docs.yml` workflow. This resolves the "Permission denied" error encountered when the GitHub Actions bot attempts to deploy documentation to GitHub Pages.