### PR TITLE
Reduce verbosity in ingestion and analytics services

### DIFF
--- a/rust/flight-sql-srv/src/flight_sql_srv.rs
+++ b/rust/flight-sql-srv/src/flight_sql_srv.rs
@@ -26,7 +26,7 @@ struct Cli {
     disable_auth: bool,
 }
 
-#[micromegas_main(max_level_override = "debug")]
+#[micromegas_main(interop_max_level = "info", max_level_override = "debug")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Cli::parse();
     let connection_string = std::env::var("MICROMEGAS_SQL_CONNECTION_STRING")

--- a/rust/telemetry-ingestion-srv/src/main.rs
+++ b/rust/telemetry-ingestion-srv/src/main.rs
@@ -55,7 +55,7 @@ async fn serve_http(
     Ok(())
 }
 
-#[micromegas_main]
+#[micromegas_main(interop_max_level = "info")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Cli::parse();
     let connection_string = std::env::var("MICROMEGAS_SQL_CONNECTION_STRING")


### PR DESCRIPTION
## Summary
- Set `interop_max_level` to "info" in telemetry-ingestion-srv and flight-sql-srv
- Reduces noise from external dependencies while keeping debug-level logging for application code

## Test plan
- [x] Verify services start without excessive logging
- [x] Confirm application debug logs are still visible
- [x] Test that functionality remains unchanged