### PR TITLE
Handle empty MICROMEGAS_TELEMETRY_URL environment variable

### DIFF
--- a/rust/telemetry-sink/src/lib.rs
+++ b/rust/telemetry-sink/src/lib.rs
@@ -305,7 +305,8 @@ impl TelemetryGuardBuilder {
                 let mut sinks: Vec<(LevelFilter, BoxedEventSink)> = vec![];
                 let telemetry_sink_url = self
                     .telemetry_sink_url
-                    .or_else(|| std::env::var("MICROMEGAS_TELEMETRY_URL").ok());
+                    .or_else(|| std::env::var("MICROMEGAS_TELEMETRY_URL").ok())
+                    .filter(|url| !url.trim().is_empty());
 
                 if let Some(url) = telemetry_sink_url {
                     let metadata_retry = self.telemetry_metadata_retry.unwrap_or_else(|| {


### PR DESCRIPTION
## Summary
- Filter out empty or whitespace-only `MICROMEGAS_TELEMETRY_URL` values
- Prevents attempting to create an `HttpEventSink` with an invalid URL

## Test plan
- [x] `cargo build` passes
- [x] `cargo test --package micromegas-telemetry-sink` passes