### PR TITLE
Add Next.js basePath configuration for sub-path deployments

### DIFF
--- a/analytics-web-app/next.config.mjs
+++ b/analytics-web-app/next.config.mjs
@@ -4,11 +4,19 @@ import { fileURLToPath } from 'url'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const isProduction = process.env.NODE_ENV === 'production'
 
+// Base path for sub-path deployment (e.g., /micromegas)
+// Must be set at build time for static assets to have correct URLs
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Explicitly set the workspace root to the analytics-web-app directory
   // This prevents the warning about multiple lockfiles
   outputFileTracingRoot: __dirname,
+
+  // Base path for deployment at a sub-path (e.g., /micromegas)
+  // When set, all static assets will be prefixed with this path
+  ...(basePath && { basePath }),
 
   // Static export for production (served by analytics-web-srv)
   // In development, frontend calls backend directly at http://localhost:8000 (via config.ts)

--- a/analytics-web-app/src/app/layout.tsx
+++ b/analytics-web-app/src/app/layout.tsx
@@ -7,6 +7,9 @@ import { AuthProvider } from '@/lib/auth'
 
 const inter = Inter({ subsets: ['latin'] })
 
+// Base path for assets (set at build time via NEXT_PUBLIC_BASE_PATH)
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
+
 export const metadata: Metadata = {
   title: {
     template: 'Micromegas - %s',
@@ -14,7 +17,7 @@ export const metadata: Metadata = {
   },
   description: 'Analytics web application for micromegas telemetry data',
   icons: {
-    icon: '/icon.svg',
+    icon: `${basePath}/icon.svg`,
   },
 }
 

--- a/analytics-web-app/src/lib/config.ts
+++ b/analytics-web-app/src/lib/config.ts
@@ -27,8 +27,10 @@ export function getConfig(): RuntimeConfig {
 
   // Development fallback (no injection needed in dev mode)
   // In dev, the backend runs on port 8000, frontend on port 3000
+  // Include the base path if set via NEXT_PUBLIC_BASE_PATH
+  const devBasePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
   cachedConfig = {
-    basePath: process.env.NODE_ENV === 'development' ? 'http://localhost:8000' : '',
+    basePath: process.env.NODE_ENV === 'development' ? `http://localhost:8000${devBasePath}` : '',
   }
   return cachedConfig
 }


### PR DESCRIPTION
## Summary
- Configure `basePath` in `next.config.mjs` from `NEXT_PUBLIC_BASE_PATH` env var for static asset URL prefixing
- Update `start_analytics_web.py` to normalize `MICROMEGAS_BASE_PATH` and pass it to the Next.js dev server
- Fix `icon.svg` path in `layout.tsx` to include base path
- Update `config.ts` to include base path in dev mode API URLs

## Test plan
- [x] Test dev server with `MICROMEGAS_BASE_PATH=mm ./start_analytics_web.py --disable-auth`
- [x] Verify frontend accessible at `http://localhost:3000/mm/`
- [x] Verify API calls work with base path
- [x] Verify icon loads correctly

Fixes #655