### PR TITLE
Fix rustdoc HTML tag warnings

### DIFF
--- a/rust/analytics/src/lakehouse/retire_partition_by_file_udf.rs
+++ b/rust/analytics/src/lakehouse/retire_partition_by_file_udf.rs
@@ -208,7 +208,7 @@ impl AsyncScalarUDFImpl for RetirePartitionByFile {
 /// A string message indicating success or failure:
 /// - "SUCCESS: Retired partition <file_path>" on successful retirement
 /// - "ERROR: Partition not found: <file_path>" if the partition doesn't exist  
-/// - "ERROR: Database error: <details>" for any database-related failures
+/// - "ERROR: Database error: \<details\>" for any database-related failures
 pub fn make_retire_partition_by_file_udf(
     lake: Arc<DataLakeConnection>,
 ) -> datafusion::logical_expr::async_udf::AsyncScalarUDF {

--- a/rust/analytics/src/properties/property_set.rs
+++ b/rust/analytics/src/properties/property_set.rs
@@ -35,7 +35,7 @@ impl PropertySet {
         Ok(())
     }
 
-    /// Get a reference to the underlying Arc<Object> for pointer-based operations.
+    /// Get a reference to the underlying `Arc<Object>` for pointer-based operations.
     ///
     /// This is used by custom dictionary builders for efficient deduplication
     /// based on Arc pointer addresses rather than content hashing.

--- a/rust/analytics/src/properties/property_set_jsonb_dictionary_builder.rs
+++ b/rust/analytics/src/properties/property_set_jsonb_dictionary_builder.rs
@@ -30,7 +30,7 @@ impl ObjectPointer {
 /// Custom dictionary builder for PropertySet → JSONB encoding with pointer-based deduplication.
 ///
 /// This builder eliminates redundant JSONB serialization and dictionary hash lookups
-/// for duplicate PropertySets by using PropertySet's Arc<Object> pointer addresses as keys.
+/// for duplicate PropertySets by using PropertySet's `Arc<Object>` pointer addresses as keys.
 ///
 /// Performance benefits over Arrow's BinaryDictionaryBuilder:
 /// - Eliminates content-based hashing: Arrow's builder hashes JSONB bytes for deduplication
@@ -38,7 +38,7 @@ impl ObjectPointer {
 /// - Serialization only when needed: Only serialize PropertySet on first encounter
 /// - Memory efficiency: Shared PropertySet references, single JSONB copy per unique set
 pub struct PropertySetJsonbDictionaryBuilder {
-    /// Maps Arc<Object> pointer to dictionary index (avoids content hashing)
+    /// Maps `Arc<Object>` pointer to dictionary index (avoids content hashing)
     pointer_to_index: HashMap<ObjectPointer, i32>,
     /// Pre-serialized JSONB values in dictionary
     jsonb_values: Vec<Vec<u8>>,


### PR DESCRIPTION
## Summary
- Fixes rustdoc warnings about unclosed HTML tags in documentation comments
- Escaped angle brackets in doc comments to prevent rustdoc from interpreting them as HTML

## Changes
- `retire_partition_by_file_udf.rs`: Escaped `<details>` in error message documentation
- `property_set.rs`: Used backticks around `Arc<Object>` type reference
- `property_set_jsonb_dictionary_builder.rs`: Used backticks around `Arc<Object>` type references

## Test plan
- [x] Run `cargo doc --workspace --no-deps` - builds successfully without warnings
- [x] Run `cargo fmt --check` - code formatting is correct

Fixes https://github.com/madesroches/micromegas/actions/runs/18608575456