### PR TITLE
Pass time range through process navigation links

### DIFF
--- a/analytics-web-app/src/app/process/page.tsx
+++ b/analytics-web-app/src/app/process/page.tsx
@@ -41,7 +41,7 @@ LIMIT 1`
 function ProcessPageContent() {
   const searchParams = useSearchParams()
   const processId = searchParams.get('id')
-  const { apiTimeRange } = useTimeRange()
+  const { apiTimeRange, timeRange } = useTimeRange()
 
   const [process, setProcess] = useState<SqlRow | null>(null)
   const [statistics, setStatistics] = useState<SqlRow | null>(null)
@@ -208,14 +208,14 @@ function ProcessPageContent() {
           </div>
           <div className="flex gap-3">
             <Link
-              href={`/process_log?process_id=${processId}`}
+              href={`/process_log?process_id=${processId}&from=${encodeURIComponent(timeRange.from)}&to=${encodeURIComponent(timeRange.to)}`}
               className="flex items-center gap-2 px-4 py-2 bg-theme-border text-theme-text-primary rounded-md hover:bg-theme-border-hover transition-colors text-sm"
             >
               <FileText className="w-4 h-4" />
               View Log
             </Link>
             <Link
-              href={`/process_trace?process_id=${processId}`}
+              href={`/process_trace?process_id=${processId}&from=${encodeURIComponent(timeRange.from)}&to=${encodeURIComponent(timeRange.to)}`}
               className="flex items-center gap-2 px-4 py-2 bg-accent-link text-white rounded-md hover:bg-accent-link-hover transition-colors text-sm"
             >
               <Activity className="w-4 h-4" />

--- a/analytics-web-app/src/app/processes/page.tsx
+++ b/analytics-web-app/src/app/processes/page.tsx
@@ -292,7 +292,7 @@ function ProcessesPageContent() {
                     >
                       <td className="px-4 py-3">
                         <Link
-                          href={`/process?id=${row.process_id}`}
+                          href={`/process?id=${row.process_id}&from=${encodeURIComponent(String(row.start_time))}&to=${encodeURIComponent(String(row.last_update_time))}`}
                           className="text-accent-link hover:underline"
                         >
                           {String(row.exe ?? '')}


### PR DESCRIPTION
## Summary
- Process list links now include time range (from=start_time, to=last_update_time)
- Process page links to log and trace views now preserve the current time range

## Test plan
- [x] Click a process in the process list, verify time picker shows the process's time range
- [x] From process page, click View Log, verify time range is preserved
- [x] From process page, click Generate Trace, verify time range is preserved