### PR TITLE
Update README to focus on async span tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file documents the historical progress of the Micromegas project. For current focus, please see the main [README.md](./README.md).
 
+## July 2025
+ * Released [version 0.11.0](https://crates.io/crates/micromegas)
+ * Working on http gateway for easier interoperability
+ * Add export mechanism to view materialization to send data out as it is ingested
+
 ## June 2025
  * Released [version 0.10.0](https://crates.io/crates/micromegas)
  * Process properties in measures and log_entries

--- a/README.md
+++ b/README.md
@@ -63,12 +63,14 @@ To get started with Micromegas, please refer to the [GETTING_STARTED.md](./doc/G
 
 ## Current Status & Roadmap
 
-Our current focus is on delivering a robust and feature-rich query federation experience.
+Our current focus is on **async span tracing** - delivering comprehensive observability for asynchronous Rust applications.
 
-*   **July 2025** 
-  * Released [version 0.11.0](https://crates.io/crates/micromegas)
-  * Working on http gateway for easier interoperability
-  * Add export mechanism to view materialization to send data out as it is ingested
+*   **August 2025** 
+  * **Async Span Tracing Infrastructure**: Complete async tracing support with automatic future instrumentation
+  * **`micromegas_main` Proc Macro**: Drop-in replacement for `tokio::main` with automatic telemetry setup
+  * **`#[span_fn]` Macro Enhancement**: Now supports both sync and async functions with unified instrumentation
+  * **Manual Async Instrumentation**: `InstrumentedFuture` wrapper for fine-grained control over async span tracking
+  * **Thread-Safe Runtime Integration**: Seamless tokio runtime integration with automatic thread lifecycle management
 
 For a detailed history of changes, please see the [CHANGELOG.md](./CHANGELOG.md) file.
 


### PR DESCRIPTION
## Summary
- Update README to reflect current project focus on async span tracing
- Move July 2025 status from README to CHANGELOG.md for better organization
- Highlight August 2025 async tracing developments

## Changes
- **README.md**: Shift focus from query federation to async span tracing, featuring:
  - `micromegas_main` proc macro as drop-in replacement for `tokio::main`
  - Enhanced `#[span_fn]` macro supporting both sync and async functions
  - `InstrumentedFuture` wrapper for manual async instrumentation
  - Thread-safe tokio runtime integration
- **CHANGELOG.md**: Add July 2025 entry with version 0.11.0 and HTTP gateway work

## Test plan
- [x] Verify README accurately reflects current async tracing capabilities
- [x] Confirm CHANGELOG maintains chronological order
- [x] Ensure no information loss during status migration