### PR TITLE
Fix table screen save not persisting query changes

### DIFF
--- a/analytics-web-app/src/lib/screen-renderers/__tests__/useSqlHandlers.test.ts
+++ b/analytics-web-app/src/lib/screen-renderers/__tests__/useSqlHandlers.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for useSqlHandlers hook
+ */
+import { renderHook, act } from '@testing-library/react'
+import { useSqlHandlers } from '../useSqlHandlers'
+
+describe('useSqlHandlers', () => {
+  const createMocks = () => ({
+    onConfigChange: jest.fn(),
+    setHasUnsavedChanges: jest.fn(),
+    execute: jest.fn(),
+  })
+
+  describe('handleSqlChange', () => {
+    it('should update config when SQL changes (regression test for save bug)', () => {
+      // This test ensures that editing SQL updates the config immediately,
+      // so that clicking Save will persist the current editor content.
+      // Previously, handleSqlChange only called setHasUnsavedChanges without
+      // updating the config, causing Save to save stale SQL.
+      const mocks = createMocks()
+      const config = { sql: 'SELECT * FROM old_query' }
+      const savedConfig = { sql: 'SELECT * FROM old_query' }
+
+      const { result } = renderHook(() =>
+        useSqlHandlers({
+          config,
+          savedConfig,
+          ...mocks,
+        })
+      )
+
+      act(() => {
+        result.current.handleSqlChange('SELECT * FROM new_query')
+      })
+
+      // Config should be updated with new SQL
+      expect(mocks.onConfigChange).toHaveBeenCalledWith({
+        sql: 'SELECT * FROM new_query',
+      })
+      // Should also mark as unsaved
+      expect(mocks.setHasUnsavedChanges).toHaveBeenCalledWith(true)
+    })
+
+    it('should mark as not unsaved when SQL matches saved config', () => {
+      const mocks = createMocks()
+      const config = { sql: 'SELECT * FROM modified' }
+      const savedConfig = { sql: 'SELECT * FROM original' }
+
+      const { result } = renderHook(() =>
+        useSqlHandlers({
+          config,
+          savedConfig,
+          ...mocks,
+        })
+      )
+
+      act(() => {
+        result.current.handleSqlChange('SELECT * FROM original')
+      })
+
+      expect(mocks.setHasUnsavedChanges).toHaveBeenCalledWith(false)
+    })
+
+    it('should still update config when savedConfig is null (new screen)', () => {
+      const mocks = createMocks()
+      const config = { sql: 'SELECT 1' }
+
+      const { result } = renderHook(() =>
+        useSqlHandlers({
+          config,
+          savedConfig: null,
+          ...mocks,
+        })
+      )
+
+      act(() => {
+        result.current.handleSqlChange('SELECT 2')
+      })
+
+      // Config should still be updated even without savedConfig
+      expect(mocks.onConfigChange).toHaveBeenCalledWith({ sql: 'SELECT 2' })
+      // setHasUnsavedChanges should not be called when savedConfig is null
+      expect(mocks.setHasUnsavedChanges).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleRunQuery', () => {
+    it('should update config, mark unsaved, and execute query', () => {
+      const mocks = createMocks()
+      const config = { sql: 'SELECT * FROM old' }
+      const savedConfig = { sql: 'SELECT * FROM old' }
+
+      const { result } = renderHook(() =>
+        useSqlHandlers({
+          config,
+          savedConfig,
+          ...mocks,
+        })
+      )
+
+      act(() => {
+        result.current.handleRunQuery('SELECT * FROM new')
+      })
+
+      expect(mocks.onConfigChange).toHaveBeenCalledWith({ sql: 'SELECT * FROM new' })
+      expect(mocks.setHasUnsavedChanges).toHaveBeenCalledWith(true)
+      expect(mocks.execute).toHaveBeenCalledWith('SELECT * FROM new')
+    })
+
+    it('should not mark unsaved when SQL matches saved config', () => {
+      const mocks = createMocks()
+      const config = { sql: 'SELECT * FROM table' }
+      const savedConfig = { sql: 'SELECT * FROM table' }
+
+      const { result } = renderHook(() =>
+        useSqlHandlers({
+          config,
+          savedConfig,
+          ...mocks,
+        })
+      )
+
+      act(() => {
+        result.current.handleRunQuery('SELECT * FROM table')
+      })
+
+      expect(mocks.setHasUnsavedChanges).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('handleResetQuery', () => {
+    it('should reset to saved SQL and execute', () => {
+      const mocks = createMocks()
+      const config = { sql: 'SELECT * FROM modified' }
+      const savedConfig = { sql: 'SELECT * FROM original' }
+
+      const { result } = renderHook(() =>
+        useSqlHandlers({
+          config,
+          savedConfig,
+          ...mocks,
+        })
+      )
+
+      act(() => {
+        result.current.handleResetQuery()
+      })
+
+      expect(mocks.onConfigChange).toHaveBeenCalledWith({ sql: 'SELECT * FROM original' })
+      expect(mocks.execute).toHaveBeenCalledWith('SELECT * FROM original')
+    })
+
+    it('should use current config SQL when savedConfig is null', () => {
+      const mocks = createMocks()
+      const config = { sql: 'SELECT * FROM current' }
+
+      const { result } = renderHook(() =>
+        useSqlHandlers({
+          config,
+          savedConfig: null,
+          ...mocks,
+        })
+      )
+
+      act(() => {
+        result.current.handleResetQuery()
+      })
+
+      expect(mocks.execute).toHaveBeenCalledWith('SELECT * FROM current')
+    })
+  })
+})

--- a/analytics-web-app/src/lib/screen-renderers/useSqlHandlers.ts
+++ b/analytics-web-app/src/lib/screen-renderers/useSqlHandlers.ts
@@ -65,11 +65,13 @@ export function useSqlHandlers({
 
   const handleSqlChange = useCallback(
     (sql: string) => {
+      // Update config immediately so Save will save the current editor content
+      onConfigChange({ ...config, sql })
       if (savedConfig) {
         setHasUnsavedChanges(sql !== savedConfig.sql)
       }
     },
-    [savedConfig, setHasUnsavedChanges]
+    [config, savedConfig, onConfigChange, setHasUnsavedChanges]
   )
 
   return { handleRunQuery, handleResetQuery, handleSqlChange }


### PR DESCRIPTION
## Summary
- Fixed bug where `handleSqlChange` wasn't updating config, causing Save to persist stale SQL instead of current editor content
- Added `onConfigChange({ ...config, sql })` call to sync config immediately on editor changes
- Added comprehensive regression tests for `useSqlHandlers` hook

## Test plan
- [x] All 7 new tests pass
- [x] Lint clean
- [x] Type check clean
- [x] Manual test: edit SQL in table screen, click Save without running query, verify saved SQL matches editor content