### PR TITLE
Use spawn_with_context for parallel thread spans execution

### DIFF
--- a/rust/analytics/src/lakehouse/perfetto_trace_execution_plan.rs
+++ b/rust/analytics/src/lakehouse/perfetto_trace_execution_plan.rs
@@ -131,7 +131,7 @@ impl ExecutionPlan for PerfettoTraceExecutionPlan {
         Ok(self)
     }
 
-	#[span_fn]
+    #[span_fn]
     fn execute(
         &self,
         _partition: usize,


### PR DESCRIPTION
## Summary
- Use `spawn_with_context()` for true multi-threaded parallelism when building thread span streams in Perfetto trace generation
- Add `#[span_fn]` tracing instrumentation to `execute()` and `generate_perfetto_trace_stream()`

## Test plan
- [ ] Verify Perfetto trace export works correctly with the new parallel execution
- [ ] Check traces show proper parent-child span relationships