### PR TITLE
Add API key authenticator to Unreal telemetry sink

### DIFF
--- a/unreal/MicromegasTelemetrySink/Private/ApiKeyAuthenticator.cpp
+++ b/unreal/MicromegasTelemetrySink/Private/ApiKeyAuthenticator.cpp
@@ -1,0 +1,42 @@
+//
+// MicromegasTelemetrySink/ApiKeyAuthenticator.cpp
+//
+
+#include "MicromegasTelemetrySink/ApiKeyAuthenticator.h"
+#include "MicromegasTelemetrySink/Log.h"
+#include "Interfaces/IHttpRequest.h"
+
+FApiKeyAuthenticator::FApiKeyAuthenticator(const FString& InApiKey)
+	: ApiKey(InApiKey)
+{
+	if (ApiKey.IsEmpty())
+	{
+		UE_LOG(LogMicromegasTelemetrySink, Warning, TEXT("API key is empty"));
+	}
+	else
+	{
+		UE_LOG(LogMicromegasTelemetrySink, Log, TEXT("Using API key authentication"));
+	}
+}
+
+FApiKeyAuthenticator::~FApiKeyAuthenticator() = default;
+
+void FApiKeyAuthenticator::Init(const MicromegasTracing::EventSinkPtr& InSink)
+{
+	// No sink dependency needed for API key auth
+}
+
+bool FApiKeyAuthenticator::IsReady()
+{
+	return !ApiKey.IsEmpty();
+}
+
+bool FApiKeyAuthenticator::Sign(IHttpRequest& Request)
+{
+	if (ApiKey.IsEmpty())
+	{
+		return false;
+	}
+	Request.SetHeader(TEXT("Authorization"), FString::Printf(TEXT("Bearer %s"), *ApiKey));
+	return true;
+}

--- a/unreal/MicromegasTelemetrySink/Private/MicromegasTelemetrySinkModule.cpp
+++ b/unreal/MicromegasTelemetrySink/Private/MicromegasTelemetrySinkModule.cpp
@@ -119,3 +119,7 @@ IMPLEMENT_MODULE(FMicromegasTelemetrySinkModule, MicromegasTelemetrySink)
 ITelemetryAuthenticator::~ITelemetryAuthenticator()
 {
 }
+
+void ITelemetryAuthenticator::Shutdown()
+{
+}

--- a/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/ApiKeyAuthenticator.h
+++ b/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/ApiKeyAuthenticator.h
@@ -1,0 +1,30 @@
+#pragma once
+//
+// MicromegasTelemetrySink/ApiKeyAuthenticator.h
+//
+// Generic API key authenticator for telemetry.
+// Accepts API key via constructor, sends as Bearer token.
+//
+
+#include "Containers/UnrealString.h"
+#include "MicromegasTelemetrySink/TelemetryAuthenticator.h"
+
+/**
+ * Simple API key authenticator.
+ * API key is provided at construction time.
+ * Always ready, signs requests with Bearer token.
+ */
+class MICROMEGASTELEMETRYSINK_API FApiKeyAuthenticator : public ITelemetryAuthenticator
+{
+public:
+	explicit FApiKeyAuthenticator(const FString& InApiKey);
+	virtual ~FApiKeyAuthenticator();
+
+	// ITelemetryAuthenticator
+	virtual void Init(const MicromegasTracing::EventSinkPtr& InSink) override;
+	virtual bool IsReady() override;
+	virtual bool Sign(IHttpRequest& Request) override;
+
+private:
+	FString ApiKey;
+};

--- a/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/TelemetryAuthenticator.h
+++ b/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/TelemetryAuthenticator.h
@@ -12,8 +12,9 @@ class MICROMEGASTELEMETRYSINK_API ITelemetryAuthenticator
 public:
 	virtual ~ITelemetryAuthenticator() = 0;
 	virtual void Init(const MicromegasTracing::EventSinkPtr& InSink) = 0;
+	virtual void Shutdown();
 	virtual bool IsReady() = 0;
-	virtual bool Sign(IHttpRequest& request) = 0;
+	virtual bool Sign(IHttpRequest& Request) = 0;
 };
 
 typedef TSharedPtr<ITelemetryAuthenticator, ESPMode::ThreadSafe> SharedTelemetryAuthenticator;


### PR DESCRIPTION
## Summary
- Adds `FApiKeyAuthenticator` class for simple Bearer token authentication in Unreal telemetry sink
- Adds `Shutdown()` method to `ITelemetryAuthenticator` interface with default empty implementation
- Allows telemetry to authenticate using API keys instead of requiring more complex auth flows

## Test plan
- [x] Build Unreal project with the plugin
- [x] Verify API key auth works with telemetry ingestion service