### PR TITLE
Apply micromegas branding to analytics web app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - Accepts `--format` for output: `table` (default), `csv`, `json`
   - Example: `poetry run python query.py "SELECT time, level, msg FROM log_entries LIMIT 10" --begin 1h --format csv`
 
+## Branding
+
+Logo and color scheme assets are in the `branding/` folder:
+- **Brand sheet**: `micromegas-brand-sheet.svg` (full reference with color palette)
+- **Logos**: horizontal, vertical, icon variants for dark/light backgrounds
+- **Colors**: Rust orange (#bf360c), Blue (#1565c0), Gold (#ffc107), Dark bg (#0a0a0f)
+
 ## Architecture
 
 Micromegas: unified observability platform for logs, metrics, and traces.

--- a/analytics-web-app/public/icon.svg
+++ b/analytics-web-app/public/icon.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="r1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#bf360c"/>
+      <stop offset="100%" stop-color="#8d3a14"/>
+    </linearGradient>
+    <linearGradient id="r2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1565c0"/>
+      <stop offset="100%" stop-color="#0d47a1"/>
+    </linearGradient>
+    <linearGradient id="r3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffc107"/>
+      <stop offset="100%" stop-color="#ffb300"/>
+    </linearGradient>
+  </defs>
+  <g transform="translate(16, 16)">
+    <ellipse rx="13" ry="5" fill="none" stroke="url(#r1)" stroke-width="2" transform="rotate(-20)" opacity="0.9"/>
+    <ellipse rx="10" ry="4" fill="none" stroke="url(#r2)" stroke-width="2" transform="rotate(25)" opacity="0.9"/>
+    <ellipse rx="7.5" ry="3" fill="none" stroke="url(#r3)" stroke-width="2" transform="rotate(-8)" opacity="0.9"/>
+    <polygon points="0,-3 0.6,-1 2.2,-1 0.8,0.2 1.4,2.2 0,1.2 -1.4,2.2 -0.8,0.2 -2.2,-1 -0.6,-1" fill="#1a1a2e"/>
+  </g>
+</svg>

--- a/analytics-web-app/src/app/globals.css
+++ b/analytics-web-app/src/app/globals.css
@@ -4,47 +4,55 @@
 
 @layer base {
   :root {
-    /* Dark theme as default (Grafana-inspired) */
-    --background: 216 28% 7%;
+    /* Dark theme with Micromegas brand colors */
+    --background: 240 33% 3%;
     --foreground: 210 20% 90%;
-    --card: 216 22% 11%;
+    --card: 240 27% 7%;
     --card-foreground: 210 20% 90%;
-    --popover: 216 22% 11%;
+    --popover: 240 27% 7%;
     --popover-foreground: 210 20% 90%;
-    --primary: 217 91% 60%;
+    --primary: 213 79% 42%;
     --primary-foreground: 210 40% 98%;
-    --secondary: 215 20% 18%;
+    --secondary: 240 20% 12%;
     --secondary-foreground: 210 20% 90%;
-    --muted: 215 20% 18%;
+    --muted: 240 20% 12%;
     --muted-foreground: 215 16% 57%;
-    --accent: 215 20% 18%;
+    --accent: 240 20% 15%;
     --accent-foreground: 210 20% 90%;
     --destructive: 0 63% 31%;
     --destructive-foreground: 210 40% 98%;
-    --border: 215 20% 22%;
-    --input: 215 20% 22%;
-    --ring: 217 91% 60%;
+    --border: 240 15% 18%;
+    --input: 240 15% 18%;
+    --ring: 213 79% 42%;
     --radius: 0.5rem;
 
-    /* Custom colors matching mockups */
-    --app-bg: #0f1419;
-    --header-bg: #1a1f26;
-    --sidebar-bg: #1a1f26;
-    --panel-bg: #1a1f26;
-    --card-bg: #22272e;
-    --border-color: #2f3540;
-    --border-hover: #3d4450;
+    /* Micromegas brand palette */
+    --brand-rust: #bf360c;
+    --brand-rust-dark: #8d3a14;
+    --brand-blue: #1565c0;
+    --brand-blue-dark: #0d47a1;
+    --brand-gold: #ffc107;
+    --brand-gold-dark: #ffb300;
+
+    /* Custom colors - Micromegas dark theme */
+    --app-bg: #0a0a0f;
+    --header-bg: #12121a;
+    --sidebar-bg: #12121a;
+    --panel-bg: #12121a;
+    --card-bg: #1a1a2e;
+    --border-color: #2a2a3e;
+    --border-hover: #3a3a4e;
     --text-primary: #e7e9ea;
     --text-secondary: #9ca3af;
     --text-muted: #6b7280;
-    --accent-link: #3b82f6;
-    --accent-link-hover: #2563eb;
+    --accent-link: #1565c0;
+    --accent-link-hover: #1976d2;
     --accent-success: #22c55e;
-    --accent-highlight: #c084fc;
-    --accent-variable: #fb923c;
+    --accent-highlight: #ffc107;
+    --accent-variable: #bf360c;
     --accent-error: #f87171;
     --accent-error-bright: #dc2626;
-    --accent-warning: #facc15;
+    --accent-warning: #ffc107;
   }
 }
 

--- a/analytics-web-app/src/app/layout.tsx
+++ b/analytics-web-app/src/app/layout.tsx
@@ -10,6 +10,9 @@ const inter = Inter({ subsets: ['latin'] })
 export const metadata: Metadata = {
   title: 'Analytics Web App - Micromegas',
   description: 'Analytics web application for micromegas telemetry data',
+  icons: {
+    icon: '/icon.svg',
+  },
 }
 
 export default function RootLayout({

--- a/analytics-web-app/src/app/login/page.tsx
+++ b/analytics-web-app/src/app/login/page.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '@/lib/auth'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { AlertCircle, LogIn } from 'lucide-react'
+import { MicromegasLogo } from '@/components/MicromegasLogo'
 
 function LoginContent() {
   const { status, error, login } = useAuth()
@@ -27,12 +28,12 @@ function LoginContent() {
 
   if (status === 'loading') {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <Card className="w-full max-w-md">
+      <div className="min-h-screen flex items-center justify-center bg-app-bg">
+        <Card className="w-full max-w-md bg-app-panel border-theme-border">
           <CardContent className="pt-6">
             <div className="flex flex-col items-center space-y-4">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
-              <p className="text-sm text-gray-600">Checking authentication...</p>
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-brand-blue"></div>
+              <p className="text-sm text-theme-text-secondary">Checking authentication...</p>
             </div>
           </CardContent>
         </Card>
@@ -41,24 +42,29 @@ function LoginContent() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <CardTitle className="text-2xl">Analytics Web App</CardTitle>
-          <CardDescription>
-            Sign in to access telemetry data and analytics
-          </CardDescription>
+    <div className="min-h-screen flex items-center justify-center bg-app-bg">
+      <Card className="w-full max-w-md bg-app-panel border-theme-border">
+        <CardHeader className="text-center space-y-4">
+          <div className="flex justify-center">
+            <MicromegasLogo size="lg" />
+          </div>
+          <div>
+            <CardTitle className="text-xl text-theme-text-primary">Analytics</CardTitle>
+            <CardDescription className="text-theme-text-secondary">
+              Sign in to access telemetry data and analytics
+            </CardDescription>
+          </div>
         </CardHeader>
         <CardContent className="space-y-4">
           {(authError || error) && (
-            <div className="bg-red-50 border border-red-200 rounded-md p-4">
+            <div className="bg-accent-error/10 border border-accent-error/30 rounded-md p-4">
               <div className="flex items-start">
-                <AlertCircle className="h-5 w-5 text-red-400 mt-0.5 mr-2" />
+                <AlertCircle className="h-5 w-5 text-accent-error mt-0.5 mr-2" />
                 <div>
-                  <h3 className="text-sm font-medium text-red-800">
+                  <h3 className="text-sm font-medium text-accent-error">
                     Authentication Error
                   </h3>
-                  <p className="text-sm text-red-700 mt-1">
+                  <p className="text-sm text-accent-error/80 mt-1">
                     {authError || error}
                   </p>
                 </div>
@@ -67,15 +73,15 @@ function LoginContent() {
           )}
 
           {status === 'error' ? (
-            <div className="bg-yellow-50 border border-yellow-200 rounded-md p-4">
-              <p className="text-sm text-yellow-800">
+            <div className="bg-accent-warning/10 border border-accent-warning/30 rounded-md p-4">
+              <p className="text-sm text-accent-warning">
                 Unable to connect to authentication service. Please try again later.
               </p>
             </div>
           ) : (
             <Button
               onClick={handleLogin}
-              className="w-full"
+              className="w-full bg-brand-blue hover:bg-brand-blue-dark text-white"
               size="lg"
             >
               <LogIn className="mr-2 h-4 w-4" />
@@ -83,7 +89,7 @@ function LoginContent() {
             </Button>
           )}
 
-          <p className="text-xs text-center text-gray-500 mt-4">
+          <p className="text-xs text-center text-theme-text-muted mt-4">
             You will be redirected to your organization&apos;s identity provider.
           </p>
         </CardContent>
@@ -94,12 +100,12 @@ function LoginContent() {
 
 function LoginFallback() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <Card className="w-full max-w-md">
+    <div className="min-h-screen flex items-center justify-center bg-app-bg">
+      <Card className="w-full max-w-md bg-app-panel border-theme-border">
         <CardContent className="pt-6">
           <div className="flex flex-col items-center space-y-4">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
-            <p className="text-sm text-gray-600">Loading...</p>
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-brand-blue"></div>
+            <p className="text-sm text-theme-text-secondary">Loading...</p>
           </div>
         </CardContent>
       </Card>

--- a/analytics-web-app/src/components/MicromegasLogo.tsx
+++ b/analytics-web-app/src/components/MicromegasLogo.tsx
@@ -1,0 +1,97 @@
+interface MicromegasLogoProps {
+  className?: string
+  showText?: boolean
+  size?: 'sm' | 'md' | 'lg'
+}
+
+export function MicromegasLogo({ className = '', showText = true, size = 'md' }: MicromegasLogoProps) {
+  const sizeConfig = {
+    sm: { icon: 24, text: 14, gap: 6 },
+    md: { icon: 32, text: 18, gap: 8 },
+    lg: { icon: 48, text: 24, gap: 12 },
+  }
+
+  const { icon, text, gap } = sizeConfig[size]
+
+  return (
+    <div className={`flex items-center ${className}`} style={{ gap }}>
+      <svg
+        viewBox="0 0 100 100"
+        width={icon}
+        height={icon}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <defs>
+          <linearGradient id="ring1" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="#bf360c" />
+            <stop offset="100%" stopColor="#8d3a14" />
+          </linearGradient>
+          <linearGradient id="ring2" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="#1565c0" />
+            <stop offset="100%" stopColor="#0d47a1" />
+          </linearGradient>
+          <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="#ffc107" />
+            <stop offset="100%" stopColor="#ffb300" />
+          </linearGradient>
+          <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="1" result="coloredBlur" />
+            <feMerge>
+              <feMergeNode in="coloredBlur" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+        </defs>
+        <g transform="translate(50, 50)">
+          <ellipse
+            cx="0"
+            cy="0"
+            rx="42"
+            ry="16"
+            fill="none"
+            stroke="url(#ring1)"
+            strokeWidth="2.5"
+            transform="rotate(-20)"
+            opacity="0.9"
+          />
+          <ellipse
+            cx="0"
+            cy="0"
+            rx="33"
+            ry="13"
+            fill="none"
+            stroke="url(#ring2)"
+            strokeWidth="2.5"
+            transform="rotate(25)"
+            opacity="0.9"
+          />
+          <ellipse
+            cx="0"
+            cy="0"
+            rx="24"
+            ry="9"
+            fill="none"
+            stroke="url(#ring3)"
+            strokeWidth="2.5"
+            transform="rotate(-8)"
+            opacity="0.9"
+          />
+          <g filter="url(#glow)">
+            <polygon
+              points="0,-6 1.2,-2 4.5,-2 2,0.5 3,4.5 0,2 -3,4.5 -2,0.5 -4.5,-2 -1.2,-2"
+              fill="#ffffff"
+            />
+          </g>
+        </g>
+      </svg>
+      {showText && (
+        <span
+          className="font-light tracking-widest text-white"
+          style={{ fontSize: text }}
+        >
+          micromegas
+        </span>
+      )}
+    </div>
+  )
+}

--- a/analytics-web-app/src/components/layout/Header.tsx
+++ b/analytics-web-app/src/components/layout/Header.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/lib/auth'
 import { RefreshCw, ChevronDown, LogOut } from 'lucide-react'
 import Link from 'next/link'
 import { TimeRangeSelector } from './TimeRangeSelector'
+import { MicromegasLogo } from '@/components/MicromegasLogo'
 
 interface HeaderProps {
   onRefresh?: () => void
@@ -37,8 +38,8 @@ export function Header({ onRefresh }: HeaderProps) {
   return (
     <header className="flex items-center justify-between px-3 sm:px-6 py-3 bg-app-header border-b border-theme-border">
       <div className="flex items-center gap-3 sm:gap-6">
-        <Link href="/" className="text-base sm:text-lg font-semibold text-accent-link hover:text-accent-link-hover transition-colors">
-          Micromegas
+        <Link href="/" className="hover:opacity-80 transition-opacity">
+          <MicromegasLogo size="sm" />
         </Link>
       </div>
 

--- a/analytics-web-app/tailwind.config.ts
+++ b/analytics-web-app/tailwind.config.ts
@@ -73,6 +73,15 @@ const config: Config = {
           bright: "var(--accent-error-bright)",
         },
         "accent-warning": "var(--accent-warning)",
+        // Micromegas brand colors
+        brand: {
+          rust: "var(--brand-rust)",
+          "rust-dark": "var(--brand-rust-dark)",
+          blue: "var(--brand-blue)",
+          "blue-dark": "var(--brand-blue-dark)",
+          gold: "var(--brand-gold)",
+          "gold-dark": "var(--brand-gold-dark)",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary
- Update color scheme to brand palette (rust orange, blue, gold)
- Add MicromegasLogo component with orbital rings and center star
- Add logo to header and login page
- Add transparent SVG favicon
- Document branding assets location in CLAUDE.md

## Test plan
- [ ] Verify favicon appears in browser tab
- [ ] Check logo displays in header
- [ ] Verify login page shows logo and dark theme
- [ ] Confirm brand colors are applied throughout