### PR TITLE
Add more metrics and process info to Unreal telemetry plugin

### DIFF
--- a/unreal/MicromegasTelemetrySink/MicromegasTelemetrySink.Build.cs
+++ b/unreal/MicromegasTelemetrySink/MicromegasTelemetrySink.Build.cs
@@ -10,6 +10,7 @@ public class MicromegasTelemetrySink : ModuleRules
 			"Core",
 			"CoreUObject",
 			"Engine", 
+			"Json",
 			"HTTP",
 			"RenderCore",
 			"RHI",

--- a/unreal/MicromegasTelemetrySink/ThirdParty/jsoncons-0.173.4/jsoncons_ext/jsonpath/json_location.hpp
+++ b/unreal/MicromegasTelemetrySink/ThirdParty/jsoncons-0.173.4/jsoncons_ext/jsonpath/json_location.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright 2013-2023 Daniel Parker
+// Copyright 2013-2023 Daniel Parker
 // Distributed under the Boost license, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/unreal/MicromegasTelemetrySink/ThirdParty/jsoncons-0.173.4/jsoncons_ext/jsonpath/path_node.hpp
+++ b/unreal/MicromegasTelemetrySink/ThirdParty/jsoncons-0.173.4/jsoncons_ext/jsonpath/path_node.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright 2013-2023 Daniel Parker
+// Copyright 2013-2023 Daniel Parker
 // Distributed under the Boost license, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 


### PR DESCRIPTION
## Summary
- Add command line arguments as JSON array (`exe_args`) and raw `command-line` to process properties for better process identification
- Add new frame metrics: IdleTime, IdleTimeOvershoot, GameEngineFrameTime, AsyncLoadingTime, DrawCalls, PrimitivesDrawn
- Add SingleQualityLevel scalability metric
- Skip render thread metrics on dedicated servers (they don't have render/RHI threads)
- Fix GUID format to use lowercase hyphens for consistency

## Test plan
- [ ] Verify new process properties appear in telemetry
- [ ] Verify new frame metrics are collected on clients
- [ ] Verify dedicated servers don't emit render metrics