### PR TITLE
Update documentation links to use hosted docs and fix markdown formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ We welcome code contributions! If you'd like to contribute code, please follow t
 
 ## Development Setup
 
-For information on setting up your local development environment, please refer to the [GETTING_STARTED.md](./GETTING_STARTED.md) guide.
+For information on setting up your local development environment, please refer to the [Getting Started](https://madesroches.github.io/micromegas/docs/getting-started/) guide.
 
 ## Monorepo Structure
 

--- a/mkdocs/docs/contributing.md
+++ b/mkdocs/docs/contributing.md
@@ -35,7 +35,7 @@ We welcome code contributions! If you'd like to contribute code, please follow t
 
 ## Development Setup
 
-For information on setting up your local development environment, please refer to the [GETTING_STARTED.md](./GETTING_STARTED.md) guide.
+For information on setting up your local development environment, please refer to the [Getting Started](getting-started.md) guide.
 
 ## Monorepo Structure
 

--- a/mkdocs/serve.py
+++ b/mkdocs/serve.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Simple script to start the MkDocs development server."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Get the mkdocs directory (where this script is located)
+MKDOCS_DIR = Path(__file__).parent.absolute()
+REPO_ROOT = MKDOCS_DIR.parent
+VENV_MKDOCS = REPO_ROOT / "docs-venv" / "bin" / "mkdocs"
+CONFIG_FILE = MKDOCS_DIR / "mkdocs.yml"
+
+def main():
+    """Start the MkDocs development server."""
+
+    # Check if venv mkdocs exists
+    if not VENV_MKDOCS.exists():
+        print(f"Error: MkDocs not found at {VENV_MKDOCS}", file=sys.stderr)
+        print("Please run: python3 -m venv docs-venv && docs-venv/bin/pip install mkdocs mkdocs-material mkdocstrings", file=sys.stderr)
+        sys.exit(1)
+
+    # Check if config file exists
+    if not CONFIG_FILE.exists():
+        print(f"Error: Config file not found at {CONFIG_FILE}", file=sys.stderr)
+        sys.exit(1)
+
+    # Build command
+    cmd = [
+        str(VENV_MKDOCS),
+        "serve",
+        "--config-file", str(CONFIG_FILE),
+        "--dev-addr", "0.0.0.0:8000"
+    ]
+
+    print(f"Starting MkDocs server...")
+    print(f"Server will be available at: http://localhost:8000")
+    print(f"Press Ctrl+C to stop")
+    print()
+
+    try:
+        subprocess.run(cmd, check=True)
+    except KeyboardInterrupt:
+        print("\nServer stopped.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error running MkDocs: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/rust/auth/src/oidc.rs
+++ b/rust/auth/src/oidc.rs
@@ -79,7 +79,7 @@ impl JwksCache {
 /// Configuration for a single OIDC issuer
 #[derive(Debug, Clone, Deserialize)]
 pub struct OidcIssuer {
-    /// Issuer URL (e.g., "https://accounts.google.com")
+    /// Issuer URL (e.g., <https://accounts.google.com>)
     pub issuer: String,
     /// Expected audience (client ID)
     pub audience: String,


### PR DESCRIPTION
## Summary
- Update CONTRIBUTING.md to reference hosted Getting Started guide instead of local GETTING_STARTED.md file
- Update mkdocs/docs/contributing.md to use proper mkdocs relative link syntax
- Fix markdown formatting in rust/auth/src/oidc.rs (use angle brackets for bare URL)
- Add mkdocs/serve.py helper script for local documentation preview

## Test plan
- [x] Documentation links render correctly
- [x] Markdown linting passes