### PR TITLE
Fix: Auto-refresh auth token on 401 API responses

### DIFF
--- a/analytics-web-app/src/lib/api.ts
+++ b/analytics-web-app/src/lib/api.ts
@@ -38,12 +38,13 @@ async function refreshToken(): Promise<boolean> {
     return false
   }
 
+  // Set timestamp immediately to prevent race conditions with concurrent calls
+  lastRefreshAttempt = now
+
   // If a refresh is already in progress, wait for it
   if (refreshPromise) {
     return refreshPromise
   }
-
-  lastRefreshAttempt = now
 
   refreshPromise = (async () => {
     try {
@@ -126,6 +127,7 @@ export async function generateTrace(
   })
 
   if (!response.ok) {
+    // 401 check handles the case where token refresh failed - user must re-authenticate
     if (response.status === 401) {
       throw new AuthenticationError()
     }
@@ -244,6 +246,7 @@ export async function executeSqlQuery(request: SqlQueryRequest): Promise<SqlQuer
   })
 
   if (!response.ok) {
+    // 401 check handles the case where token refresh failed - user must re-authenticate
     if (response.status === 401) {
       throw new AuthenticationError()
     }


### PR DESCRIPTION
## Summary
- Add automatic token refresh when API requests receive 401 Unauthorized responses
- Include race condition prevention with single concurrent refresh and 5-second cooldown
- Wrap `generateTrace` and `executeSqlQuery` with new `authenticatedFetch` helper

## Test plan
- [ ] Test that API requests work when token is valid
- [ ] Test that expired tokens trigger automatic refresh
- [ ] Verify that rapid 401s don't cause refresh loops
- [ ] Confirm users are redirected to login when refresh fails