### PR TITLE
Fix null decoding error in list_partitions table function

### DIFF
--- a/rust/analytics/src/lakehouse/list_partitions_table_function.rs
+++ b/rust/analytics/src/lakehouse/list_partitions_table_function.rs
@@ -69,22 +69,23 @@ impl TableProvider for ListPartitionsTableProvider {
             Field::new(
                 "min_event_time",
                 DataType::Timestamp(TimeUnit::Nanosecond, Some("+00:00".into())),
-                false,
+                true,
             ),
             Field::new(
                 "max_event_time",
                 DataType::Timestamp(TimeUnit::Nanosecond, Some("+00:00".into())),
-                false,
+                true,
             ),
             Field::new(
                 "updated",
                 DataType::Timestamp(TimeUnit::Nanosecond, Some("+00:00".into())),
                 false,
             ),
-            Field::new("file_path", DataType::Utf8, false),
+            Field::new("file_path", DataType::Utf8, true),
             Field::new("file_size", DataType::Int64, false),
             Field::new("file_schema_hash", DataType::Binary, false),
             Field::new("source_data_hash", DataType::Binary, false),
+            Field::new("num_rows", DataType::Int64, false),
         ]))
     }
 
@@ -106,10 +107,12 @@ impl TableProvider for ListPartitionsTableProvider {
 				    end_insert_time,
 				    min_event_time,
 				    max_event_time,
-				    updated, file_path,
+				    updated,
+				    file_path,
 				    file_size,
 				    file_schema_hash,
-				    source_data_hash
+				    source_data_hash,
+				    num_rows
 			 FROM lakehouse_partitions;",
         )
         .fetch_all(&self.lake.db_pool)


### PR DESCRIPTION
## Summary
Fixes null decoding error when querying `list_partitions()` table function with empty lakehouse partitions.

## Problem
After commit #537 added support for empty lakehouse partitions, the `list_partitions()` table function would crash with:
```
Error executing plan: External(try_get failed on row
Caused by: error occurred while decoding column 4: unexpected null; try decoding as an Option
```

This occurred because empty partitions have NULL values for `min_event_time`, `max_event_time`, and `file_path`, but the Arrow schema marked these columns as non-nullable.

## Changes
- Mark `min_event_time`, `max_event_time`, and `file_path` as nullable in Arrow schema
- Add missing `num_rows` column to schema and SQL query
- Keep `file_size`, `file_schema_hash`, and `source_data_hash` as non-nullable (always have values)

## Related
- Similar to fix in #539 for `retire_partitions`
- Supports empty partitions feature from #537

## Testing
- ✅ Builds successfully
- ✅ Python admin.py tests pass (uses list_partitions in queries)
- ✅ Verified empty partitions exist in database with NULL values
- ✅ Python code handles NULL file_path correctly