### PR TITLE
Add DefaultContext::SetBatch for Unreal tracing

### DIFF
--- a/unreal/MicromegasTracing/Private/DefaultContext.cpp
+++ b/unreal/MicromegasTracing/Private/DefaultContext.cpp
@@ -40,6 +40,30 @@ namespace MicromegasTracing
 		UpdatePropertySet();
 	}
 
+	void DefaultContext::SetBatch(TArrayView<TPair<FName, FName>> BatchEntries)
+	{
+		FScopeLock Lock(&Mutex);
+		for (const TPair<FName, FName>& Entry : BatchEntries)
+		{
+			FName* StoredValue = Context.Find(Entry.Key);
+			if (StoredValue != nullptr)
+			{
+				if (*StoredValue == Entry.Value)
+				{
+					continue;
+				}
+
+				*StoredValue = Entry.Value;
+			}
+			else
+			{
+				Context.Add(Entry.Key, Entry.Value);
+			}
+		}
+
+		UpdatePropertySet();
+	}
+
 	void DefaultContext::Unset(FName Key)
 	{
 		FScopeLock Lock(&Mutex);

--- a/unreal/MicromegasTracing/Public/MicromegasTracing/DefaultContext.h
+++ b/unreal/MicromegasTracing/Public/MicromegasTracing/DefaultContext.h
@@ -22,6 +22,7 @@ namespace MicromegasTracing
 		// Set, Unset and Clear are expensive and are not expected to be called frequently.
 		// Since the keys and values are never freed, local cardinality has to be limited.
 		void Set(FName Key, FName Value);
+		void SetBatch(TArrayView<TPair<FName, FName>> BatchEntries);
 		void Unset(FName Key);
 		void Clear();
 


### PR DESCRIPTION
## Summary
- Add `SetBatch` method to `DefaultContext` for setting multiple context entries in a single call
- Uses a single mutex lock for the batch operation, improving efficiency over multiple `Set` calls

## Test plan
- [x] Verify compilation of the Unreal plugin
- [x] Test batch context setting in an Unreal project