### PR TITLE
Update documentation links and improve setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ Micromegas consists of several key components:
 
 Unlike traditional observability platforms with opaque and often escalating costs, Micromegas offers a transparent and **orders of magnitude more efficient** solution. With Micromegas, you can afford to record billions of events without relying heavily on sampling, gaining a complete and accurate picture of your systems. By leveraging your own cloud infrastructure, Micromegas drastically reduces your observability spend, especially at scale.
 
-Discover how Micromegas achieves this unparalleled cost efficiency and compare it with traditional solutions in our detailed [Cost Effectiveness](./doc/cost/COST_EFFECTIVENESS.md) document.
+Discover how Micromegas achieves this unparalleled cost efficiency and compare it with traditional solutions in our detailed [Cost Effectiveness](https://madesroches.github.io/micromegas/docs/cost-effectiveness/) document.
 
 ## Getting Started
 
-To get started with Micromegas, please refer to the [GETTING_STARTED.md](./doc/GETTING_STARTED.md) guide.
+To get started with Micromegas, please refer to the [Getting Started](https://madesroches.github.io/micromegas/docs/getting-started/) guide.
 
 
 ## Current Status & Roadmap
@@ -76,7 +76,7 @@ For a detailed history of changes, please see the [CHANGELOG.md](./CHANGELOG.md)
 
 ## Contributing
 
-We welcome contributions from the community! If you're interested in helping improve Micromegas, please see our [Contribution Guidelines](CONTRIBUTING.md) for more details on how to get involved.
+We welcome contributions from the community! If you're interested in helping improve Micromegas, please see our [Contribution Guidelines](https://madesroches.github.io/micromegas/docs/contributing/) for more details on how to get involved.
 
 Whether it's bug reports, feature requests, or code contributions, your input is valuable.
 

--- a/mkdocs/docs/contributing.md
+++ b/mkdocs/docs/contributing.md
@@ -28,9 +28,6 @@ By participating in this project, you agree to maintain a respectful and inclusi
    # Python development
    cd python/micromegas
    poetry install
-   
-   # Documentation
-   pip install -r docs/docs-requirements.txt
    ```
 
 ## Contributing Code
@@ -56,7 +53,36 @@ By participating in this project, you agree to maintain a respectful and inclusi
    - **Dependencies**: Keep alphabetical order in Cargo.toml
    - **Error handling**: Use `expect()` with descriptive messages instead of `unwrap()`
 
-3. **Write tests**:
+3. **Start development services**:
+   
+   For testing and development, you can start all required services (PostgreSQL, telemetry-ingestion-srv, flight-sql-srv, and telemetry-admin) using the dev.py script:
+   
+   ```bash
+   # Start all services in a tmux session (debug mode)
+   python3 local_test_env/dev.py
+   
+   # Or in release mode for better performance
+   python3 local_test_env/dev.py release
+   ```
+   
+   This will:
+   - Build the Rust services
+   - Start PostgreSQL database
+   - Start telemetry-ingestion-srv on port 9000
+   - Start flight-sql-srv on port 32010  
+   - Start telemetry-admin service
+   - Open a tmux session with all services running in separate panes
+   
+   To stop all services:
+   ```bash
+   # Use the stop script
+   python3 local_test_env/stop-dev.py
+   
+   # Or manually kill the tmux session
+   tmux kill-session -t micromegas
+   ```
+
+4. **Write tests**:
    ```bash
    # Rust tests
    cd rust
@@ -67,29 +93,19 @@ By participating in this project, you agree to maintain a respectful and inclusi
    pytest
    ```
 
-4. **Run CI pipeline locally**:
+5. **Run CI pipeline locally**:
    ```bash
    cd rust
    python3 ../build/rust_ci.py
    ```
 
-5. **Commit with clear messages**:
+6. **Commit with clear messages**:
    ```bash
    git commit -m "Add histogram generation for span duration analysis"
    ```
-   
-   **Note**: Never include AI-generated credits or co-author tags in commit messages.
 
-6. **Push and create Pull Request**:
-   ```bash
-   git push origin feature/your-feature-name
-   ```
-   
-   Before creating a PR, run:
-   ```bash
-   git log --oneline main..HEAD
-   ```
-   to list all commits in your branch.
+7. **Create Pull Request**:
+   Once your changes are ready, create a pull request on GitHub.
 
 ### Code Review Process
 
@@ -100,24 +116,53 @@ By participating in this project, you agree to maintain a respectful and inclusi
 
 ## Contributing Documentation
 
+### Setup
+
+1. **Install documentation dependencies**:
+   ```bash
+   # Create and activate virtual environment (recommended)
+   python3 -m venv docs-venv
+   source docs-venv/bin/activate  # On Windows: docs-venv\Scripts\activate
+   
+   # Install dependencies
+   pip install -r docs/docs-requirements.txt
+   ```
+
 ### MkDocs Documentation
 
 The main documentation uses MkDocs with Material theme:
 
 1. **Edit documentation**:
-   - Files are in `docs/` directory
+   - Files are in `mkdocs/docs/` directory
+   - Configuration in `mkdocs/mkdocs.yml`
    - Use Markdown format
    - Follow existing structure and style
 
 2. **Preview changes**:
    ```bash
+   cd mkdocs
+   
+   # Using the virtual environment
+   /home/mad/micromegas/docs-venv/bin/mkdocs serve --dev-addr=0.0.0.0:8000
+   
+   # Or if mkdocs is in your PATH
    mkdocs serve
+   
    # Visit http://localhost:8000
    ```
 
 3. **Build documentation**:
    ```bash
-   python docs/build-docs.py
+   cd mkdocs
+   /home/mad/micromegas/docs-venv/bin/mkdocs build
+   
+   # Output will be in mkdocs/site/
+   ```
+
+4. **Deploy documentation**:
+   ```bash
+   # Documentation is automatically deployed via GitHub Actions
+   # when changes are pushed to the main branch
    ```
 
 ### Documentation Guidelines

--- a/mkdocs/docs/getting-started.md
+++ b/mkdocs/docs/getting-started.md
@@ -10,6 +10,9 @@ Before you begin, ensure you have the following installed:
 - **[Python 3.8+](https://www.python.org/downloads/)** - For the client API and setup scripts
 - **[Rust](https://www.rust-lang.org/tools/install)** - For building Micromegas services
 
+Optional:
+- **[tmux](https://github.com/tmux/tmux/wiki)** - For managing multiple services in a single terminal (Linux/macOS)
+
 ## Environment Setup
 
 Set the following environment variables for local development:
@@ -39,46 +42,68 @@ git clone https://github.com/madesroches/micromegas.git
 cd micromegas
 ```
 
-### 2. Start PostgreSQL Database
+### 2. Start All Services
 
-Start a local PostgreSQL instance using Docker:
+#### Option A: Using tmux (Linux/macOS)
 
+The easiest way to start all required services is using the development script with tmux:
+
+```bash
+# Start all services in a tmux session (debug mode)
+python3 local_test_env/dev.py
+
+# Or in release mode for better performance
+python3 local_test_env/dev.py release
+```
+
+This will automatically:
+
+- Build all Rust services
+- Start PostgreSQL database
+- Start telemetry-ingestion-srv on port 9000
+- Start flight-sql-srv on port 32010
+- Start telemetry-admin service
+- Open a tmux session with all services running in separate panes
+
+!!! tip "Managing Services with tmux"
+    - To switch between service panes: `Ctrl+B` then arrow keys
+    - To detach from tmux (leave services running): `Ctrl+B` then `D`
+    - To reattach to tmux: `tmux attach -t micromegas`
+    - To stop all services: `python3 local_test_env/stop-dev.py`
+
+#### Option B: Manual Startup (Windows or without tmux)
+
+If you're on Windows or prefer not to use tmux, start each service in a separate terminal:
+
+**Terminal 1: PostgreSQL Database**
 ```bash
 cd local_test_env/db
 python run.py
 ```
 
-This will:
-- Pull the PostgreSQL Docker image
-- Start the database container
-- Set up the initial schema
-
-### 3. Start Core Services
-
-You'll need to start three services in separate terminals:
-
-#### Terminal 1: Ingestion Server
+**Terminal 2: Ingestion Server**
 ```bash
 cd rust
 cargo run -p telemetry-ingestion-srv -- --listen-endpoint-http 127.0.0.1:9000
 ```
 
-#### Terminal 2: FlightSQL Server
+**Terminal 3: FlightSQL Server**
 ```bash
 cd rust
 cargo run -p flight-sql-srv -- --disable-auth
 ```
 
-#### Terminal 3: Maintenance Daemon
+**Terminal 4: Admin Service**
 ```bash
 cd rust
 cargo run -p telemetry-admin -- crond
 ```
 
 !!! info "Service Roles"
-    - **Ingestion Server**: Receives telemetry data from applications
-    - **FlightSQL Server**: Provides SQL query interface for analytics
-    - **Maintenance Daemon**: Handles background processing and view materialization
+    - **PostgreSQL**: Stores metadata and service configuration
+    - **Ingestion Server**: Receives telemetry data from applications (port 9000)
+    - **FlightSQL Server**: Provides SQL query interface for analytics (port 32010)
+    - **Admin Service**: Handles background processing and global view materialization
 
 ## Verify Installation
 

--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -2,6 +2,9 @@
 
 Welcome to Micromegas, a unified observability platform designed for high-performance telemetry collection and analytics.
 
+[**→ Source Code on GitHub**](https://github.com/madesroches/micromegas){ .md-button .md-button--primary }
+[**→ Get Started**](getting-started.md){ .md-button }
+
 ## What is Micromegas?
 
 Micromegas is a comprehensive observability solution that provides:


### PR DESCRIPTION
## Summary
- Updated README.md links to point to the deployed mkdocs documentation
- Improved getting started guide with `dev.py` script for easier service startup
- Reorganized contributing documentation to separate code and documentation workflows

## Changes
- **README.md**: Updated links for Cost Effectiveness, Getting Started, and Contributing to use GitHub Pages URLs
- **getting-started.md**: 
  - Added tmux as optional dependency
  - Provided two setup options: using tmux (Linux/macOS) or manual startup (Windows)
  - Updated to use `dev.py` script as the primary method for starting services
- **contributing.md**: 
  - Moved documentation setup to dedicated section
  - Added service startup instructions using `dev.py`
  - Removed git command examples to keep focus on workflow
- **index.md**: Added prominent "Source Code on GitHub" button on home page

## Test plan
- [x] Verified all documentation links point to correct URLs
- [x] Tested mkdocs build and serve commands
- [x] Confirmed formatting renders correctly in mkdocs preview