### PR TITLE
Fix GoatCounter missing from presentation builds

### DIFF
--- a/doc/high-frequency-observability/build-inline.js
+++ b/doc/high-frequency-observability/build-inline.js
@@ -71,6 +71,8 @@ ${presentationMd}
 console.log('Presentation built at: ${buildTime}');
 ${mainJs}
     </script>
+    <script data-goatcounter="https://madesroches.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>`;
 

--- a/doc/unified-observability-for-games/build-inline.js
+++ b/doc/unified-observability-for-games/build-inline.js
@@ -71,6 +71,8 @@ ${presentationMd}
 console.log('Presentation built at: ${buildTime}');
 ${mainJs}
     </script>
+    <script data-goatcounter="https://madesroches.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>`;
 


### PR DESCRIPTION
## Summary
- The `build-inline.js` scripts for both presentations construct the deployed HTML from a template literal, so the GoatCounter script added to the source `index.html` files was never included in the built `presentation-inline.html`
- Added the GoatCounter snippet to both `build-inline.js` templates so it survives the build

## Test plan
- [ ] Verify CI build succeeds
- [ ] After deploy, check that https://madesroches.github.io/micromegas/unified-observability-for-games/ and https://madesroches.github.io/micromegas/high-frequency-observability/ include the GoatCounter script