### PR TITLE
Add scalability and VSync context to Unreal telemetry

### DIFF
--- a/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/MetricPublisher.h
+++ b/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/MetricPublisher.h
@@ -24,6 +24,7 @@ private:
 	void OnWorldInit(UWorld* /*World*/, const UWorld::InitializationValues /*IVS*/);
 	void OnWorldTornDown(UWorld* World);
 	static void EmitScalabilityMetrics(const Scalability::FQualityLevels& NewLevels);
+	static void EmitVSyncStatus(IConsoleVariable* CVar);
 
 	FName CurrentWorldName;
 };


### PR DESCRIPTION
## Summary
- Add scalability quality levels to DefaultContext using SetBatch when settings change
- Track VSync console variable changes and update context accordingly

## Test plan
- [ ] Verify scalability metrics are emitted on settings change
- [ ] Verify VSync status is tracked in context