### PR TITLE
Disable source maps in production builds

### DIFF
--- a/analytics-web-app/vite.config.ts
+++ b/analytics-web-app/vite.config.ts
@@ -36,7 +36,7 @@ export default defineConfig(({ mode }) => {
     },
     build: {
       outDir: 'dist',
-      sourcemap: true,
+      sourcemap: mode === 'development',
     },
     server: {
       port: frontendPort,


### PR DESCRIPTION
## Summary
- Disable source maps in production builds for analytics-web-app
- Source maps remain enabled in development mode for debugging

## Test plan
- [x] `yarn lint` passes
- [x] `yarn type-check` passes
- [x] `yarn test` passes (76 tests)
- [x] `yarn build` produces no `.map` files