### PR TITLE
Fix secureJsonData undefined error and rename plugin to Micromegas FlightSQL

### DIFF
--- a/grafana/src/components/utils.ts
+++ b/grafana/src/components/utils.ts
@@ -143,6 +143,9 @@ export const onAuthTypeChange = (selectedAuthType: any, options: any, onOptionsC
   const notPassType = selectedAuthType?.label !== "username/password"
   const notOAuthType = selectedAuthType?.label !== "oauth2"
 
+  // Initialize secureJsonData if it doesn't exist to prevent undefined access errors
+  const existingSecureJsonData = options.secureJsonData || {}
+
   onOptionsChange({
     ...options,
     jsonData: {
@@ -155,15 +158,15 @@ export const onAuthTypeChange = (selectedAuthType: any, options: any, onOptionsC
     },
     secureJsonFields: {
       ...options.secureJsonFields,
-      token: notTokenType ? false : options.secureJsonFields.token,
-      password: notPassType ? false : options.secureJsonFields.password,
-      oauthClientSecret: notOAuthType ? false : options.secureJsonFields.oauthClientSecret,
+      token: notTokenType ? false : options.secureJsonFields?.token,
+      password: notPassType ? false : options.secureJsonFields?.password,
+      oauthClientSecret: notOAuthType ? false : options.secureJsonFields?.oauthClientSecret,
     },
     secureJsonData: {
-      ...options.secureJsonData,
-      token: notTokenType ? '' : options.secureJsonData.token,
-      password: notPassType ? '' : options.secureJsonData.password,
-      oauthClientSecret: notOAuthType ? '' : options.secureJsonData.oauthClientSecret,
+      ...existingSecureJsonData,
+      token: notTokenType ? '' : existingSecureJsonData.token,
+      password: notPassType ? '' : existingSecureJsonData.password,
+      oauthClientSecret: notOAuthType ? '' : existingSecureJsonData.oauthClientSecret,
     },
   })
 }

--- a/grafana/src/plugin.json
+++ b/grafana/src/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
-  "name": "Micromegas",
+  "name": "Micromegas FlightSQL",
   "id": "micromegas-micromegas-datasource",
   "logs": true,
   "metrics": true,


### PR DESCRIPTION
## Summary
- Fix undefined access error when `secureJsonData` or `secureJsonFields` are not initialized during auth type changes
- Rename Grafana plugin from "Micromegas" to "Micromegas FlightSQL" for clearer identification

## Test plan
- [ ] Verify plugin loads in Grafana without console errors
- [ ] Test switching between auth types (token, username/password, oauth2) in data source config
- [ ] Confirm plugin appears as "Micromegas FlightSQL" in Grafana data source list