### PR TITLE
Fix urllib3 security vulnerabilities and OIDC token validation bug

### DIFF
--- a/python/micromegas/poetry.lock
+++ b/python/micromegas/poetry.lock
@@ -1060,21 +1060,21 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.1"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
-    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
+    {file = "urllib3-2.6.1-py3-none-any.whl", hash = "sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b"},
+    {file = "urllib3-2.6.1.tar.gz", hash = "sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
+brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [metadata]
 lock-version = "2.1"

--- a/python/micromegas/tests/auth/test_oidc_unit.py
+++ b/python/micromegas/tests/auth/test_oidc_unit.py
@@ -98,10 +98,14 @@ def test_oidc_get_token_valid():
         mock_get.return_value = mock_response
 
         mock_client = MagicMock()
-        # Token expires in 10 minutes (> 5 min buffer)
+        # Create a valid JWT with far-future expiration
+        # Header: {"typ":"JWT","alg":"HS256"}
+        # Payload: {"sub":"test","exp":9999999999}
+        # Signature: test-signature (doesn't need to be valid for this test)
+        valid_jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwiZXhwIjo5OTk5OTk5OTk5fQ.dGVzdC1zaWduYXR1cmU"
         mock_client.token = {
             "access_token": "test-access",
-            "id_token": "test-id-token",
+            "id_token": valid_jwt,
             "refresh_token": "test-refresh",
             "expires_at": time.time() + 600,  # 10 minutes
         }
@@ -118,7 +122,7 @@ def test_oidc_get_token_valid():
         )
 
         token = provider.get_token()
-        assert token == "test-id-token"
+        assert token == valid_jwt
         # Should not call fetch_token since token is still valid
         mock_client.fetch_token.assert_not_called()
 


### PR DESCRIPTION
## Summary
- Update urllib3 from 2.5.0 to 2.6.1 to fix high severity CVEs
- Fix OIDC bug where unsigned tokens (alg=none) were not properly rejected

## Details
**Security fixes:**
- CVE-2025-66418: urllib3 unbounded decompression chain
- CVE-2025-66471: urllib3 highly compressed data handling

**Bug fix:**
- `_validate_id_token()` was inside a try/except that caught and suppressed security errors
- Unsigned JWT tokens (alg=none) would trigger a refresh instead of being rejected
- Moved validation outside try/except so security exceptions propagate

**Test fixes:**
- Updated admin test mock data to use `pd.Timestamp` instead of integers
- Updated OIDC test to use proper JWT format instead of plain string

## Test plan
- [x] All 81 Python tests pass
- [ ] Dependabot alerts auto-close after merge