### PR TITLE
Update branding: replace Amber with Wheat as primary gold color

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Logo and color scheme assets are in the `branding/` folder:
 - **Brand sheet**: `micromegas-brand-sheet.svg` (full reference with color palette)
 - **Logos**: horizontal, vertical, icon variants for dark/light backgrounds
-- **Colors**: Rust orange (#bf360c), Blue (#1565c0), Gold (#ffc107), Dark bg (#0a0a0f)
+- **Colors**: Rust orange (#bf360c), Blue (#1565c0), Wheat (#ffb300), Dark bg (#0a0a0f)
 
 ## Architecture
 

--- a/analytics-web-app/public/icon.svg
+++ b/analytics-web-app/public/icon.svg
@@ -9,8 +9,8 @@
       <stop offset="100%" stop-color="#0d47a1"/>
     </linearGradient>
     <linearGradient id="r3" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#ffc107"/>
-      <stop offset="100%" stop-color="#ffb300"/>
+      <stop offset="0%" stop-color="#ffb300"/>
+      <stop offset="100%" stop-color="#e6a000"/>
     </linearGradient>
   </defs>
   <g transform="translate(16, 16)">

--- a/analytics-web-app/src/app/globals.css
+++ b/analytics-web-app/src/app/globals.css
@@ -31,8 +31,8 @@
     --brand-rust-dark: #8d3a14;
     --brand-blue: #1565c0;
     --brand-blue-dark: #0d47a1;
-    --brand-gold: #ffc107;
-    --brand-gold-dark: #ffb300;
+    --brand-gold: #ffb300;
+    --brand-gold-dark: #e6a000;
 
     /* Custom colors - Micromegas dark theme */
     --app-bg: #0a0a0f;
@@ -48,11 +48,11 @@
     --accent-link: #1565c0;
     --accent-link-hover: #1976d2;
     --accent-success: #22c55e;
-    --accent-highlight: #ffc107;
+    --accent-highlight: #ffb300;
     --accent-variable: #bf360c;
     --accent-error: #f87171;
     --accent-error-bright: #dc2626;
-    --accent-warning: #ffc107;
+    --accent-warning: #ffb300;
   }
 }
 

--- a/analytics-web-app/src/components/MicromegasLogo.tsx
+++ b/analytics-web-app/src/components/MicromegasLogo.tsx
@@ -31,8 +31,8 @@ export function MicromegasLogo({ className = '', showText = true, size = 'md' }:
             <stop offset="100%" stopColor="#0d47a1" />
           </linearGradient>
           <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stopColor="#ffc107" />
-            <stop offset="100%" stopColor="#ffb300" />
+            <stop offset="0%" stopColor="#ffb300" />
+            <stop offset="100%" stopColor="#e6a000" />
           </linearGradient>
           <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
             <feGaussianBlur stdDeviation="1" result="coloredBlur" />

--- a/branding/extended-palette-swatches.svg
+++ b/branding/extended-palette-swatches.svg
@@ -1,0 +1,278 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900">
+  <rect width="1200" height="900" fill="#0a0a0f"/>
+
+  <!-- Title -->
+  <text x="600" y="45" text-anchor="middle" fill="#ffffff" font-family="system-ui, sans-serif" font-size="24" font-weight="300" letter-spacing="6">EXTENDED COLOR PALETTE</text>
+  <text x="600" y="70" text-anchor="middle" fill="#666" font-family="monospace" font-size="11">Inspired by Van Gogh's "Wheatfield with Crows"</text>
+
+  <!-- Primary Colors -->
+  <text x="100" y="115" fill="#888" font-family="monospace" font-size="11" letter-spacing="2">PRIMARY</text>
+
+  <g transform="translate(100, 130)">
+    <rect width="60" height="60" fill="#bf360c" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Rust</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#bf360c</text>
+  </g>
+  <g transform="translate(175, 130)">
+    <rect width="60" height="60" fill="#1565c0" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Cobalt</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#1565c0</text>
+  </g>
+  <g transform="translate(250, 130)">
+    <rect width="60" height="60" fill="#ffb300" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Wheat</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#ffb300</text>
+  </g>
+  <g transform="translate(325, 130)">
+    <rect width="60" height="60" fill="#0a0a0f" stroke="#333" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Night</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#0a0a0f</text>
+  </g>
+  <g transform="translate(400, 130)">
+    <rect width="60" height="60" fill="#1a1a2e" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Charcoal</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#1a1a2e</text>
+  </g>
+
+  <!-- Stormy Sky -->
+  <text x="100" y="260" fill="#888" font-family="monospace" font-size="11" letter-spacing="2">STORMY SKY</text>
+
+  <g transform="translate(100, 275)">
+    <rect width="60" height="60" fill="#1a237e" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Storm</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#1a237e</text>
+  </g>
+  <g transform="translate(175, 275)">
+    <rect width="60" height="60" fill="#283593" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Twilight</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#283593</text>
+  </g>
+  <g transform="translate(250, 275)">
+    <rect width="60" height="60" fill="#0d47a1" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Prussian</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#0d47a1</text>
+  </g>
+  <g transform="translate(325, 275)">
+    <rect width="60" height="60" fill="#42a5f5" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Horizon</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#42a5f5</text>
+  </g>
+  <g transform="translate(400, 275)">
+    <rect width="60" height="60" fill="#5e35b1" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Violet</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#5e35b1</text>
+  </g>
+  <g transform="translate(475, 275)">
+    <rect width="60" height="60" fill="#7e57c2" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Lavender</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#7e57c2</text>
+  </g>
+
+  <!-- Wheat Field -->
+  <text x="100" y="405" fill="#888" font-family="monospace" font-size="11" letter-spacing="2">WHEAT FIELD</text>
+
+  <g transform="translate(100, 420)">
+    <rect width="60" height="60" fill="#ff8f00" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Harvest</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#ff8f00</text>
+  </g>
+  <g transform="translate(175, 420)">
+    <rect width="60" height="60" fill="#ffb300" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Wheat</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#ffb300</text>
+  </g>
+  <g transform="translate(250, 420)">
+    <rect width="60" height="60" fill="#ffd54f" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Grain</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#ffd54f</text>
+  </g>
+  <g transform="translate(325, 420)">
+    <rect width="60" height="60" fill="#ffecb3" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Straw</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#ffecb3</text>
+  </g>
+  <g transform="translate(400, 420)">
+    <rect width="60" height="60" fill="#e65100" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Ochre</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#e65100</text>
+  </g>
+  <g transform="translate(475, 420)">
+    <rect width="60" height="60" fill="#8d3a14" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Sienna</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#8d3a14</text>
+  </g>
+
+  <!-- Earth & Path -->
+  <text x="620" y="115" fill="#888" font-family="monospace" font-size="11" letter-spacing="2">EARTH &amp; PATH</text>
+
+  <g transform="translate(620, 130)">
+    <rect width="60" height="60" fill="#2e7d32" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Field</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#2e7d32</text>
+  </g>
+  <g transform="translate(695, 130)">
+    <rect width="60" height="60" fill="#66bb6a" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Sage</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#66bb6a</text>
+  </g>
+  <g transform="translate(770, 130)">
+    <rect width="60" height="60" fill="#827717" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Olive</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#827717</text>
+  </g>
+  <g transform="translate(845, 130)">
+    <rect width="60" height="60" fill="#4e342e" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Umber</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#4e342e</text>
+  </g>
+  <g transform="translate(920, 130)">
+    <rect width="60" height="60" fill="#6d4c41" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Clay</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#6d4c41</text>
+  </g>
+  <g transform="translate(995, 130)">
+    <rect width="60" height="60" fill="#3e2723" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Earth</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#3e2723</text>
+  </g>
+
+  <!-- Crow & Shadow -->
+  <text x="620" y="260" fill="#888" font-family="monospace" font-size="11" letter-spacing="2">CROW &amp; SHADOW</text>
+
+  <g transform="translate(620, 275)">
+    <rect width="60" height="60" fill="#121212" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Crow</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#121212</text>
+  </g>
+  <g transform="translate(695, 275)">
+    <rect width="60" height="60" fill="#1e1e2f" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Shadow</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#1e1e2f</text>
+  </g>
+  <g transform="translate(770, 275)">
+    <rect width="60" height="60" fill="#37474f" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Slate</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#37474f</text>
+  </g>
+  <g transform="translate(845, 275)">
+    <rect width="60" height="60" fill="#546e7a" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Pewter</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#546e7a</text>
+  </g>
+  <g transform="translate(920, 275)">
+    <rect width="60" height="60" fill="#90a4ae" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Cloud</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#90a4ae</text>
+  </g>
+  <g transform="translate(995, 275)">
+    <rect width="60" height="60" fill="#cfd8dc" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Misty</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#cfd8dc</text>
+  </g>
+
+  <!-- Status Colors -->
+  <text x="620" y="405" fill="#888" font-family="monospace" font-size="11" letter-spacing="2">STATUS &amp; ACCENT</text>
+
+  <g transform="translate(620, 420)">
+    <rect width="60" height="60" fill="#c62828" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Crimson</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#c62828</text>
+  </g>
+  <g transform="translate(695, 420)">
+    <rect width="60" height="60" fill="#ff7043" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Coral</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#ff7043</text>
+  </g>
+  <g transform="translate(770, 420)">
+    <rect width="60" height="60" fill="#00897b" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Teal</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#00897b</text>
+  </g>
+  <g transform="translate(845, 420)">
+    <rect width="60" height="60" fill="#00acc1" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Cyan</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#00acc1</text>
+  </g>
+  <g transform="translate(920, 420)">
+    <rect width="60" height="60" fill="#ad1457" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Pink</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#ad1457</text>
+  </g>
+  <g transform="translate(995, 420)">
+    <rect width="60" height="60" fill="#9e9d24" rx="4"/>
+    <text x="30" y="80" text-anchor="middle" fill="#666" font-family="monospace" font-size="8">Lime</text>
+    <text x="30" y="92" text-anchor="middle" fill="#555" font-family="monospace" font-size="7">#9e9d24</text>
+  </g>
+
+  <!-- Chart Sequence -->
+  <text x="600" y="565" text-anchor="middle" fill="#888" font-family="monospace" font-size="11" letter-spacing="2">CHART COLOR SEQUENCE (12 SERIES)</text>
+
+  <g transform="translate(140, 590)">
+    <rect width="70" height="35" fill="#bf360c" rx="3"/>
+    <rect x="77" width="70" height="35" fill="#1565c0" rx="3"/>
+    <rect x="154" width="70" height="35" fill="#ffb300" rx="3"/>
+    <rect x="231" width="70" height="35" fill="#2e7d32" rx="3"/>
+    <rect x="308" width="70" height="35" fill="#5e35b1" rx="3"/>
+    <rect x="385" width="70" height="35" fill="#ff8f00" rx="3"/>
+    <rect x="462" width="70" height="35" fill="#00897b" rx="3"/>
+    <rect x="539" width="70" height="35" fill="#c62828" rx="3"/>
+    <rect x="616" width="70" height="35" fill="#7e57c2" rx="3"/>
+    <rect x="693" width="70" height="35" fill="#827717" rx="3"/>
+    <rect x="770" width="70" height="35" fill="#00acc1" rx="3"/>
+    <rect x="847" width="70" height="35" fill="#ad1457" rx="3"/>
+  </g>
+
+  <!-- Sequential Gradients -->
+  <text x="600" y="680" text-anchor="middle" fill="#888" font-family="monospace" font-size="11" letter-spacing="2">SEQUENTIAL GRADIENTS</text>
+
+  <defs>
+    <linearGradient id="seqBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#e3f2fd"/>
+      <stop offset="20%" style="stop-color:#90caf9"/>
+      <stop offset="40%" style="stop-color:#42a5f5"/>
+      <stop offset="60%" style="stop-color:#1565c0"/>
+      <stop offset="80%" style="stop-color:#0d47a1"/>
+      <stop offset="100%" style="stop-color:#1a237e"/>
+    </linearGradient>
+    <linearGradient id="seqOrange" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#fff3e0"/>
+      <stop offset="20%" style="stop-color:#ffcc80"/>
+      <stop offset="40%" style="stop-color:#ff8f00"/>
+      <stop offset="60%" style="stop-color:#bf360c"/>
+      <stop offset="80%" style="stop-color:#8d3a14"/>
+      <stop offset="100%" style="stop-color:#4e342e"/>
+    </linearGradient>
+    <linearGradient id="diverging" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#bf360c"/>
+      <stop offset="17%" style="stop-color:#ff8f00"/>
+      <stop offset="33%" style="stop-color:#ffd54f"/>
+      <stop offset="50%" style="stop-color:#f5f5f7"/>
+      <stop offset="67%" style="stop-color:#90caf9"/>
+      <stop offset="83%" style="stop-color:#1565c0"/>
+      <stop offset="100%" style="stop-color:#1a237e"/>
+    </linearGradient>
+  </defs>
+
+  <g transform="translate(140, 700)">
+    <text x="0" y="0" fill="#666" font-family="monospace" font-size="9">Blues</text>
+    <rect x="60" y="-12" width="300" height="20" fill="url(#seqBlue)" rx="3"/>
+
+    <text x="380" y="0" fill="#666" font-family="monospace" font-size="9">Oranges</text>
+    <rect x="450" y="-12" width="300" height="20" fill="url(#seqOrange)" rx="3"/>
+
+    <text x="770" y="0" fill="#666" font-family="monospace" font-size="9">Diverging</text>
+    <rect x="850" y="-12" width="200" height="20" fill="url(#diverging)" rx="3"/>
+  </g>
+
+  <!-- Van Gogh reference -->
+  <text x="600" y="780" text-anchor="middle" fill="#444" font-family="system-ui, sans-serif" font-size="10" font-style="italic">"I have a terrible lucidity at moments... when nature is so beautiful."</text>
+  <text x="600" y="800" text-anchor="middle" fill="#333" font-family="monospace" font-size="9">- Vincent van Gogh, July 1890</text>
+
+  <!-- Micromegas logo small -->
+  <g transform="translate(600, 860) scale(0.25)">
+    <ellipse cx="0" cy="0" rx="100" ry="38" fill="none" stroke="#bf360c" stroke-width="4" transform="rotate(-20)" opacity="0.8"/>
+    <ellipse cx="0" cy="0" rx="79" ry="30" fill="none" stroke="#1565c0" stroke-width="4" transform="rotate(25)" opacity="0.8"/>
+    <ellipse cx="0" cy="0" rx="58" ry="22" fill="none" stroke="#ffb300" stroke-width="4" transform="rotate(-8)" opacity="0.8"/>
+    <polygon points="0,-12 2,-4 9,-4 3,1 6,9 0,4 -6,9 -3,1 -9,-4 -2,-4" fill="#ffffff"/>
+  </g>
+</svg>

--- a/branding/extended-palette.md
+++ b/branding/extended-palette.md
@@ -1,0 +1,214 @@
+# Micromegas Extended Color Palette
+
+Inspired by Van Gogh's "Wheatfield with Crows" (1890) - turbulent skies, golden wheat, and earthy paths.
+
+## Primary Colors (existing)
+
+| Name | Hex | RGB | Use |
+|------|-----|-----|-----|
+| Rust Orange | `#bf360c` | 191, 54, 12 | Primary accent, ring 1 |
+| Cobalt Blue | `#1565c0` | 21, 101, 192 | Secondary accent, ring 2 |
+| Wheat | `#ffb300` | 255, 179, 0 | Tertiary accent, ring 3 |
+| Deep Night | `#0a0a0f` | 10, 10, 15 | Dark background |
+| Charcoal | `#1a1a2e` | 26, 26, 46 | Dark text/icons |
+
+## Extended Palette - Stormy Sky (blues/purples)
+
+| Name | Hex | RGB | Use |
+|------|-----|-----|-----|
+| Storm Blue | `#1a237e` | 26, 35, 126 | Deep accent, headers |
+| Twilight | `#283593` | 40, 53, 147 | Charts, secondary data |
+| Prussian | `#0d47a1` | 13, 71, 161 | Links, interactive |
+| Horizon | `#42a5f5` | 66, 165, 245 | Info states, highlights |
+| Violet Dusk | `#5e35b1` | 94, 53, 177 | Tertiary data series |
+| Lavender Storm | `#7e57c2` | 126, 87, 194 | Light accent, tags |
+
+## Extended Palette - Wheat Field (yellows/golds)
+
+| Name | Hex | RGB | Use |
+|------|-----|-----|-----|
+| Harvest Gold | `#ff8f00` | 255, 143, 0 | Warnings, emphasis |
+| Amber | `#ffc107` | 255, 193, 7 | Secondary gold |
+| Ripe Grain | `#ffd54f` | 255, 213, 79 | Highlights, hover |
+| Pale Straw | `#ffecb3` | 255, 236, 179 | Light backgrounds |
+| Ochre | `#e65100` | 230, 81, 0 | Critical warnings |
+| Burnt Sienna | `#8d3a14` | 141, 58, 20 | Dark rust accent |
+
+## Extended Palette - Earth & Path (browns/greens)
+
+| Name | Hex | RGB | Use |
+|------|-----|-----|-----|
+| Field Green | `#2e7d32` | 46, 125, 50 | Success states |
+| Sage | `#66bb6a` | 102, 187, 106 | Positive data |
+| Olive Path | `#827717` | 130, 119, 23 | Muted accent |
+| Umber | `#4e342e` | 78, 52, 46 | Dark earth accent |
+| Clay | `#6d4c41` | 109, 76, 65 | Warm neutral |
+| Tilled Earth | `#3e2723` | 62, 39, 35 | Deep brown |
+
+## Extended Palette - Crow & Shadow (neutrals)
+
+| Name | Hex | RGB | Use |
+|------|-----|-----|-----|
+| Crow Black | `#121212` | 18, 18, 18 | True black accents |
+| Shadow | `#1e1e2f` | 30, 30, 47 | Card backgrounds |
+| Slate | `#37474f` | 55, 71, 79 | Secondary text |
+| Pewter | `#546e7a` | 84, 110, 122 | Muted text |
+| Cloud Grey | `#90a4ae` | 144, 164, 174 | Disabled states |
+| Misty | `#cfd8dc` | 207, 216, 220 | Borders, dividers |
+
+## Extended Palette - Accent & Status
+
+| Name | Hex | RGB | Use |
+|------|-----|-----|-----|
+| Crimson | `#c62828` | 198, 40, 40 | Errors, critical |
+| Coral | `#ff7043` | 255, 112, 67 | Attention needed |
+| Teal | `#00897b` | 0, 137, 123 | Alternative success |
+| Cyan | `#00acc1` | 0, 172, 193 | Info, links |
+| Pink Dusk | `#ad1457` | 173, 20, 87 | Accent, special |
+| Lime | `#9e9d24` | 158, 157, 36 | Neutral positive |
+
+## Chart Color Sequences
+
+### Primary Sequence (12 colors for data series)
+```
+#bf360c  Rust Orange
+#1565c0  Cobalt Blue
+#ffb300  Wheat
+#2e7d32  Field Green
+#5e35b1  Violet Dusk
+#ff8f00  Harvest Gold
+#00897b  Teal
+#c62828  Crimson
+#7e57c2  Lavender Storm
+#827717  Olive Path
+#00acc1  Cyan
+#ad1457  Pink Dusk
+```
+
+### Sequential Blues (for gradients/heatmaps)
+```
+#e3f2fd → #90caf9 → #42a5f5 → #1565c0 → #0d47a1 → #1a237e
+```
+
+### Sequential Oranges (for gradients/heatmaps)
+```
+#fff3e0 → #ffcc80 → #ff8f00 → #bf360c → #8d3a14 → #4e342e
+```
+
+### Diverging (for comparison data)
+```
+#bf360c → #ff8f00 → #ffd54f → #f5f5f7 → #90caf9 → #1565c0 → #1a237e
+```
+
+## CSS Variables
+
+```css
+:root {
+  /* Primary */
+  --color-rust: #bf360c;
+  --color-cobalt: #1565c0;
+  --color-wheat: #ffb300;
+  --color-night: #0a0a0f;
+  --color-charcoal: #1a1a2e;
+
+  /* Stormy Sky */
+  --color-storm: #1a237e;
+  --color-twilight: #283593;
+  --color-prussian: #0d47a1;
+  --color-horizon: #42a5f5;
+  --color-violet: #5e35b1;
+  --color-lavender: #7e57c2;
+
+  /* Wheat Field */
+  --color-harvest: #ff8f00;
+  --color-wheat: #ffb300;
+  --color-grain: #ffd54f;
+  --color-straw: #ffecb3;
+  --color-ochre: #e65100;
+  --color-sienna: #8d3a14;
+
+  /* Earth & Path */
+  --color-field: #2e7d32;
+  --color-sage: #66bb6a;
+  --color-olive: #827717;
+  --color-umber: #4e342e;
+  --color-clay: #6d4c41;
+  --color-earth: #3e2723;
+
+  /* Crow & Shadow */
+  --color-crow: #121212;
+  --color-shadow: #1e1e2f;
+  --color-slate: #37474f;
+  --color-pewter: #546e7a;
+  --color-cloud: #90a4ae;
+  --color-misty: #cfd8dc;
+
+  /* Status */
+  --color-error: #c62828;
+  --color-coral: #ff7043;
+  --color-success: #2e7d32;
+  --color-teal: #00897b;
+  --color-info: #00acc1;
+  --color-special: #ad1457;
+  --color-lime: #9e9d24;
+}
+```
+
+## TypeScript Constants
+
+```typescript
+export const colors = {
+  // Primary
+  rust: '#bf360c',
+  cobalt: '#1565c0',
+  wheat: '#ffb300',
+  night: '#0a0a0f',
+  charcoal: '#1a1a2e',
+
+  // Stormy Sky
+  storm: '#1a237e',
+  twilight: '#283593',
+  prussian: '#0d47a1',
+  horizon: '#42a5f5',
+  violet: '#5e35b1',
+  lavender: '#7e57c2',
+
+  // Wheat Field
+  harvest: '#ff8f00',
+  wheat: '#ffb300',
+  grain: '#ffd54f',
+  straw: '#ffecb3',
+  ochre: '#e65100',
+  sienna: '#8d3a14',
+
+  // Earth & Path
+  field: '#2e7d32',
+  sage: '#66bb6a',
+  olive: '#827717',
+  umber: '#4e342e',
+  clay: '#6d4c41',
+  earth: '#3e2723',
+
+  // Crow & Shadow
+  crow: '#121212',
+  shadow: '#1e1e2f',
+  slate: '#37474f',
+  pewter: '#546e7a',
+  cloud: '#90a4ae',
+  misty: '#cfd8dc',
+
+  // Status
+  error: '#c62828',
+  coral: '#ff7043',
+  success: '#2e7d32',
+  teal: '#00897b',
+  info: '#00acc1',
+  special: '#ad1457',
+  lime: '#9e9d24',
+} as const;
+
+export const chartSequence = [
+  '#bf360c', '#1565c0', '#ffb300', '#2e7d32', '#5e35b1', '#ff8f00',
+  '#00897b', '#c62828', '#7e57c2', '#827717', '#00acc1', '#ad1457',
+] as const;
+```

--- a/branding/micromegas-brand-sheet.svg
+++ b/branding/micromegas-brand-sheet.svg
@@ -9,8 +9,8 @@
       <stop offset="100%" style="stop-color:#0d47a1"/>
     </linearGradient>
     <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ffc107"/>
-      <stop offset="100%" style="stop-color:#ffb300"/>
+      <stop offset="0%" style="stop-color:#ffb300"/>
+      <stop offset="100%" style="stop-color:#e6a000"/>
     </linearGradient>
     <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
@@ -210,8 +210,8 @@
     <rect x="50" y="15" width="40" height="40" fill="#1565c0" rx="4"/>
     <text x="70" y="75" text-anchor="middle" fill="#666" font-family="monospace" font-size="9">#1565c0</text>
     
-    <rect x="100" y="15" width="40" height="40" fill="#ffc107" rx="4"/>
-    <text x="120" y="75" text-anchor="middle" fill="#666" font-family="monospace" font-size="9">#ffc107</text>
+    <rect x="100" y="15" width="40" height="40" fill="#ffb300" rx="4"/>
+    <text x="120" y="75" text-anchor="middle" fill="#666" font-family="monospace" font-size="9">#ffb300</text>
     
     <rect x="150" y="15" width="40" height="40" fill="#1a1a2e" rx="4"/>
     <text x="170" y="75" text-anchor="middle" fill="#666" font-family="monospace" font-size="9">#1a1a2e</text>

--- a/branding/micromegas-horizontal-dark.svg
+++ b/branding/micromegas-horizontal-dark.svg
@@ -9,8 +9,8 @@
       <stop offset="100%" style="stop-color:#0d47a1"/>
     </linearGradient>
     <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ffc107"/>
-      <stop offset="100%" style="stop-color:#ffb300"/>
+      <stop offset="0%" style="stop-color:#ffb300"/>
+      <stop offset="100%" style="stop-color:#e6a000"/>
     </linearGradient>
     <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="1.5" result="coloredBlur"/>

--- a/branding/micromegas-horizontal-light.svg
+++ b/branding/micromegas-horizontal-light.svg
@@ -9,8 +9,8 @@
       <stop offset="100%" style="stop-color:#0d47a1"/>
     </linearGradient>
     <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ffc107"/>
-      <stop offset="100%" style="stop-color:#ffb300"/>
+      <stop offset="0%" style="stop-color:#ffb300"/>
+      <stop offset="100%" style="stop-color:#e6a000"/>
     </linearGradient>
   </defs>
   

--- a/branding/micromegas-icon-512.svg
+++ b/branding/micromegas-icon-512.svg
@@ -9,8 +9,8 @@
       <stop offset="100%" style="stop-color:#0d47a1"/>
     </linearGradient>
     <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ffc107"/>
-      <stop offset="100%" style="stop-color:#ffb300"/>
+      <stop offset="0%" style="stop-color:#ffb300"/>
+      <stop offset="100%" style="stop-color:#e6a000"/>
     </linearGradient>
   </defs>
   

--- a/branding/micromegas-icon-transparent.svg
+++ b/branding/micromegas-icon-transparent.svg
@@ -9,8 +9,8 @@
       <stop offset="100%" style="stop-color:#0d47a1"/>
     </linearGradient>
     <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ffc107"/>
-      <stop offset="100%" style="stop-color:#ffb300"/>
+      <stop offset="0%" style="stop-color:#ffb300"/>
+      <stop offset="100%" style="stop-color:#e6a000"/>
     </linearGradient>
   </defs>
   

--- a/branding/micromegas-primary-dark.svg
+++ b/branding/micromegas-primary-dark.svg
@@ -9,8 +9,8 @@
       <stop offset="100%" style="stop-color:#0d47a1"/>
     </linearGradient>
     <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ffc107"/>
-      <stop offset="100%" style="stop-color:#ffb300"/>
+      <stop offset="0%" style="stop-color:#ffb300"/>
+      <stop offset="100%" style="stop-color:#e6a000"/>
     </linearGradient>
     <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="2" result="coloredBlur"/>

--- a/branding/micromegas-primary-light.svg
+++ b/branding/micromegas-primary-light.svg
@@ -9,8 +9,8 @@
       <stop offset="100%" style="stop-color:#0d47a1"/>
     </linearGradient>
     <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ffc107"/>
-      <stop offset="100%" style="stop-color:#ffb300"/>
+      <stop offset="0%" style="stop-color:#ffb300"/>
+      <stop offset="100%" style="stop-color:#e6a000"/>
     </linearGradient>
   </defs>
   

--- a/branding/micromegas-social-avatar.svg
+++ b/branding/micromegas-social-avatar.svg
@@ -9,8 +9,8 @@
       <stop offset="100%" style="stop-color:#0d47a1"/>
     </linearGradient>
     <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ffc107"/>
-      <stop offset="100%" style="stop-color:#ffb300"/>
+      <stop offset="0%" style="stop-color:#ffb300"/>
+      <stop offset="100%" style="stop-color:#e6a000"/>
     </linearGradient>
     <clipPath id="circleClip">
       <circle cx="200" cy="200" r="200"/>

--- a/mkdocs/docs/assets/images/micromegas-icon-512.svg
+++ b/mkdocs/docs/assets/images/micromegas-icon-512.svg
@@ -9,8 +9,8 @@
       <stop offset="100%" style="stop-color:#0d47a1"/>
     </linearGradient>
     <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ffc107"/>
-      <stop offset="100%" style="stop-color:#ffb300"/>
+      <stop offset="0%" style="stop-color:#ffb300"/>
+      <stop offset="100%" style="stop-color:#e6a000"/>
     </linearGradient>
   </defs>
   

--- a/mkdocs/docs/assets/images/micromegas-icon-transparent.svg
+++ b/mkdocs/docs/assets/images/micromegas-icon-transparent.svg
@@ -9,8 +9,8 @@
       <stop offset="100%" style="stop-color:#0d47a1"/>
     </linearGradient>
     <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ffc107"/>
-      <stop offset="100%" style="stop-color:#ffb300"/>
+      <stop offset="0%" style="stop-color:#ffb300"/>
+      <stop offset="100%" style="stop-color:#e6a000"/>
     </linearGradient>
   </defs>
   

--- a/mkdocs/docs/assets/images/micromegas-primary-dark.svg
+++ b/mkdocs/docs/assets/images/micromegas-primary-dark.svg
@@ -9,8 +9,8 @@
       <stop offset="100%" style="stop-color:#0d47a1"/>
     </linearGradient>
     <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ffc107"/>
-      <stop offset="100%" style="stop-color:#ffb300"/>
+      <stop offset="0%" style="stop-color:#ffb300"/>
+      <stop offset="100%" style="stop-color:#e6a000"/>
     </linearGradient>
     <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="2" result="coloredBlur"/>

--- a/mkdocs/docs/assets/images/micromegas-primary-light.svg
+++ b/mkdocs/docs/assets/images/micromegas-primary-light.svg
@@ -9,8 +9,8 @@
       <stop offset="100%" style="stop-color:#0d47a1"/>
     </linearGradient>
     <linearGradient id="ring3" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ffc107"/>
-      <stop offset="100%" style="stop-color:#ffb300"/>
+      <stop offset="0%" style="stop-color:#ffb300"/>
+      <stop offset="100%" style="stop-color:#e6a000"/>
     </linearGradient>
   </defs>
   


### PR DESCRIPTION
## Summary
- Replace primary gold color from Amber (#ffc107) to Wheat (#ffb300) across all branding assets
- Add extended color palette inspired by Van Gogh's "Wheatfield with Crows" painting
- Update analytics web app theme to use new color scheme

## Changes
- Updated 16 SVG logo/branding files
- Added `branding/extended-palette.md` with full color documentation (CSS vars, TypeScript constants)
- Added `branding/extended-palette-swatches.svg` visual reference
- Updated `CLAUDE.md` branding documentation

## Test plan
- [ ] Verify logo renders correctly in mkdocs site
- [ ] Verify analytics web app displays correct brand colors
- [ ] Visual review of brand sheet SVG