### PR TITLE
Analytics web app improvements

### DIFF
--- a/analytics-web-app/src/components/ThreadCoverageTimeline.tsx
+++ b/analytics-web-app/src/components/ThreadCoverageTimeline.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { ThreadCoverage } from '@/types'
 import { ChartAxisBounds } from './TimeSeriesChart'
 
@@ -18,7 +18,6 @@ export function ThreadCoverageTimeline({
   onTimeRangeSelect,
 }: ThreadCoverageTimelineProps) {
   const duration = timeRange.to - timeRange.from
-  const containerRef = useRef<HTMLDivElement>(null)
   const [selection, setSelection] = useState<{ startX: number; currentX: number } | null>(null)
   const [isDragging, setIsDragging] = useState(false)
 
@@ -138,7 +137,6 @@ export function ThreadCoverageTimeline({
 
               {/* Timeline bar area - matches chart plot area */}
               <div
-                ref={containerRef}
                 className={`h-6 relative bg-app-bg rounded ${onTimeRangeSelect ? 'cursor-crosshair' : ''}`}
                 style={{ width: plotWidth ?? '100%' }}
                 onMouseDown={handleMouseDown}


### PR DESCRIPTION
## Summary
- Remove unused `containerRef` from ThreadCoverageTimeline component

## Test plan
- [x] Verify drag-to-select on thread coverage timeline still works