### PR TITLE
Fix README markdown formatting for better hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ To get started with Micromegas, please refer to the [GETTING_STARTED.md](./doc/G
 
 Our current focus is on **async span tracing** - delivering comprehensive observability for asynchronous Rust applications.
 
-*   **August 2025** 
-  * **Async Span Tracing Infrastructure**: Complete async tracing support with automatic future instrumentation
-  * **`micromegas_main` Proc Macro**: Drop-in replacement for `tokio::main` with automatic telemetry setup
-  * **`#[span_fn]` Macro Enhancement**: Now supports both sync and async functions with unified instrumentation
-  * **Manual Async Instrumentation**: `InstrumentedFuture` wrapper for fine-grained control over async span tracking
-  * **Thread-Safe Runtime Integration**: Seamless tokio runtime integration with automatic thread lifecycle management
+### August 2025
+* **Async Span Tracing Infrastructure**: Complete async tracing support with automatic future instrumentation
+* **`micromegas_main` Proc Macro**: Drop-in replacement for `tokio::main` with automatic telemetry setup
+* **`#[span_fn]` Macro Enhancement**: Now supports both sync and async functions with unified instrumentation
+* **Manual Async Instrumentation**: `InstrumentedFuture` wrapper for fine-grained control over async span tracking
+* **Thread-Safe Runtime Integration**: Seamless tokio runtime integration with automatic thread lifecycle management
 
 For a detailed history of changes, please see the [CHANGELOG.md](./CHANGELOG.md) file.
 


### PR DESCRIPTION
## Summary
Fix markdown formatting in the "Current Status & Roadmap" section for better visual hierarchy.

## Changes
- Change "August 2025" from bullet point to proper header (`###`)
- Convert nested bullet points to use single asterisks for consistent formatting
- Improve readability by creating clear hierarchical structure:
  - Level 2: "Current Status & Roadmap"
  - Level 3: "August 2025" 
  - Bullet points: Individual async tracing features

## Test plan
- [x] Verify markdown renders with proper header hierarchy
- [x] Confirm bullet points are properly nested under month header
- [x] Check that visual formatting is clean and readable