### PR TITLE
Fix jsonwebtoken type confusion vulnerability (GHSA-h395-gr6q-cpjc)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3042,16 +3042,24 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "base64 0.22.1",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
  "js-sys",
+ "p256",
+ "p384",
  "pem",
- "ring",
+ "rand 0.8.5",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2",
+ "signature",
  "simple_asn1",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -46,7 +46,7 @@ hmac = "0.12"
 http = "1.1"
 internment = "0.8"
 jsonb = { version = "0.5.3", default-features = false, features = ["databend", "preserve_order"] }
-jsonwebtoken = "9"
+jsonwebtoken = { version = "10.3", features = ["rust_crypto"] }
 lazy_static = "1.4"
 log = { version = "0.4", features = ["std"] }
 lz4 = "1.23"


### PR DESCRIPTION
## Summary
- Upgrade `jsonwebtoken` from 9 to 10.3 to fix type confusion vulnerability
- Add `rust_crypto` feature required by v10.x

## Security Issue
Fixes [Dependabot alert #95](https://github.com/madesroches/micromegas/security/dependabot/95) (GHSA-h395-gr6q-cpjc)

The vulnerability allowed attackers to bypass JWT time-based security checks (`nbf`, `exp`) by sending claims with incorrect JSON types (e.g., string instead of number).

## Test plan
- [x] All auth package tests pass
- [x] Full CI pipeline passes (`python3 ../build/rust_ci.py`)