### PR TITLE
Remove process list from available screen types

### DIFF
--- a/rust/analytics-web-srv/src/screen_types.rs
+++ b/rust/analytics-web-srv/src/screen_types.rs
@@ -12,7 +12,7 @@ impl fmt::Display for ParseScreenTypeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "invalid screen type '{}', expected one of: process_list, metrics, log, table, notebook",
+            "invalid screen type '{}', expected one of: metrics, log, table, notebook",
             self.invalid_value
         )
     }
@@ -24,6 +24,7 @@ impl std::error::Error for ParseScreenTypeError {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ScreenType {
+    /// Deprecated: no longer available for creation, kept for backward compatibility with existing screens.
     ProcessList,
     Metrics,
     Log,

--- a/rust/analytics-web-srv/tests/screen_types_tests.rs
+++ b/rust/analytics-web-srv/tests/screen_types_tests.rs
@@ -154,7 +154,7 @@ fn test_screen_type_default_config() {
 fn test_screen_type_from_str_error() {
     let err = "unknown_type".parse::<ScreenType>().unwrap_err();
     assert!(err.to_string().contains("unknown_type"));
-    assert!(err.to_string().contains("process_list"));
+    assert!(!err.to_string().contains("process_list"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Remove `ProcessList` from `ScreenType::all()` so it no longer appears as a creatable screen type
- Remove `process_list` from the parse error message to avoid suggesting it as valid
- Keep the enum variant with a deprecation doc comment for backward compatibility with existing screens

Closes #789

## Test plan
- [x] Updated `test_all_screen_types` to assert `ProcessList` is excluded
- [x] Updated `test_screen_type_from_str_error` to assert `process_list` is not in error message
- [x] Existing serialization/deserialization tests still pass for `ProcessList` (backward compat)