### PR TITLE
Local dev scripts and async tracing enhancements

### DIFF
--- a/AI_GUIDELINES.md
+++ b/AI_GUIDELINES.md
@@ -17,6 +17,7 @@
 - Use existing utilities and patterns found in neighboring files
 - Keep commit messages short
 - **Commit Messages**: NEVER include AI-generated credits or co-author tags in commit messages
+- **Pull Requests**: Always run `git log --oneline main..HEAD` before creating PRs to list all commits in the branch
 
 ## Project Structure
 - Main Cargo.toml is located at `rust/Cargo.toml`

--- a/AI_GUIDELINES.md
+++ b/AI_GUIDELINES.md
@@ -7,6 +7,7 @@
 - **Error Handling**: Use `expect()` with descriptive messages instead of `unwrap()`
 - **Testing**: Use `cargo test -- --nocapture` to see println! output during tests
 - **Formatting**: Always run `cargo fmt` before any commit to ensure consistent code formatting
+- **Format Strings**: Use inline format arguments `format!("value: {variable}")` instead of `format!("value: {}", variable)`
 - **Proc Macros**: Use proc macros through their parent crate (e.g., `micromegas_tracing::prelude::*`) rather than importing proc macro crates directly
 - **Prelude Imports**: Always use `prelude::*` when importing from a prelude module
 

--- a/AI_GUIDELINES.md
+++ b/AI_GUIDELINES.md
@@ -16,6 +16,7 @@
 - Maintain security best practices - never expose secrets or keys
 - Use existing utilities and patterns found in neighboring files
 - Keep commit messages short
+- **Commit Messages**: NEVER include AI-generated credits or co-author tags in commit messages
 
 ## Project Structure
 - Main Cargo.toml is located at `rust/Cargo.toml`

--- a/local_test_env/dev-stop.py
+++ b/local_test_env/dev-stop.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+"""
+Micromegas Development Environment Stop Script
+Usage: python3 dev-stop.py
+"""
+
+import subprocess
+import sys
+
+SESSION = "micromegas"
+
+def run_command(cmd, check=True, shell=True):
+    """Run a shell command"""
+    print(f"Running: {cmd}")
+    return subprocess.run(cmd, shell=shell, check=check, capture_output=True, text=True)
+
+def check_session_exists():
+    """Check if tmux session exists"""
+    try:
+        result = run_command(f"tmux has-session -t {SESSION}", check=False)
+        return result.returncode == 0
+    except subprocess.CalledProcessError:
+        return False
+
+def kill_session():
+    """Kill the tmux session"""
+    if not check_session_exists():
+        print(f"No tmux session '{SESSION}' found - nothing to stop")
+        return
+    
+    try:
+        print(f"🛑 Stopping {SESSION} development environment...")
+        run_command(f"tmux kill-session -t {SESSION}")
+        print(f"✅ Successfully stopped {SESSION} session and all services")
+    except subprocess.CalledProcessError as e:
+        print(f"Error stopping session: {e}")
+        sys.exit(1)
+
+def main():
+    try:
+        kill_session()
+    except KeyboardInterrupt:
+        print("\nInterrupted by user")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/local_test_env/dev.py
+++ b/local_test_env/dev.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+"""
+Micromegas Development Environment Startup Script
+Usage: python3 dev.py [debug|release]
+"""
+
+import sys
+import os
+import subprocess
+import argparse
+from pathlib import Path
+
+SESSION = "micromegas"
+RUST_DIR = "../rust"
+
+def run_command(cmd, check=True, shell=True):
+    """Run a shell command"""
+    print(f"Running: {cmd}")
+    return subprocess.run(cmd, shell=shell, check=check)
+
+def kill_existing_session():
+    """Kill existing tmux session if it exists"""
+    try:
+        run_command(f"tmux kill-session -t {SESSION}", check=False)
+    except subprocess.CalledProcessError:
+        pass
+
+def build_rust_services(build_mode):
+    """Build Rust services in specified mode"""
+    build_flags = "--release" if build_mode == "release" else ""
+    print(f"🔧 Building Rust services in {build_mode} mode...")
+    
+    os.chdir(RUST_DIR)
+    run_command(f"cargo build {build_flags}")
+    os.chdir("../local_test_env")
+
+def create_tmux_session():
+    """Create and configure tmux session"""
+    print("🚀 Starting services in tmux session...")
+    
+    # Create session and main window
+    run_command(f"tmux new-session -d -s {SESSION} -n services")
+    
+    # Create 4-pane layout
+    run_command(f"tmux split-window -h -t {SESSION}:services")
+    run_command(f"tmux split-window -v -t {SESSION}:services.0")
+    run_command(f"tmux split-window -v -t {SESSION}:services.2")
+    
+    # Label panes
+    pane_labels = [
+        (0, "PostgreSQL"),
+        (1, "Ingestion"),
+        (2, "Analytics"),
+        (3, "Admin")
+    ]
+    
+    for pane_num, label in pane_labels:
+        run_command(f"tmux select-pane -t {pane_num} -T '{label}'")
+
+def start_services():
+    """Start all services in tmux panes"""
+    services = [
+        (0, 'echo "🐘 Starting PostgreSQL..."; cd db && python3 run.py'),
+        (1, 'echo "📥 Starting Ingestion Server..."; cd ../rust && cargo run -p telemetry-ingestion-srv -- --listen-endpoint-http 127.0.0.1:9000'),
+        (2, 'echo "📊 Starting Analytics Server..."; cd ../rust && cargo run -p flight-sql-srv -- --disable-auth'),
+        (3, 'echo "⚙️  Starting Admin Daemon..."; cd ../rust && cargo run -p telemetry-admin -- crond')
+    ]
+    
+    for pane_num, command in services:
+        run_command(f"tmux send-keys -t {pane_num} '{command}' C-m")
+
+def create_dev_window(build_mode):
+    """Create additional development window"""
+    run_command(f"tmux new-window -t {SESSION} -n dev")
+    run_command(f"tmux send-keys -t {SESSION}:dev 'cd ../rust && echo \"Development window - build mode: {build_mode}\"' C-m")
+
+def attach_session():
+    """Attach to tmux session"""
+    run_command(f"tmux attach-session -t {SESSION}")
+
+def main():
+    parser = argparse.ArgumentParser(description="Start Micromegas development environment")
+    parser.add_argument("build_mode", nargs="?", default="debug", 
+                       choices=["debug", "release"],
+                       help="Build mode (default: debug)")
+    
+    args = parser.parse_args()
+    build_mode = args.build_mode
+    
+    try:
+        kill_existing_session()
+        build_rust_services(build_mode)
+        create_tmux_session()
+        start_services()
+        create_dev_window(build_mode)
+        attach_session()
+        
+    except subprocess.CalledProcessError as e:
+        print(f"Error: Command failed with exit code {e.returncode}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print("\nInterrupted by user")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/rust/telemetry-ingestion-srv/test/generator.rs
+++ b/rust/telemetry-ingestion-srv/test/generator.rs
@@ -2,11 +2,72 @@
 
 use micromegas::micromegas_main;
 use micromegas::tracing::prelude::*;
+use std::time::Duration;
+use tokio::time::sleep;
+
+// Sync span function example
+#[span_fn]
+fn sync_operation(value: i32) -> i32 {
+    info!("performing sync operation with value: {}", value);
+    std::thread::sleep(Duration::from_millis(50));
+    value * 2
+}
+
+// Async span function example
+#[span_fn]
+async fn async_operation(delay_ms: u64) -> String {
+    info!("starting async operation with {}ms delay", delay_ms);
+    sleep(Duration::from_millis(delay_ms)).await;
+    format!("completed after {}ms", delay_ms)
+}
+
+// Nested async function
+#[span_fn]
+async fn nested_async_operation() {
+    let result1 = async_operation(100).await;
+    info!("first async result: {}", result1);
+
+    let result2 = async_operation(150).await;
+    info!("second async result: {}", result2);
+}
+
+// Manual span instrumentation example
+async fn manual_async_work() {
+    static_span_desc!(WORK_DESC, "manual_work");
+
+    async {
+        info!("doing manual async work");
+        sleep(Duration::from_millis(75)).await;
+        info!("manual work completed");
+    }
+    .instrument(&WORK_DESC)
+    .await;
+}
 
 #[micromegas_main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("hello from generator");
+
+    // Generate metrics
     imetric!("Frame Time", "ticks", 1000);
     fmetric!("Frame Time", "ticks", 1.0);
+    imetric!("Memory Usage", "bytes", 2048);
+    fmetric!("CPU Usage", "percent", 75.5);
+
+    // Generate sync span events
+    let sync_result = sync_operation(42);
+    info!("sync operation result: {}", sync_result);
+
+    // Generate async span events
+    let async_result = async_operation(200).await;
+    info!("async operation result: {}", async_result);
+
+    // Generate nested async spans
+    nested_async_operation().await;
+
+    // Generate manual instrumentation spans
+    manual_async_work().await;
+
+    info!("generator completed successfully");
     Ok(())
 }

--- a/rust/telemetry-ingestion-srv/test/generator.rs
+++ b/rust/telemetry-ingestion-srv/test/generator.rs
@@ -8,7 +8,7 @@ use tokio::time::sleep;
 // Sync span function example
 #[span_fn]
 fn sync_operation(value: i32) -> i32 {
-    info!("performing sync operation with value: {}", value);
+    info!("performing sync operation with value: {value}");
     std::thread::sleep(Duration::from_millis(50));
     value * 2
 }
@@ -16,19 +16,19 @@ fn sync_operation(value: i32) -> i32 {
 // Async span function example
 #[span_fn]
 async fn async_operation(delay_ms: u64) -> String {
-    info!("starting async operation with {}ms delay", delay_ms);
+    info!("starting async operation with {delay_ms}ms delay");
     sleep(Duration::from_millis(delay_ms)).await;
-    format!("completed after {}ms", delay_ms)
+    format!("completed after {delay_ms}ms")
 }
 
 // Nested async function
 #[span_fn]
 async fn nested_async_operation() {
     let result1 = async_operation(100).await;
-    info!("first async result: {}", result1);
+    info!("first async result: {result1}");
 
     let result2 = async_operation(150).await;
-    info!("second async result: {}", result2);
+    info!("second async result: {result2}");
 }
 
 // Manual span instrumentation example
@@ -56,11 +56,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Generate sync span events
     let sync_result = sync_operation(42);
-    info!("sync operation result: {}", sync_result);
+    info!("sync operation result: {sync_result}");
 
     // Generate async span events
     let async_result = async_operation(200).await;
-    info!("async operation result: {}", async_result);
+    info!("async operation result: {async_result}");
 
     // Generate nested async spans
     nested_async_operation().await;

--- a/rust/tracing/proc-macros/src/lib.rs
+++ b/rust/tracing/proc-macros/src/lib.rs
@@ -57,9 +57,9 @@ pub fn span_fn(args: TokenStream, input: TokenStream) -> TokenStream {
         function.sig.output = parse_quote! { -> impl std::future::Future<Output = #output_type> };
         function.block = parse_quote! {
             {
-                micromegas_tracing::static_span_desc!(_SCOPE_DESC, concat!(module_path!(), "::", #function_name));
+                static_span_desc!(_SCOPE_DESC, concat!(module_path!(), "::", #function_name));
                 let fut = async move #original_block;
-                micromegas_tracing::spans::InstrumentedFuture::new(fut, &_SCOPE_DESC)
+                InstrumentedFuture::new(fut, &_SCOPE_DESC)
             }
         };
     } else {
@@ -67,7 +67,7 @@ pub fn span_fn(args: TokenStream, input: TokenStream) -> TokenStream {
         function.block.stmts.insert(
             0,
             parse_quote! {
-                micromegas_tracing::span_scope!(_METADATA_FUNC, concat!(module_path!(), "::", #function_name));
+                span_scope!(_METADATA_FUNC, concat!(module_path!(), "::", #function_name));
             },
         );
     }
@@ -87,7 +87,7 @@ pub fn log_fn(args: TokenStream, input: TokenStream) -> TokenStream {
     function.block.stmts.insert(
         0,
         parse_quote! {
-            micromegas_tracing::trace!(#function_name);
+            trace!(#function_name);
         },
     );
     TokenStream::from(quote! {

--- a/rust/tracing/tests/test_macros.rs
+++ b/rust/tracing/tests/test_macros.rs
@@ -11,7 +11,7 @@ use micromegas_tracing::levels::{Level, LevelFilter, set_max_level};
 use micromegas_tracing::log;
 use micromegas_tracing::property_set::{Property, PropertySet};
 use micromegas_tracing::time::frequency;
-use micromegas_tracing::{fmetric, imetric, info, span_scope};
+use micromegas_tracing::{fmetric, imetric, info, span_scope, trace};
 use micromegas_tracing_proc_macros::{log_fn, span_fn};
 use utils::{DebugEventSink, LogDispatch, SharedState, State};
 


### PR DESCRIPTION
## Summary
- Add Python scripts for local development workflow (`dev.py` and `dev-stop.py`)  
- Enhance telemetry generator with sync/async span examples and proper metrics
- Fix proc macro imports to use prelude patterns
- Add development guidelines for commit messages and PR creation

## Test plan
- [x] Test development script: `python3 local_test_env/dev.py`
- [x] Test stop script: `python3 local_test_env/dev-stop.py`  
- [x] Verify all 4 services start correctly in labeled tmux panes
- [x] Run enhanced generator to confirm async span tracing works
- [x] Test both debug and release build modes