### PR TITLE
Add file existence validation to json_table_provider

### DIFF
--- a/rust/analytics/tests/json_table_test.rs
+++ b/rust/analytics/tests/json_table_test.rs
@@ -175,3 +175,23 @@ async fn test_multiple_json_tables() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_json_table_provider_nonexistent_file() -> Result<()> {
+    let nonexistent_url = "file:///this/path/does/not/exist/data.json";
+
+    // This should fail when the file doesn't exist
+    let result = json_table_provider(nonexistent_url).await;
+
+    assert!(result.is_err(), "Expected error when file doesn't exist");
+
+    // Verify the error message is informative
+    let error_msg = result.unwrap_err().to_string();
+    assert!(
+        error_msg.contains("No files found"),
+        "Error message should mention no files found, got: {}",
+        error_msg
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Adds validation to ensure files exist before creating JSON table provider
- Extracts file existence checking into reusable `verify_files_exist()` helper function
- Checks using `head()` with fallback to `list()` for directory/prefix patterns
- Returns clear error message when no files are found

## Test plan
- [x] Added test `test_json_table_provider_nonexistent_file` that verifies error on missing files
- [x] All existing JSON table tests pass (5/5)
- [x] Full analytics test suite passes (77/77)
- [x] Code formatted with `cargo fmt`
- [x] Clippy passes with no warnings