### PR TITLE
Document auth_provider parameter and deprecate headers in Python API

### DIFF
--- a/mkdocs/serve.py
+++ b/mkdocs/serve.py
@@ -31,11 +31,11 @@ def main():
         str(VENV_MKDOCS),
         "serve",
         "--config-file", str(CONFIG_FILE),
-        "--dev-addr", "0.0.0.0:8000"
+        "--dev-addr", "0.0.0.0:8765"
     ]
 
     print(f"Starting MkDocs server...")
-    print(f"Server will be available at: http://localhost:8000")
+    print(f"Server will be available at: http://localhost:8765")
     print(f"Press Ctrl+C to stop")
     print()
 


### PR DESCRIPTION
- Add complete FlightSQLClient constructor signature with auth_provider
- Document auth_provider as recommended authentication method
- Mark headers parameter as deprecated throughout documentation
- Update authentication examples to prioritize OIDC with auth_provider
- Add MkDocs warning admonitions for deprecated patterns
- Update connection examples to show modern authentication
- Change mkdocs server port from 8000 to 8765 to avoid conflicts

Fixes missing documentation for the recommended authentication approach and properly marks the legacy headers parameter as deprecated.