### PR TITLE
Add schema documentation links to SQL panels

### DIFF
--- a/analytics-web-app/src/app/process_log/page.tsx
+++ b/analytics-web-app/src/app/process_log/page.tsx
@@ -464,6 +464,10 @@ function ProcessLogContent() {
       onReset={handleResetQuery}
       isLoading={sqlMutation.isPending}
       error={queryError}
+      docLink={{
+        url: 'https://madesroches.github.io/micromegas/docs/query-guide/schema-reference/#log_entries',
+        label: 'log_entries schema reference',
+      }}
     />
   ) : undefined
 

--- a/analytics-web-app/src/app/processes/page.tsx
+++ b/analytics-web-app/src/app/processes/page.tsx
@@ -214,6 +214,10 @@ function ProcessesPageContent() {
       onReset={handleResetQuery}
       isLoading={sqlMutation.isPending}
       error={queryError}
+      docLink={{
+        url: 'https://madesroches.github.io/micromegas/docs/query-guide/schema-reference/#processes',
+        label: 'processes schema reference',
+      }}
     />
   )
 

--- a/analytics-web-app/src/components/QueryEditor.tsx
+++ b/analytics-web-app/src/components/QueryEditor.tsx
@@ -12,6 +12,7 @@ interface QueryEditorProps {
   onReset: () => void
   isLoading?: boolean
   error?: string | null
+  docLink?: { url: string; label: string }
 }
 
 export function QueryEditor({
@@ -23,6 +24,7 @@ export function QueryEditor({
   onReset,
   isLoading = false,
   error,
+  docLink,
 }: QueryEditorProps) {
   const [isCollapsed, setIsCollapsed] = useState(true)
   const [sql, setSql] = useState(defaultSql)
@@ -181,6 +183,23 @@ export function QueryEditor({
               <br />
               Current: <span className="text-theme-text-primary">{timeRangeLabel}</span>
             </p>
+          </div>
+        )}
+
+        {/* Documentation Link */}
+        {docLink && (
+          <div className="mt-4">
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-theme-text-muted mb-2">
+              Documentation
+            </h4>
+            <a
+              href={docLink.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-accent-link hover:underline"
+            >
+              {docLink.label}
+            </a>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Add documentation links to QueryEditor component
- Link process log SQL panel to log_entries schema reference
- Link processes page SQL panel to processes schema reference

## Test plan
- [x] Open processes page and expand SQL panel - verify "processes schema reference" link appears
- [x] Open process log page and expand SQL panel - verify "log_entries schema reference" link appears
- [x] Click links and verify they open correct documentation pages