### PR TITLE
Add branding assets

### DIFF
--- a/branding/micromegas-brand-sheet.svg
+++ b/branding/micromegas-brand-sheet.svg
@@ -1,0 +1,220 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 1400">
+  <defs>
+    <linearGradient id="ring1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#bf360c"/>
+      <stop offset="100%" style="stop-color:#8d3a14"/>
+    </linearGradient>
+    <linearGradient id="ring2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1565c0"/>
+      <stop offset="100%" style="stop-color:#0d47a1"/>
+    </linearGradient>
+    <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffc107"/>
+      <stop offset="100%" style="stop-color:#ffb300"/>
+    </linearGradient>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <!-- DARK SECTION -->
+  <rect x="0" y="0" width="1200" height="700" fill="#0a0a0f"/>
+  
+  <!-- Title -->
+  <text x="600" y="50" text-anchor="middle" fill="#ffffff" font-family="system-ui, sans-serif" font-size="28" font-weight="300" letter-spacing="8">MICROMEGAS BRAND ASSETS</text>
+  <text x="600" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="12">RUST EARTH PALETTE</text>
+  
+  <text x="600" y="120" text-anchor="middle" fill="#444" font-family="monospace" font-size="14" letter-spacing="4">DARK BACKGROUND</text>
+  
+  <!-- Primary Vertical Dark -->
+  <g transform="translate(200, 300)">
+    <text x="0" y="-130" text-anchor="middle" fill="#555" font-family="monospace" font-size="11">PRIMARY VERTICAL</text>
+    <ellipse cx="0" cy="0" rx="100" ry="38" fill="none" stroke="url(#ring1)" stroke-width="2.5" transform="rotate(-20)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="79" ry="30" fill="none" stroke="url(#ring2)" stroke-width="2.5" transform="rotate(25)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="58" ry="22" fill="none" stroke="url(#ring3)" stroke-width="2.5" transform="rotate(-8)" opacity="0.9"/>
+    <g filter="url(#glow)">
+      <polygon points="0,-12 2,-4 9,-4 3,1 6,9 0,4 -6,9 -3,1 -9,-4 -2,-4" fill="#ffffff"/>
+    </g>
+    <text x="0" y="90" text-anchor="middle" fill="#ffffff" font-family="system-ui, sans-serif" font-size="28" font-weight="300" letter-spacing="4">micromegas</text>
+  </g>
+  
+  <!-- Horizontal Dark -->
+  <g transform="translate(580, 300)">
+    <text x="120" y="-130" text-anchor="middle" fill="#555" font-family="monospace" font-size="11">HORIZONTAL LOCKUP</text>
+    <g transform="scale(0.6)">
+      <ellipse cx="0" cy="0" rx="100" ry="38" fill="none" stroke="url(#ring1)" stroke-width="3.5" transform="rotate(-20)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="79" ry="30" fill="none" stroke="url(#ring2)" stroke-width="3.5" transform="rotate(25)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="58" ry="22" fill="none" stroke="url(#ring3)" stroke-width="3.5" transform="rotate(-8)" opacity="0.9"/>
+      <g filter="url(#glow)">
+        <polygon points="0,-12 2,-4 9,-4 3,1 6,9 0,4 -6,9 -3,1 -9,-4 -2,-4" fill="#ffffff"/>
+      </g>
+    </g>
+    <text x="85" y="10" text-anchor="start" fill="#ffffff" font-family="system-ui, sans-serif" font-size="32" font-weight="300" letter-spacing="4">micromegas</text>
+  </g>
+  
+  <!-- Icon Only Dark -->
+  <g transform="translate(1000, 300)">
+    <text x="0" y="-130" text-anchor="middle" fill="#555" font-family="monospace" font-size="11">ICON ONLY</text>
+    <ellipse cx="0" cy="0" rx="100" ry="38" fill="none" stroke="url(#ring1)" stroke-width="2.5" transform="rotate(-20)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="79" ry="30" fill="none" stroke="url(#ring2)" stroke-width="2.5" transform="rotate(25)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="58" ry="22" fill="none" stroke="url(#ring3)" stroke-width="2.5" transform="rotate(-8)" opacity="0.9"/>
+    <g filter="url(#glow)">
+      <polygon points="0,-12 2,-4 9,-4 3,1 6,9 0,4 -6,9 -3,1 -9,-4 -2,-4" fill="#ffffff"/>
+    </g>
+  </g>
+  
+  <!-- Small icons row -->
+  <text x="200" y="460" text-anchor="middle" fill="#555" font-family="monospace" font-size="11">APP ICONS</text>
+  
+  <!-- 64px -->
+  <g transform="translate(130, 540)">
+    <rect x="-40" y="-40" width="80" height="80" fill="#12121a" rx="12"/>
+    <g transform="scale(0.35)">
+      <ellipse cx="0" cy="0" rx="100" ry="38" fill="none" stroke="url(#ring1)" stroke-width="5" transform="rotate(-20)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="79" ry="30" fill="none" stroke="url(#ring2)" stroke-width="5" transform="rotate(25)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="58" ry="22" fill="none" stroke="url(#ring3)" stroke-width="5" transform="rotate(-8)" opacity="0.9"/>
+      <polygon points="0,-12 2,-4 9,-4 3,1 6,9 0,4 -6,9 -3,1 -9,-4 -2,-4" fill="#ffffff"/>
+    </g>
+    <text x="0" y="60" text-anchor="middle" fill="#444" font-family="monospace" font-size="10">64px</text>
+  </g>
+  
+  <!-- 48px -->
+  <g transform="translate(230, 540)">
+    <rect x="-30" y="-30" width="60" height="60" fill="#12121a" rx="10"/>
+    <g transform="scale(0.26)">
+      <ellipse cx="0" cy="0" rx="100" ry="38" fill="none" stroke="url(#ring1)" stroke-width="6" transform="rotate(-20)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="79" ry="30" fill="none" stroke="url(#ring2)" stroke-width="6" transform="rotate(25)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="58" ry="22" fill="none" stroke="url(#ring3)" stroke-width="6" transform="rotate(-8)" opacity="0.9"/>
+      <polygon points="0,-12 2,-4 9,-4 3,1 6,9 0,4 -6,9 -3,1 -9,-4 -2,-4" fill="#ffffff"/>
+    </g>
+    <text x="0" y="50" text-anchor="middle" fill="#444" font-family="monospace" font-size="10">48px</text>
+  </g>
+  
+  <!-- 32px -->
+  <g transform="translate(310, 540)">
+    <rect x="-20" y="-20" width="40" height="40" fill="#12121a" rx="6"/>
+    <g transform="scale(0.18)">
+      <ellipse cx="0" cy="0" rx="100" ry="38" fill="none" stroke="url(#ring1)" stroke-width="8" transform="rotate(-20)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="79" ry="30" fill="none" stroke="url(#ring2)" stroke-width="8" transform="rotate(25)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="58" ry="22" fill="none" stroke="url(#ring3)" stroke-width="8" transform="rotate(-8)" opacity="0.9"/>
+      <polygon points="0,-14 2.5,-5 11,-5 4,1 7,11 0,5 -7,11 -4,1 -11,-5 -2.5,-5" fill="#ffffff"/>
+    </g>
+    <text x="0" y="40" text-anchor="middle" fill="#444" font-family="monospace" font-size="10">32px</text>
+  </g>
+  
+  <!-- Social Avatar -->
+  <g transform="translate(500, 540)">
+    <text x="0" y="-70" text-anchor="middle" fill="#555" font-family="monospace" font-size="11">SOCIAL AVATAR</text>
+    <circle cx="0" cy="0" r="50" fill="#12121a"/>
+    <g transform="scale(0.4)">
+      <ellipse cx="0" cy="0" rx="100" ry="38" fill="none" stroke="url(#ring1)" stroke-width="4" transform="rotate(-20)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="79" ry="30" fill="none" stroke="url(#ring2)" stroke-width="4" transform="rotate(25)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="58" ry="22" fill="none" stroke="url(#ring3)" stroke-width="4" transform="rotate(-8)" opacity="0.9"/>
+      <polygon points="0,-12 2,-4 9,-4 3,1 6,9 0,4 -6,9 -3,1 -9,-4 -2,-4" fill="#ffffff"/>
+    </g>
+  </g>
+  
+  <!-- Monochrome White -->
+  <g transform="translate(700, 540)">
+    <text x="0" y="-70" text-anchor="middle" fill="#555" font-family="monospace" font-size="11">MONO WHITE</text>
+    <g transform="scale(0.5)">
+      <ellipse cx="0" cy="0" rx="100" ry="38" fill="none" stroke="#ffffff" stroke-width="3" transform="rotate(-20)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="79" ry="30" fill="none" stroke="#ffffff" stroke-width="3" transform="rotate(25)" opacity="0.6"/>
+      <ellipse cx="0" cy="0" rx="58" ry="22" fill="none" stroke="#ffffff" stroke-width="3" transform="rotate(-8)" opacity="0.3"/>
+      <polygon points="0,-12 2,-4 9,-4 3,1 6,9 0,4 -6,9 -3,1 -9,-4 -2,-4" fill="#ffffff"/>
+    </g>
+  </g>
+  
+  <!-- Wordmark Only -->
+  <g transform="translate(950, 540)">
+    <text x="0" y="-70" text-anchor="middle" fill="#555" font-family="monospace" font-size="11">WORDMARK ONLY</text>
+    <text x="0" y="10" text-anchor="middle" fill="#ffffff" font-family="system-ui, sans-serif" font-size="32" font-weight="300" letter-spacing="5">micromegas</text>
+  </g>
+  
+  <!-- LIGHT SECTION -->
+  <rect x="0" y="700" width="1200" height="700" fill="#f5f5f7"/>
+  
+  <text x="600" y="750" text-anchor="middle" fill="#999" font-family="monospace" font-size="14" letter-spacing="4">LIGHT BACKGROUND</text>
+  
+  <!-- Primary Vertical Light -->
+  <g transform="translate(200, 930)">
+    <text x="0" y="-130" text-anchor="middle" fill="#999" font-family="monospace" font-size="11">PRIMARY VERTICAL</text>
+    <ellipse cx="0" cy="0" rx="100" ry="38" fill="none" stroke="url(#ring1)" stroke-width="2.5" transform="rotate(-20)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="79" ry="30" fill="none" stroke="url(#ring2)" stroke-width="2.5" transform="rotate(25)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="58" ry="22" fill="none" stroke="url(#ring3)" stroke-width="2.5" transform="rotate(-8)" opacity="0.9"/>
+    <polygon points="0,-12 2,-4 9,-4 3,1 6,9 0,4 -6,9 -3,1 -9,-4 -2,-4" fill="#1a1a2e"/>
+    <text x="0" y="90" text-anchor="middle" fill="#1a1a2e" font-family="system-ui, sans-serif" font-size="28" font-weight="300" letter-spacing="4">micromegas</text>
+  </g>
+  
+  <!-- Horizontal Light -->
+  <g transform="translate(580, 930)">
+    <text x="120" y="-130" text-anchor="middle" fill="#999" font-family="monospace" font-size="11">HORIZONTAL LOCKUP</text>
+    <g transform="scale(0.6)">
+      <ellipse cx="0" cy="0" rx="100" ry="38" fill="none" stroke="url(#ring1)" stroke-width="3.5" transform="rotate(-20)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="79" ry="30" fill="none" stroke="url(#ring2)" stroke-width="3.5" transform="rotate(25)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="58" ry="22" fill="none" stroke="url(#ring3)" stroke-width="3.5" transform="rotate(-8)" opacity="0.9"/>
+      <polygon points="0,-12 2,-4 9,-4 3,1 6,9 0,4 -6,9 -3,1 -9,-4 -2,-4" fill="#1a1a2e"/>
+    </g>
+    <text x="85" y="10" text-anchor="start" fill="#1a1a2e" font-family="system-ui, sans-serif" font-size="32" font-weight="300" letter-spacing="4">micromegas</text>
+  </g>
+  
+  <!-- Icon Only Light -->
+  <g transform="translate(1000, 930)">
+    <text x="0" y="-130" text-anchor="middle" fill="#999" font-family="monospace" font-size="11">ICON ONLY</text>
+    <ellipse cx="0" cy="0" rx="100" ry="38" fill="none" stroke="url(#ring1)" stroke-width="2.5" transform="rotate(-20)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="79" ry="30" fill="none" stroke="url(#ring2)" stroke-width="2.5" transform="rotate(25)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="58" ry="22" fill="none" stroke="url(#ring3)" stroke-width="2.5" transform="rotate(-8)" opacity="0.9"/>
+    <polygon points="0,-12 2,-4 9,-4 3,1 6,9 0,4 -6,9 -3,1 -9,-4 -2,-4" fill="#1a1a2e"/>
+  </g>
+  
+  <!-- Social Avatar Light -->
+  <g transform="translate(200, 1170)">
+    <text x="0" y="-70" text-anchor="middle" fill="#999" font-family="monospace" font-size="11">SOCIAL AVATAR</text>
+    <circle cx="0" cy="0" r="50" fill="#ffffff" stroke="#e0e0e0" stroke-width="1"/>
+    <g transform="scale(0.4)">
+      <ellipse cx="0" cy="0" rx="100" ry="38" fill="none" stroke="url(#ring1)" stroke-width="4" transform="rotate(-20)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="79" ry="30" fill="none" stroke="url(#ring2)" stroke-width="4" transform="rotate(25)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="58" ry="22" fill="none" stroke="url(#ring3)" stroke-width="4" transform="rotate(-8)" opacity="0.9"/>
+      <polygon points="0,-12 2,-4 9,-4 3,1 6,9 0,4 -6,9 -3,1 -9,-4 -2,-4" fill="#1a1a2e"/>
+    </g>
+  </g>
+  
+  <!-- Monochrome Black -->
+  <g transform="translate(400, 1170)">
+    <text x="0" y="-70" text-anchor="middle" fill="#999" font-family="monospace" font-size="11">MONO BLACK</text>
+    <g transform="scale(0.5)">
+      <ellipse cx="0" cy="0" rx="100" ry="38" fill="none" stroke="#1a1a2e" stroke-width="3" transform="rotate(-20)" opacity="0.9"/>
+      <ellipse cx="0" cy="0" rx="79" ry="30" fill="none" stroke="#1a1a2e" stroke-width="3" transform="rotate(25)" opacity="0.6"/>
+      <ellipse cx="0" cy="0" rx="58" ry="22" fill="none" stroke="#1a1a2e" stroke-width="3" transform="rotate(-8)" opacity="0.3"/>
+      <polygon points="0,-12 2,-4 9,-4 3,1 6,9 0,4 -6,9 -3,1 -9,-4 -2,-4" fill="#1a1a2e"/>
+    </g>
+  </g>
+  
+  <!-- Wordmark Only Light -->
+  <g transform="translate(650, 1170)">
+    <text x="0" y="-70" text-anchor="middle" fill="#999" font-family="monospace" font-size="11">WORDMARK ONLY</text>
+    <text x="0" y="10" text-anchor="middle" fill="#1a1a2e" font-family="system-ui, sans-serif" font-size="32" font-weight="300" letter-spacing="5">micromegas</text>
+  </g>
+  
+  <!-- Color Palette -->
+  <g transform="translate(920, 1120)">
+    <text x="60" y="0" text-anchor="middle" fill="#999" font-family="monospace" font-size="11">COLOR PALETTE</text>
+    
+    <rect x="0" y="15" width="40" height="40" fill="#bf360c" rx="4"/>
+    <text x="20" y="75" text-anchor="middle" fill="#666" font-family="monospace" font-size="9">#bf360c</text>
+    
+    <rect x="50" y="15" width="40" height="40" fill="#1565c0" rx="4"/>
+    <text x="70" y="75" text-anchor="middle" fill="#666" font-family="monospace" font-size="9">#1565c0</text>
+    
+    <rect x="100" y="15" width="40" height="40" fill="#ffc107" rx="4"/>
+    <text x="120" y="75" text-anchor="middle" fill="#666" font-family="monospace" font-size="9">#ffc107</text>
+    
+    <rect x="150" y="15" width="40" height="40" fill="#1a1a2e" rx="4"/>
+    <text x="170" y="75" text-anchor="middle" fill="#666" font-family="monospace" font-size="9">#1a1a2e</text>
+  </g>
+  
+</svg>

--- a/branding/micromegas-horizontal-dark.svg
+++ b/branding/micromegas-horizontal-dark.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 150">
+  <defs>
+    <linearGradient id="ring1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#bf360c"/>
+      <stop offset="100%" style="stop-color:#8d3a14"/>
+    </linearGradient>
+    <linearGradient id="ring2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1565c0"/>
+      <stop offset="100%" style="stop-color:#0d47a1"/>
+    </linearGradient>
+    <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffc107"/>
+      <stop offset="100%" style="stop-color:#ffb300"/>
+    </linearGradient>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="1.5" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <rect width="600" height="150" fill="#0a0a0f"/>
+  
+  <g transform="translate(75, 75)">
+    <ellipse cx="0" cy="0" rx="55" ry="21" fill="none" stroke="url(#ring1)" stroke-width="2" transform="rotate(-20)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="44" ry="17" fill="none" stroke="url(#ring2)" stroke-width="2" transform="rotate(25)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="32" ry="12" fill="none" stroke="url(#ring3)" stroke-width="2" transform="rotate(-8)" opacity="0.9"/>
+    <g filter="url(#glow)">
+      <polygon points="0,-7 1.2,-2.5 5,-2.5 2,0.5 3.5,5 0,2.5 -3.5,5 -2,0.5 -5,-2.5 -1.2,-2.5" fill="#ffffff"/>
+    </g>
+  </g>
+  
+  <text x="150" y="88" fill="#ffffff" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="42" font-weight="300" letter-spacing="5">micromegas</text>
+</svg>

--- a/branding/micromegas-horizontal-light.svg
+++ b/branding/micromegas-horizontal-light.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 150">
+  <defs>
+    <linearGradient id="ring1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#bf360c"/>
+      <stop offset="100%" style="stop-color:#8d3a14"/>
+    </linearGradient>
+    <linearGradient id="ring2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1565c0"/>
+      <stop offset="100%" style="stop-color:#0d47a1"/>
+    </linearGradient>
+    <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffc107"/>
+      <stop offset="100%" style="stop-color:#ffb300"/>
+    </linearGradient>
+  </defs>
+  
+  <rect width="600" height="150" fill="#ffffff"/>
+  
+  <g transform="translate(75, 75)">
+    <ellipse cx="0" cy="0" rx="55" ry="21" fill="none" stroke="url(#ring1)" stroke-width="2" transform="rotate(-20)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="44" ry="17" fill="none" stroke="url(#ring2)" stroke-width="2" transform="rotate(25)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="32" ry="12" fill="none" stroke="url(#ring3)" stroke-width="2" transform="rotate(-8)" opacity="0.9"/>
+    <polygon points="0,-7 1.2,-2.5 5,-2.5 2,0.5 3.5,5 0,2.5 -3.5,5 -2,0.5 -5,-2.5 -1.2,-2.5" fill="#1a1a2e"/>
+  </g>
+  
+  <text x="150" y="88" fill="#1a1a2e" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="42" font-weight="300" letter-spacing="5">micromegas</text>
+</svg>

--- a/branding/micromegas-icon-512.svg
+++ b/branding/micromegas-icon-512.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="ring1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#bf360c"/>
+      <stop offset="100%" style="stop-color:#8d3a14"/>
+    </linearGradient>
+    <linearGradient id="ring2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1565c0"/>
+      <stop offset="100%" style="stop-color:#0d47a1"/>
+    </linearGradient>
+    <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffc107"/>
+      <stop offset="100%" style="stop-color:#ffb300"/>
+    </linearGradient>
+  </defs>
+  
+  <rect width="512" height="512" fill="#0a0a0f" rx="64"/>
+  
+  <g transform="translate(256, 256)">
+    <ellipse cx="0" cy="0" rx="180" ry="68" fill="none" stroke="url(#ring1)" stroke-width="12" transform="rotate(-20)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="142" ry="54" fill="none" stroke="url(#ring2)" stroke-width="12" transform="rotate(25)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="105" ry="40" fill="none" stroke="url(#ring3)" stroke-width="12" transform="rotate(-8)" opacity="0.9"/>
+    <polygon points="0,-22 4,-7 16,-7 6,2 11,16 0,7 -11,16 -6,2 -16,-7 -4,-7" fill="#ffffff"/>
+  </g>
+</svg>

--- a/branding/micromegas-icon-transparent.svg
+++ b/branding/micromegas-icon-transparent.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <defs>
+    <linearGradient id="ring1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#bf360c"/>
+      <stop offset="100%" style="stop-color:#8d3a14"/>
+    </linearGradient>
+    <linearGradient id="ring2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1565c0"/>
+      <stop offset="100%" style="stop-color:#0d47a1"/>
+    </linearGradient>
+    <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffc107"/>
+      <stop offset="100%" style="stop-color:#ffb300"/>
+    </linearGradient>
+  </defs>
+  
+  <g transform="translate(100, 100)">
+    <ellipse cx="0" cy="0" rx="85" ry="32" fill="none" stroke="url(#ring1)" stroke-width="3" transform="rotate(-20)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="67" ry="26" fill="none" stroke="url(#ring2)" stroke-width="3" transform="rotate(25)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="50" ry="19" fill="none" stroke="url(#ring3)" stroke-width="3" transform="rotate(-8)" opacity="0.9"/>
+    <polygon points="0,-10 2,-3.5 7.5,-3.5 3,0.5 5,7.5 0,4 -5,7.5 -3,0.5 -7.5,-3.5 -2,-3.5" fill="#ffffff"/>
+  </g>
+</svg>

--- a/branding/micromegas-mono-black.svg
+++ b/branding/micromegas-mono-black.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <g transform="translate(100, 100)">
+    <ellipse cx="0" cy="0" rx="85" ry="32" fill="none" stroke="#1a1a2e" stroke-width="3" transform="rotate(-20)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="67" ry="26" fill="none" stroke="#1a1a2e" stroke-width="3" transform="rotate(25)" opacity="0.6"/>
+    <ellipse cx="0" cy="0" rx="50" ry="19" fill="none" stroke="#1a1a2e" stroke-width="3" transform="rotate(-8)" opacity="0.3"/>
+    <polygon points="0,-10 2,-3.5 7.5,-3.5 3,0.5 5,7.5 0,4 -5,7.5 -3,0.5 -7.5,-3.5 -2,-3.5" fill="#1a1a2e"/>
+  </g>
+</svg>

--- a/branding/micromegas-mono-white.svg
+++ b/branding/micromegas-mono-white.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <g transform="translate(100, 100)">
+    <ellipse cx="0" cy="0" rx="85" ry="32" fill="none" stroke="#ffffff" stroke-width="3" transform="rotate(-20)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="67" ry="26" fill="none" stroke="#ffffff" stroke-width="3" transform="rotate(25)" opacity="0.6"/>
+    <ellipse cx="0" cy="0" rx="50" ry="19" fill="none" stroke="#ffffff" stroke-width="3" transform="rotate(-8)" opacity="0.3"/>
+    <polygon points="0,-10 2,-3.5 7.5,-3.5 3,0.5 5,7.5 0,4 -5,7.5 -3,0.5 -7.5,-3.5 -2,-3.5" fill="#ffffff"/>
+  </g>
+</svg>

--- a/branding/micromegas-primary-dark.svg
+++ b/branding/micromegas-primary-dark.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 500">
+  <defs>
+    <linearGradient id="ring1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#bf360c"/>
+      <stop offset="100%" style="stop-color:#8d3a14"/>
+    </linearGradient>
+    <linearGradient id="ring2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1565c0"/>
+      <stop offset="100%" style="stop-color:#0d47a1"/>
+    </linearGradient>
+    <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffc107"/>
+      <stop offset="100%" style="stop-color:#ffb300"/>
+    </linearGradient>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <rect width="400" height="500" fill="#0a0a0f"/>
+  
+  <g transform="translate(200, 180)">
+    <ellipse cx="0" cy="0" rx="120" ry="45" fill="none" stroke="url(#ring1)" stroke-width="2.5" transform="rotate(-20)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="95" ry="36" fill="none" stroke="url(#ring2)" stroke-width="2.5" transform="rotate(25)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="70" ry="26" fill="none" stroke="url(#ring3)" stroke-width="2.5" transform="rotate(-8)" opacity="0.9"/>
+    <g filter="url(#glow)">
+      <polygon points="0,-14 2.5,-5 11,-5 4,1 7,11 0,5 -7,11 -4,1 -11,-5 -2.5,-5" fill="#ffffff"/>
+    </g>
+  </g>
+  
+  <text x="200" y="380" text-anchor="middle" fill="#ffffff" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="42" font-weight="300" letter-spacing="6">micromegas</text>
+</svg>

--- a/branding/micromegas-primary-light.svg
+++ b/branding/micromegas-primary-light.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 500">
+  <defs>
+    <linearGradient id="ring1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#bf360c"/>
+      <stop offset="100%" style="stop-color:#8d3a14"/>
+    </linearGradient>
+    <linearGradient id="ring2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1565c0"/>
+      <stop offset="100%" style="stop-color:#0d47a1"/>
+    </linearGradient>
+    <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffc107"/>
+      <stop offset="100%" style="stop-color:#ffb300"/>
+    </linearGradient>
+  </defs>
+  
+  <rect width="400" height="500" fill="#ffffff"/>
+  
+  <g transform="translate(200, 180)">
+    <ellipse cx="0" cy="0" rx="120" ry="45" fill="none" stroke="url(#ring1)" stroke-width="2.5" transform="rotate(-20)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="95" ry="36" fill="none" stroke="url(#ring2)" stroke-width="2.5" transform="rotate(25)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="70" ry="26" fill="none" stroke="url(#ring3)" stroke-width="2.5" transform="rotate(-8)" opacity="0.9"/>
+    <polygon points="0,-14 2.5,-5 11,-5 4,1 7,11 0,5 -7,11 -4,1 -11,-5 -2.5,-5" fill="#1a1a2e"/>
+  </g>
+  
+  <text x="200" y="380" text-anchor="middle" fill="#1a1a2e" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="42" font-weight="300" letter-spacing="6">micromegas</text>
+</svg>

--- a/branding/micromegas-social-avatar.svg
+++ b/branding/micromegas-social-avatar.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+  <defs>
+    <linearGradient id="ring1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#bf360c"/>
+      <stop offset="100%" style="stop-color:#8d3a14"/>
+    </linearGradient>
+    <linearGradient id="ring2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1565c0"/>
+      <stop offset="100%" style="stop-color:#0d47a1"/>
+    </linearGradient>
+    <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffc107"/>
+      <stop offset="100%" style="stop-color:#ffb300"/>
+    </linearGradient>
+    <clipPath id="circleClip">
+      <circle cx="200" cy="200" r="200"/>
+    </clipPath>
+  </defs>
+  
+  <circle cx="200" cy="200" r="200" fill="#0a0a0f"/>
+  
+  <g transform="translate(200, 200)">
+    <ellipse cx="0" cy="0" rx="140" ry="53" fill="none" stroke="url(#ring1)" stroke-width="8" transform="rotate(-20)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="110" ry="42" fill="none" stroke="url(#ring2)" stroke-width="8" transform="rotate(25)" opacity="0.9"/>
+    <ellipse cx="0" cy="0" rx="82" ry="31" fill="none" stroke="url(#ring3)" stroke-width="8" transform="rotate(-8)" opacity="0.9"/>
+    <polygon points="0,-16 3,-5.5 11,-5.5 5,1.5 8,12 0,6 -8,12 -5,1.5 -11,-5.5 -3,-5.5" fill="#ffffff"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Add SVG branding assets to new `branding/` directory
- Includes logo variants (primary, horizontal) for dark/light backgrounds
- Includes icons, social avatar, and monochrome versions
- Uses Rust Earth color palette (#bf360c, #1565c0, #ffc107, #1a1a2e)

## Test plan
- [x] Visual inspection of SVG files