### PR TITLE
Update bytes crate to 1.11.1 to fix CVE-2026-25541

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -801,9 +801,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytesize"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,7 +33,7 @@ async-stream = "0.3"
 async-trait = "0.1"
 axum = "0.8"
 base64 = "0.22"
-bytes = "1.1"
+bytes = "1.11.1"
 cfg-if = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 ciborium = "0.2.2"


### PR DESCRIPTION
## Summary
- Updates `bytes` crate from 1.1 to 1.11.1
- Fixes Dependabot alert #96: integer overflow vulnerability in `BytesMut::reserve` (CVE-2026-25541)

## Test plan
- [x] Build passes
- [x] All tests pass