### PR TITLE
Add client IP logging to server observability

### DIFF
--- a/rust/analytics-web-srv/src/main.rs
+++ b/rust/analytics-web-srv/src/main.rs
@@ -234,7 +234,11 @@ async fn main() -> Result<()> {
     println!("CORS origin configured for: {}", cors_origin);
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
-    axum::serve(listener, app).await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .await?;
 
     Ok(())
 }

--- a/rust/public/src/servers/axum_utils.rs
+++ b/rust/public/src/servers/axum_utils.rs
@@ -12,17 +12,26 @@ use micromegas_tracing::prelude::*;
 use std::sync::Arc;
 use tokio::sync::mpsc::Receiver;
 
+use super::http_utils::get_client_ip;
+
 /// observability_middleware logs http requests, their duration and status code
 pub async fn observability_middleware(request: Request, next: Next) -> Response {
     let (parts, body) = request.into_parts();
     let uri = parts.uri.clone();
-    info!("request method={} uri={uri}", parts.method);
+    let client_ip = get_client_ip(&parts.headers, &parts.extensions);
+    info!(
+        "request method={} uri={uri} client_ip={client_ip}",
+        parts.method
+    );
     let begin_ticks = now();
     let response = next.run(Request::from_parts(parts, body)).await;
     let end_ticks = now();
     let duration = end_ticks - begin_ticks;
     imetric!("request_duration", "ticks", duration as u64);
-    info!("response status={} uri={uri}", response.status());
+    info!(
+        "response status={} uri={uri} client_ip={client_ip}",
+        response.status()
+    );
     response
 }
 

--- a/rust/public/src/servers/connect_info_layer.rs
+++ b/rust/public/src/servers/connect_info_layer.rs
@@ -1,0 +1,108 @@
+//! Connection info utilities for capturing client socket addresses in Tonic services.
+
+use futures::Stream;
+use std::{
+    io,
+    net::SocketAddr,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tonic::transport::server::Connected;
+
+/// A wrapper around a TCP stream that captures and provides the remote socket address.
+/// This is used with Tonic's `serve_with_incoming` to make client IPs available.
+pub struct ConnectedStream<T> {
+    inner: T,
+    remote_addr: SocketAddr,
+}
+
+impl<T> ConnectedStream<T> {
+    pub fn new(inner: T, remote_addr: SocketAddr) -> Self {
+        Self { inner, remote_addr }
+    }
+}
+
+impl<T: AsyncRead + Unpin> AsyncRead for ConnectedStream<T> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl<T: AsyncWrite + Unpin> AsyncWrite for ConnectedStream<T> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+/// Implement Connected trait to provide the remote address to Tonic
+impl<T> Connected for ConnectedStream<T> {
+    type ConnectInfo = SocketAddr;
+
+    fn connect_info(&self) -> Self::ConnectInfo {
+        self.remote_addr
+    }
+}
+
+/// An incoming stream adapter that wraps TCP connections with ConnectedStream
+pub struct ConnectedIncoming {
+    inner: Pin<Box<dyn Stream<Item = Result<tokio::net::TcpStream, io::Error>> + Send>>,
+}
+
+impl ConnectedIncoming {
+    pub fn from_std_listener(listener: std::net::TcpListener) -> io::Result<Self> {
+        listener.set_nonblocking(true)?;
+        let listener = tokio::net::TcpListener::from_std(listener)?;
+        Ok(Self::new(listener))
+    }
+
+    pub fn new(listener: tokio::net::TcpListener) -> Self {
+        let stream = async_stream::stream! {
+            loop {
+                match listener.accept().await {
+                    Ok((stream, _addr)) => yield Ok(stream),
+                    Err(e) => yield Err(e),
+                }
+            }
+        };
+
+        Self {
+            inner: Box::pin(stream),
+        }
+    }
+}
+
+impl Stream for ConnectedIncoming {
+    type Item = Result<ConnectedStream<tokio::net::TcpStream>, io::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.inner.as_mut().poll_next(cx) {
+            Poll::Ready(Some(Ok(stream))) => {
+                let remote_addr = match stream.peer_addr() {
+                    Ok(addr) => addr,
+                    Err(e) => return Poll::Ready(Some(Err(e))),
+                };
+                Poll::Ready(Some(Ok(ConnectedStream::new(stream, remote_addr))))
+            }
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/rust/public/src/servers/http_utils.rs
+++ b/rust/public/src/servers/http_utils.rs
@@ -1,0 +1,40 @@
+//! HTTP utilities for server implementations
+
+/// Extracts the client IP address from HTTP headers and extensions.
+///
+/// This function checks headers in order of priority:
+/// 1. X-Forwarded-For (leftmost IP is the original client when behind proxies)
+/// 2. X-Real-IP (used by some proxies like nginx)
+/// 3. Socket address from extensions (direct connection)
+///
+/// Returns "unknown" if no IP can be extracted.
+pub fn get_client_ip(headers: &http::HeaderMap, extensions: &http::Extensions) -> String {
+    // Check X-Forwarded-For header first (for load balancers/proxies)
+    // The leftmost IP is the original client when behind proxies
+    if let Some(forwarded_for) = headers.get("x-forwarded-for")
+        && let Ok(value) = forwarded_for.to_str()
+        && let Some(client_ip) = value.split(',').next()
+    {
+        return client_ip.trim().to_string();
+    }
+
+    // Check X-Real-IP header (used by some proxies like nginx)
+    if let Some(real_ip) = headers.get("x-real-ip")
+        && let Ok(value) = real_ip.to_str()
+    {
+        return value.to_string();
+    }
+
+    // Fall back to socket address from extensions
+    // Axum provides ConnectInfo<SocketAddr>, Tonic provides SocketAddr directly
+    if let Some(connect_info) = extensions.get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+    {
+        return connect_info.0.ip().to_string();
+    }
+
+    if let Some(remote_addr) = extensions.get::<std::net::SocketAddr>() {
+        return remote_addr.ip().to_string();
+    }
+
+    "unknown".to_string()
+}

--- a/rust/public/src/servers/log_uri_service.rs
+++ b/rust/public/src/servers/log_uri_service.rs
@@ -3,6 +3,8 @@ use std::task::Context;
 use std::task::Poll;
 use tower::Service;
 
+use super::http_utils::get_client_ip;
+
 /// A Tower service that logs the URI of incoming requests.
 #[derive(Clone)]
 pub struct LogUriService<S> {
@@ -24,7 +26,8 @@ where
 
     /// Logs the URI of the incoming request and then calls the inner service.
     fn call(&mut self, request: http::Request<Body>) -> Self::Future {
-        info!("uri={:?}", request.uri());
+        let client_ip = get_client_ip(request.headers(), request.extensions());
+        info!("uri={:?} client_ip={client_ip}", request.uri());
         self.service.call(request)
     }
 }

--- a/rust/public/src/servers/mod.rs
+++ b/rust/public/src/servers/mod.rs
@@ -1,5 +1,11 @@
 pub mod axum_utils;
 
+/// connection info utilities for Tonic services
+pub mod connect_info_layer;
+
+/// http utilities
+pub mod http_utils;
+
 /// scheduled task for daemon
 pub mod cron_task;
 

--- a/rust/telemetry-ingestion-srv/src/main.rs
+++ b/rust/telemetry-ingestion-srv/src/main.rs
@@ -89,7 +89,12 @@ async fn serve_http(
         "serving on {} with authentication={}",
         args.listen_endpoint_http, auth_enabled
     );
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await
+    .unwrap();
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Add client IP logging to all HTTP and gRPC server observability logs
- Extract client IP detection logic into reusable http_utils module
- Support X-Forwarded-For and X-Real-IP headers for proxy scenarios
- Configure Axum services to capture socket addresses with ConnectInfo
- Implement ConnectedIncoming wrapper for Tonic gRPC to propagate client IPs

## Changes
- **rust/public/src/servers/http_utils.rs**: New utility to extract client IP from headers (X-Forwarded-For, X-Real-IP) and socket extensions
- **rust/public/src/servers/connect_info_layer.rs**: New ConnectedIncoming stream wrapper for Tonic/gRPC services
- **rust/public/src/servers/axum_utils.rs**: Log client IP in observability middleware
- **rust/public/src/servers/log_uri_service.rs**: Log client IP in URI logging
- **rust/telemetry-ingestion-srv/src/main.rs**: Configure Axum with `into_make_service_with_connect_info`
- **rust/analytics-web-srv/src/main.rs**: Configure Axum with `into_make_service_with_connect_info`
- **rust/flight-sql-srv/src/flight_sql_srv.rs**: Use ConnectedIncoming with serve_with_incoming

## Test plan
- [x] Code builds successfully
- [x] Start services and verify client IP appears in logs (not "unknown")
- [ ] Test behind proxy with X-Forwarded-For header
- [x] Verify both HTTP and gRPC services log client IPs