### PR TITLE
Update vite to 7.1.11 to fix security vulnerability

### DIFF
--- a/doc/high-frequency-observability/package-lock.json
+++ b/doc/high-frequency-observability/package-lock.json
@@ -2214,9 +2214,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.8.tgz",
-      "integrity": "sha512-oBXvfSHEOL8jF+R9Am7h59Up07kVVGH1NrFGFoEG6bPDZP3tGpQhvkBpy5x7U6+E6wZCu9OihsWgJqDbQIm8LQ==",
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.11.tgz",
+      "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/doc/presentation-template/package-lock.json
+++ b/doc/presentation-template/package-lock.json
@@ -905,9 +905,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.8.tgz",
-      "integrity": "sha512-oBXvfSHEOL8jF+R9Am7h59Up07kVVGH1NrFGFoEG6bPDZP3tGpQhvkBpy5x7U6+E6wZCu9OihsWgJqDbQIm8LQ==",
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.11.tgz",
+      "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",


### PR DESCRIPTION
## Summary
- Update vite from 7.1.8 to 7.1.11 in doc/high-frequency-observability and doc/presentation-template
- Fixes CVE-2025-62522: vite server.fs.deny bypass via backslash on Windows
- Verified both presentations build successfully with the updated version

## Test plan
- [x] Built high-frequency-observability presentation successfully (11.11s)
- [x] Built presentation-template successfully (1.97s)
- [x] Both builds completed without errors using vite v7.1.11