### PR TITLE
Enable Claude to submit PR reviews and issue comments

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write  # Allows posting PR reviews and inline comments
+      issues: write         # Allows posting issue comments
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- Change `pull-requests` permission from `read` to `write` to allow Claude to submit formal PR reviews with inline comments
- Change `issues` permission from `read` to `write` to allow Claude to post issue comments

## Why
With read-only permissions, Claude can only respond in comment threads. With write permissions, Claude can:
- Submit PR reviews (approve / request changes / comment)
- Post inline comments on specific lines of code
- Comment on issues

Note: This does NOT enable merging PRs (would require `contents: write`).

## Test plan
- [ ] Merge this PR
- [ ] Comment `@claude review this PR` on another PR
- [ ] Verify Claude submits a formal review instead of just a comment