### PR TITLE
Fix async span event warnings in thread block processor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Development guidelines and environment setup
 
 All development guidance has been consolidated in AI_GUIDELINES.md to maintain a single source of truth for AI assistants working on this project.
+
+## CRITICAL: Commit & PR Rules
+- Keep commit messages short
+- **NEVER include AI-generated credits or co-author tags in commit messages**
+- **Pull Requests**: Always run `git log --oneline main..HEAD` before creating PRs to list all commits in the branch

--- a/rust/analytics/src/thread_block_processor.rs
+++ b/rust/analytics/src/thread_block_processor.rs
@@ -94,6 +94,13 @@ pub fn parse_thread_block_payload<Proc: ThreadBlockProcessor>(
                     processor.on_end_thread_scope(block_id, event_id, scope_desc, ts)
                 })
                 .with_context(|| "reading EndThreadNamedSpanEvent"),
+                "BeginAsyncSpanEvent"
+                | "EndAsyncSpanEvent"
+                | "BeginAsyncNamedSpanEvent"
+                | "EndAsyncNamedSpanEvent" => {
+                    // Ignore async span events as they are not relevant for thread spans view
+                    Ok(true)
+                }
                 event_type => {
                     warn!("unknown event type {}", event_type);
                     Ok(true)


### PR DESCRIPTION
## Summary
- Fix warnings when materializing thread_spans view by properly handling async span events
- Silently ignore BeginAsyncSpanEvent, EndAsyncSpanEvent, BeginAsyncNamedSpanEvent, and EndAsyncNamedSpanEvent in thread block processor

## Test plan
- [x] All tests pass
- [x] Project builds successfully  
- [x] Async span events are silently ignored instead of generating "unknown event type" warnings