### PR TITLE
Add Rust coverage script and improve dev.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ target/
 # python
 __pycache__/
 
+# coverage reports
+rust/cobertura.xml
+rust/tarpaulin-report.html
+
 python/micromegas/dist
 
 # gtags

--- a/AI_GUIDELINES.md
+++ b/AI_GUIDELINES.md
@@ -40,6 +40,7 @@
 ### Python Development (from `python/micromegas/` directory)
 - **Install dependencies**: `poetry install`
 - **Test**: `pytest`
+- **Format**: `black <file>` (REQUIRED before any commit)
 
 ## Architecture Overview
 

--- a/build/rust_coverage.py
+++ b/build/rust_coverage.py
@@ -1,0 +1,38 @@
+#!/bin/python3
+from rust_command import run_command
+import subprocess
+import sys
+
+
+def run_coverage():
+    """Run Rust code coverage using cargo-tarpaulin"""
+    try:
+        # Check if tarpaulin is installed, install if not
+        print("Checking if cargo-tarpaulin is installed...")
+        run_command("cargo tarpaulin --version")
+        print("cargo-tarpaulin is already installed.")
+    except subprocess.CalledProcessError:
+        print("cargo-tarpaulin not found. Installing...")
+        print("This may take several minutes as it needs to compile from source...")
+        try:
+            run_command("cargo install cargo-tarpaulin")
+            print("cargo-tarpaulin installed successfully.")
+        except subprocess.CalledProcessError as e:
+            print(f"Failed to install cargo-tarpaulin: {e}")
+            print("You can install it manually with: cargo install cargo-tarpaulin")
+            sys.exit(1)
+
+    # Run coverage with HTML and XML output
+    print("Running code coverage...")
+    try:
+        run_command("cargo tarpaulin --out Html --out Xml --timeout 120")
+        print("Coverage report generated:")
+        print("- HTML report: rust/tarpaulin-report.html")
+        print("- XML report: rust/cobertura.xml")
+    except subprocess.CalledProcessError as e:
+        print(f"Coverage generation failed: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run_coverage()

--- a/local_test_env/dev.py
+++ b/local_test_env/dev.py
@@ -9,10 +9,13 @@ import sys
 import os
 import subprocess
 import argparse
+import time
+import requests
 from pathlib import Path
 
 SESSION = "micromegas"
-RUST_DIR = "../rust"
+SCRIPT_DIR = Path(__file__).parent.absolute()
+RUST_DIR = SCRIPT_DIR.parent / "rust"
 
 def run_command(cmd, check=True, shell=True):
     """Run a shell command"""
@@ -31,9 +34,9 @@ def build_rust_services(build_mode):
     build_flags = "--release" if build_mode == "release" else ""
     print(f"🔧 Building Rust services in {build_mode} mode...")
     
-    os.chdir(RUST_DIR)
+    os.chdir(str(RUST_DIR))
     run_command(f"cargo build {build_flags}")
-    os.chdir("../local_test_env")
+    os.chdir(str(SCRIPT_DIR))
 
 def create_tmux_session():
     """Create and configure tmux session"""
@@ -58,17 +61,50 @@ def create_tmux_session():
     for pane_num, label in pane_labels:
         run_command(f"tmux select-pane -t {pane_num} -T '{label}'")
 
+def wait_for_service(url, service_name, timeout=60, check_interval=2):
+    """Wait for a service to become available"""
+    print(f"⏳ Waiting for {service_name} to be ready at {url}...")
+    start_time = time.time()
+    
+    while time.time() - start_time < timeout:
+        try:
+            response = requests.get(url, timeout=5)
+            if response.status_code < 500:  # Accept any non-server-error response
+                print(f"✅ {service_name} is ready!")
+                return True
+        except (requests.exceptions.RequestException, requests.exceptions.Timeout):
+            pass
+        
+        print(f"⏳ {service_name} not ready yet, retrying in {check_interval}s...")
+        time.sleep(check_interval)
+    
+    print(f"❌ Timeout waiting for {service_name} after {timeout}s")
+    return False
+
 def start_services():
-    """Start all services in tmux panes"""
-    services = [
-        (0, 'echo "🐘 Starting PostgreSQL..."; cd db && python3 run.py'),
-        (1, 'echo "📥 Starting Ingestion Server..."; cd ../rust && cargo run -p telemetry-ingestion-srv -- --listen-endpoint-http 127.0.0.1:9000'),
+    """Start all services in tmux panes with proper sequencing"""
+    # Start PostgreSQL first
+    print("🐘 Starting PostgreSQL...")
+    run_command(f"tmux send-keys -t 0 'echo \"🐘 Starting PostgreSQL...\"; cd db && python3 run.py' C-m")
+    
+    # Start Ingestion Server and wait for it to be ready
+    print("📥 Starting Ingestion Server...")
+    run_command(f"tmux send-keys -t 1 'echo \"📥 Starting Ingestion Server...\"; cd ../rust && cargo run -p telemetry-ingestion-srv -- --listen-endpoint-http 127.0.0.1:9000' C-m")
+    
+    # Wait for ingestion service to be ready
+    if not wait_for_service("http://127.0.0.1:9000/health", "Ingestion Server"):
+        print("⚠️  Warning: Ingestion server may not be ready, continuing anyway...")
+    
+    # Start remaining services
+    remaining_services = [
         (2, 'echo "📊 Starting Analytics Server..."; cd ../rust && cargo run -p flight-sql-srv -- --disable-auth'),
         (3, 'echo "⚙️  Starting Admin Daemon..."; cd ../rust && cargo run -p telemetry-admin -- crond')
     ]
     
-    for pane_num, command in services:
+    for pane_num, command in remaining_services:
+        print(f"Starting service in pane {pane_num}...")
         run_command(f"tmux send-keys -t {pane_num} '{command}' C-m")
+        time.sleep(1)  # Small delay between service starts
 
 def create_dev_window(build_mode):
     """Create additional development window"""


### PR DESCRIPTION
## Summary
- Add Rust coverage script with tarpaulin integration and HTML report generation
- Add Python black formatting requirements to development workflow
- Fix dev.py relative path issues for robust script execution from any directory
- Add sequential service startup with health checks for proper dependency management

## Test plan
- [x] Run `./build/rust_coverage.py` and verify HTML coverage report is generated
- [x] Run `./local_test_env/dev.py` from any directory and verify it works
- [x] Verify services start in correct order with ingestion service ready before others
- [x] Test timeout handling when services fail to start