### PR TITLE
Add logging to investigate span duplication bug

### DIFF
--- a/rust/analytics/src/lakehouse/thread_spans_view.rs
+++ b/rust/analytics/src/lakehouse/thread_spans_view.rs
@@ -83,6 +83,8 @@ async fn append_call_tree(
     blob_storage: Arc<BlobStorage>,
     stream: &crate::metadata::StreamMetadata,
 ) -> Result<()> {
+    let block_ids: Vec<_> = blocks.iter().map(|b| b.block_id).collect();
+    info!("append_call_tree block_ids={block_ids:?}");
     let call_tree = make_call_tree(
         blocks,
         convert_ticks.delta_ticks_to_ns(blocks[0].begin_ticks),


### PR DESCRIPTION
## Summary
- Added block ID logging in `append_call_tree` to help trace the root cause of span duplication

## Context
This is a debugging change to investigate a span duplication bug by logging which blocks are being processed when building call trees.