### PR TITLE
refactor: modernize Unreal telemetry sink module

### DIFF
--- a/unreal/MicromegasTelemetrySink/MicromegasTelemetrySink.Build.cs
+++ b/unreal/MicromegasTelemetrySink/MicromegasTelemetrySink.Build.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
 using UnrealBuildTool;
 
@@ -7,16 +5,15 @@ public class MicromegasTelemetrySink : ModuleRules
 {
 	public MicromegasTelemetrySink(ReadOnlyTargetRules Target) : base(Target)
 	{
-		PrivateDependencyModuleNames.AddRange(new string[]
-		{
+		PrivateDependencyModuleNames.AddRange([
+			"BuildSettings",
 			"Core",
 			"CoreUObject",
+			"Engine", 
+			"HTTP",
 			"RenderCore",
 			"RHI",
-			"HTTP",
-			"BuildSettings",
-			"Engine",
-		});
+		]);
 
 		PrivateIncludePaths.Add( Path.Combine(ModuleDirectory, "ThirdParty/jsoncons-0.173.4") );
 		PrivateIncludePaths.Add( Path.Combine(ModuleDirectory, "ThirdParty") );

--- a/unreal/MicromegasTelemetrySink/Private/SystemErrorReporter.cpp
+++ b/unreal/MicromegasTelemetrySink/Private/SystemErrorReporter.cpp
@@ -34,7 +34,7 @@ void FSystemErrorReporter::OnSystemError()
 		FProgramCounterSymbolInfo SymbolInfo;
 		FPlatformStackWalk::ProgramCounterToSymbolInfo(BackTrace[StackDepth], SymbolInfo);
 		FPlatformStackWalk::SymbolInfoToHumanReadableString(SymbolInfo, Message, MessageMaxSize);
-		FCStringAnsi::Strncat(Message, LINE_TERMINATOR_ANSI, MessageMaxSize);
+		FCStringAnsi::StrncatTruncateDest(Message, MessageMaxSize, LINE_TERMINATOR_ANSI);
 	}
 	MICROMEGAS_LOG("MicromegasTelemetrySink", MicromegasTracing::LogLevel::Fatal, Message);
 	FMemory::SystemFree(Message);

--- a/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/HttpEventSink.h
+++ b/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/HttpEventSink.h
@@ -2,6 +2,7 @@
 //
 //  MicromegasTelemetrySink/HttpEventSink.h
 //
+#include "Containers/Map.h"
 #include "Containers/Queue.h"
 #include "Containers/UnrealString.h"
 #include "HAL/Event.h"
@@ -43,7 +44,7 @@ public:
 	//
 	//  FRunnable
 	//
-	virtual uint32 Run();
+	virtual uint32 Run() override;
 
 private:
 	void IncrementQueueSize();
@@ -63,8 +64,9 @@ private:
 	SharedFlushMonitor Flusher;
 };
 
-MICROMEGASTELEMETRYSINK_API TSharedPtr<MicromegasTracing::EventSink, ESPMode::ThreadSafe> InitHttpEventSink(
+MICROMEGASTELEMETRYSINK_API TSharedPtr<MicromegasTracing::EventSink> InitHttpEventSink(
 	const FString& BaseUrl,
 	const SharedTelemetryAuthenticator& Auth,
 	const SharedSamplingController& Sampling,
-	const SharedFlushMonitor& Flusher);
+	const SharedFlushMonitor& Flusher,
+	const TMap<FString,FString>& AdditionalProcessProperties);

--- a/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/MicromegasTelemetrySinkModule.h
+++ b/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/MicromegasTelemetrySinkModule.h
@@ -28,5 +28,5 @@ public:
 		return FModuleManager::GetModulePtr<IMicromegasTelemetrySinkModule>(GetModuleName());
 	}
 
-	virtual void InitTelemetry(const FString& BaseUrl, const SharedTelemetryAuthenticator& Auth) = 0;
+	virtual void InitTelemetry(const FString& BaseUrl, const SharedTelemetryAuthenticator& Auth, const TMap<FString, FString>& AdditionalProcessProperties = TMap<FString, FString>()) = 0;
 };


### PR DESCRIPTION
- Use modern C++ collection initializers
- Mark constants as constexpr where appropriate
- Add support for additional process properties in InitTelemetry
- Fix deprecated FCStringAnsi::Strncat call
- Add missing override specifiers and const qualifiers
- Alphabetize module dependencies