### PR TITLE
Fix urllib3 decompression bomb vulnerability (CVE-2026-21441)

### DIFF
--- a/python/micromegas/poetry.lock
+++ b/python/micromegas/poetry.lock
@@ -1060,14 +1060,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.1"
+version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.6.1-py3-none-any.whl", hash = "sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b"},
-    {file = "urllib3-2.6.1.tar.gz", hash = "sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f"},
+    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
+    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
 ]
 
 [package.extras]


### PR DESCRIPTION
## Summary
- Update urllib3 from 2.6.1 to 2.6.3 to fix CVE-2026-21441
- High severity vulnerability: decompression bomb bypass when following HTTP redirects in streaming API

## Test plan
- [x] Unit tests pass
- [x] Poetry lock file updated correctly