### PR TITLE
Improve Perfetto trace integration robustness

### DIFF
--- a/analytics-web-app/src/lib/perfetto.ts
+++ b/analytics-web-app/src/lib/perfetto.ts
@@ -6,15 +6,18 @@ export interface OpenPerfettoOptions {
   buffer: ArrayBuffer
   processId: string
   timeRange: { begin: string; end: string }
+  onProgress?: (message: string) => void
 }
 
 export interface PerfettoError {
-  type: 'popup_blocked' | 'timeout' | 'unknown'
+  type: 'popup_blocked' | 'timeout' | 'window_closed' | 'unknown'
   message: string
 }
 
-const PERFETTO_HANDSHAKE_TIMEOUT_MS = 10000
+const PERFETTO_ORIGIN = 'https://ui.perfetto.dev'
+const PERFETTO_HANDSHAKE_TIMEOUT_MS = 20000 // Increased from 10s to 20s
 const PERFETTO_PING_INTERVAL_MS = 50
+const PERFETTO_WINDOW_CHECK_INTERVAL_MS = 500
 
 /**
  * Opens a Perfetto trace in ui.perfetto.dev
@@ -26,7 +29,7 @@ const PERFETTO_PING_INTERVAL_MS = 50
  * 4. Send trace buffer via postMessage on PONG response
  */
 export async function openInPerfetto(options: OpenPerfettoOptions): Promise<void> {
-  const { buffer, processId, timeRange } = options
+  const { buffer, processId, timeRange, onProgress } = options
 
   // Calculate time range in nanoseconds for Perfetto URL
   const beginMs = Date.parse(timeRange.begin)
@@ -34,7 +37,9 @@ export async function openInPerfetto(options: OpenPerfettoOptions): Promise<void
   const endMs = Date.parse(timeRange.end)
   const endNs = endMs * 1_000_000
 
-  const perfettoUrl = `https://ui.perfetto.dev/#!/?visStart=${beginNs}&visEnd=${endNs}`
+  const perfettoUrl = `${PERFETTO_ORIGIN}/#!/?visStart=${beginNs}&visEnd=${endNs}`
+
+  onProgress?.('Opening Perfetto UI...')
 
   // Open Perfetto UI
   const win = window.open(perfettoUrl)
@@ -46,14 +51,30 @@ export async function openInPerfetto(options: OpenPerfettoOptions): Promise<void
     throw error
   }
 
+  onProgress?.('Waiting for Perfetto UI to initialize...')
+
   return new Promise((resolve, reject) => {
+    let pingCount = 0
+
+    // Check if user closed the Perfetto window
+    const windowCheckTimer = setInterval(() => {
+      if (win.closed) {
+        cleanup()
+        const error: PerfettoError = {
+          type: 'window_closed',
+          message: 'Perfetto window was closed. Click "Open in Perfetto" to try again.',
+        }
+        reject(error)
+      }
+    }, PERFETTO_WINDOW_CHECK_INTERVAL_MS)
+
     // Set up timeout for handshake
     const timeoutId = setTimeout(() => {
-      window.removeEventListener('message', onMessageHandler)
-      clearInterval(pingTimer)
+      cleanup()
       const error: PerfettoError = {
         type: 'timeout',
-        message: 'Could not connect to Perfetto UI. Try again or download the trace.',
+        message:
+          'Could not connect to Perfetto UI after 20 seconds. The Perfetto site may be slow or unavailable. You can download the trace instead.',
       }
       reject(error)
     }, PERFETTO_HANDSHAKE_TIMEOUT_MS)
@@ -61,19 +82,34 @@ export async function openInPerfetto(options: OpenPerfettoOptions): Promise<void
     // Ping Perfetto until we get a PONG
     const pingTimer = setInterval(() => {
       try {
-        win.postMessage('PING', perfettoUrl)
+        win.postMessage('PING', PERFETTO_ORIGIN)
+        pingCount++
+        // Update progress every 2 seconds
+        if (pingCount % 40 === 0) {
+          const seconds = Math.floor((pingCount * PERFETTO_PING_INTERVAL_MS) / 1000)
+          onProgress?.(`Waiting for Perfetto... (${seconds}s)`)
+        }
       } catch {
-        // Window might be closed, ignore
+        // Window might be closed, ignore - windowCheckTimer will handle it
       }
     }, PERFETTO_PING_INTERVAL_MS)
 
+    const cleanup = () => {
+      clearTimeout(timeoutId)
+      clearInterval(pingTimer)
+      clearInterval(windowCheckTimer)
+      window.removeEventListener('message', onMessageHandler)
+    }
+
     const onMessageHandler = (evt: MessageEvent) => {
+      // Verify the message is from Perfetto
+      if (evt.origin !== PERFETTO_ORIGIN) return
       if (evt.data !== 'PONG') return
 
       // We got a PONG, the UI is ready
-      clearTimeout(timeoutId)
-      clearInterval(pingTimer)
-      window.removeEventListener('message', onMessageHandler)
+      cleanup()
+
+      onProgress?.('Sending trace to Perfetto...')
 
       // Send the trace buffer to Perfetto
       try {
@@ -84,7 +120,7 @@ export async function openInPerfetto(options: OpenPerfettoOptions): Promise<void
               title: `Micromegas trace of process ${processId}`,
             },
           },
-          perfettoUrl
+          PERFETTO_ORIGIN
         )
         resolve()
       } catch (err) {


### PR DESCRIPTION
## Summary
- Verify postMessage origin comes from ui.perfetto.dev for security
- Detect when user closes Perfetto window and report it
- Cache trace buffer to enable instant retry without regeneration
- Add "Download Instead" fallback when Perfetto connection fails
- Increase handshake timeout from 10s to 20s
- Show progress with elapsed time while waiting for Perfetto

## Test plan
- [x] Generate a trace and open in Perfetto - verify it works
- [x] Close Perfetto window while connecting - verify error message appears
- [ ] Wait for timeout - verify "Download Instead" button appears
- [x] Click "Try Again" after failure - verify it reuses cached buffer (instant)
- [ ] Click "Download Instead" - verify trace downloads without regenerating