### PR TITLE
Fix CVE-2025-58160: Update tracing-subscriber to 0.3.20

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3052,12 +3052,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3250,12 +3249,6 @@ checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -4944,9 +4937,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -69,7 +69,7 @@ tower = { version = "0.5" }
 tower-http = { version = "0.5.2", features = ["cors", "limit", "timeout"] }
 tracing = "0.1.40"
 tracing-core = "0.1.32"
-tracing-subscriber = "0.3.18"
+tracing-subscriber = "0.3.20"
 url = "2.5.0"
 uuid = { version = "1.8", features = ["v4", "serde"] }
 whoami = "1.2"


### PR DESCRIPTION
## Summary
- Updates tracing-subscriber from 0.3.18 to 0.3.20 to address security vulnerability
- Fixes CVE-2025-58160 / GHSA-xwfj-jgwm-7wp5 (ANSI escape sequence injection)
- Prevents untrusted user input from manipulating terminal output through ANSI escape sequences

## Test plan
- [x] Cargo build successful
- [x] All tests passing
- [x] No breaking changes in API

Fixes #23 (Dependabot security alert)