### PR TITLE
feat: Automate documentation publishing

### DIFF
--- a/.github/workflows/publish-rust-docs.yml
+++ b/.github/workflows/publish-rust-docs.yml
@@ -1,18 +1,13 @@
-name: Publish Rust Docs
+name: Publish Docs
 
-# on:
-#   push:
-#     branches:
-#       - main
+on:
+  push:
+    branches:
+      - '**'
 
 jobs:
   build-and-deploy-docs:
-    environment:
-      name: github-pages
     runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
 
     steps:
     - name: Checkout code
@@ -27,10 +22,16 @@ jobs:
       run: cargo doc -p micromegas --no-deps
       working-directory: rust/
 
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: rust/target/doc/micromegas/
+    - name: Prepare staging directory
+      run: |
+        mkdir -p public_docs/rust
+        cp -r rust/target/doc/micromegas/* public_docs/rust/
+        cp -r doc/* public_docs/
 
     - name: Deploy to GitHub Pages
-      uses: actions/deploy-pages@v4
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./public_docs
+        publish_branch: gh-pages
+        force_orphan: true

--- a/ai_tasks/publishing_rust_docs.md
+++ b/ai_tasks/publishing_rust_docs.md
@@ -1,14 +1,14 @@
-# Plan: Automate Rust Documentation Publishing to GitHub Pages
+# Plan: Automate Rust and Project Documentation Publishing to GitHub Pages
 
-This document outlines the plan to automatically build and publish the Rust documentation for the `micromegas` crate to GitHub Pages whenever changes are merged into the `main` branch.
+This document outlines the plan to automatically build and publish the Rust documentation for the `micromegas` crate, along with the contents of the `doc` folder, to GitHub Pages whenever changes are merged into the `main` branch.
 
 ## Goal
 
-Ensure that the latest Rust documentation is always available and accessible via GitHub Pages, reflecting the current state of the `main` branch.
+Ensure that the latest Rust and project documentation is always available and accessible via GitHub Pages, reflecting the current state of the `main` branch.
 
 ## Proposed Solution: GitHub Actions Workflow
 
-We will implement a new GitHub Actions workflow that triggers on pushes to the `main` branch, builds the documentation, and deploys it to the `gh-pages` branch.
+We will implement a new GitHub Actions workflow that triggers on pushes to the `main` branch, builds the documentation, stages it, and deploys it to the `gh-pages` branch.
 
 ### Workflow Details
 
@@ -32,20 +32,22 @@ on:
     *   **Steps:**
         1.  **Checkout Code:** Use `actions/checkout@v4` to get the latest code.
         2.  **Setup Rust:** Use `dtolnay/rust-toolchain@stable` to install the Rust toolchain.
-        3.  **Build Documentation:**
+        3.  **Build Rust Documentation:**
             *   Navigate to the `rust/` directory.
-            *   Run `cargo doc -p micromegas --no-deps` to build the documentation for the `micromegas` crate. The `--no-deps` flag ensures only our crate's documentation is built, not its dependencies, which speeds up the process and reduces output size.
-            *   The output will be in `rust/target/doc/micromegas/`.
-        4.  **Deploy to GitHub Pages:**
-            *   Use `peaceiris/actions-gh-pages@v4` to deploy the generated documentation.
-            *   **Source Directory:** The `peaceiris/actions-gh-pages` action expects the documentation to be in a specific directory. We will configure it to look into `rust/target/doc/micromegas/`.
-            *   **Target Branch:** `gh-pages` (this branch will be created automatically if it doesn't exist).
-            *   **Authentication:** Use the default `GITHUB_TOKEN` provided by GitHub Actions.
+            *   Run `cargo doc -p micromegas --no-deps` to build the documentation for the `micromegas` crate.
+        4.  **Prepare Staging Directory:**
+            *   Create a staging directory named `public_docs`.
+            *   Copy the generated Rust documentation from `rust/target/doc/micromegas/` into a `rust` subdirectory within `public_docs`.
+            *   Copy the entire contents of the top-level `doc` directory into `public_docs`.
+        5.  **Deploy to GitHub Pages:**
+            *   Use `peaceiris/actions-gh-pages@v4` to deploy the generated documentation from the `public_docs` directory.
+            *   **Target Branch:** `gh-pages`.
+            *   **Authentication:** Use the default `GITHUB_TOKEN`.
 
 ### Example Workflow (`.github/workflows/publish-rust-docs.yml`)
 
 ```yaml
-name: Publish Rust Docs
+name: Publish Docs
 
 on:
   push:
@@ -69,13 +71,19 @@ jobs:
       run: cargo doc -p micromegas --no-deps
       working-directory: rust/
 
+    - name: Prepare staging directory
+      run: |
+        mkdir -p public_docs/rust
+        cp -r rust/target/doc/micromegas/* public_docs/rust/
+        cp -r doc/* public_docs/
+
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: rust/target/doc/micromegas/
+        publish_dir: ./public_docs
         publish_branch: gh-pages
-        force_orphan: true # Overwrite existing gh-pages branch content
+        force_orphan: true
 ```
 
 ## Setup Steps
@@ -93,12 +101,11 @@ jobs:
 After implementing the workflow and configuring GitHub Pages:
 
 1.  Merge a PR into the `main` branch.
-2.  Observe the "Actions" tab in your GitHub repository to ensure the `Publish Rust Docs` workflow runs successfully.
-3.  Once the workflow completes, check the GitHub Pages URL (usually `https://<username>.github.io/<repository-name>/micromegas/`) to confirm the documentation is published and accessible.
+2.  Observe the "Actions" tab in your GitHub repository to ensure the `Publish Docs` workflow runs successfully.
+3.  Once the workflow completes, check the GitHub Pages URL. The Rust docs will be at `https://<username>.github.io/<repository-name>/rust/` and the other docs will be at their respective paths from the `doc` directory.
 
 ## Considerations
 
-*   **`--no-deps`:** This flag is used to only build documentation for the `micromegas` crate itself, not its dependencies. This keeps the generated documentation focused and smaller.
+*   **Staging Directory:** A staging directory (`public_docs`) is used to combine the outputs from different sources before deploying.
 *   **`force_orphan: true`:** This option in `peaceiris/actions-gh-pages` ensures that the `gh-pages` branch is completely overwritten with the new documentation, preventing stale files from previous builds.
 *   **GitHub Token Permissions:** The default `GITHUB_TOKEN` usually has sufficient permissions to push to the `gh-pages` branch. If not, repository settings might need adjustment.
-*   **Custom Domain:** If a custom domain is desired, it can be configured in the GitHub Pages settings after the initial setup.


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automatically build and publish the Rust documentation and the contents of the `doc` folder to GitHub Pages.

The workflow is configured to:
- Trigger on pushes to any branch for testing purposes.
- Build the Rustdoc for the `micromegas` crate.
- Copy the `doc` folder contents.
- Deploy the combined documentation to the `gh-pages` branch.

This will ensure that the documentation is always up-to-date and readily accessible.