### PR TITLE
Link documentation site in crate READMEs and PyPI metadata

### DIFF
--- a/python/micromegas/pyproject.toml
+++ b/python/micromegas/pyproject.toml
@@ -1,8 +1,11 @@
 [tool.poetry]
 name = "micromegas"
 version = "0.20.0"
-description = "Python analytics client for https://github.com/madesroches/micromegas/"
+description = "Python analytics client for the Micromegas observability platform"
 authors = ["Marc-Antoine Desroches <madesroches@gmail.com>"]
+homepage = "https://github.com/madesroches/micromegas/"
+documentation = "https://madesroches.github.io/micromegas/"
+repository = "https://github.com/madesroches/micromegas/"
 readme = "README.md"
 
 [tool.poetry.dependencies]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.20.0"
 edition = "2024"
 license = "Apache-2.0"
 homepage = "https://github.com/madesroches/micromegas/"
+documentation = "https://madesroches.github.io/micromegas/"
 authors = ["Marc-Antoine Desroches <madesroches@gmail.com>"]
 repository = "https://github.com/madesroches/micromegas/"
 keywords = ["observability", "telemetry", "analytics"]

--- a/rust/tracing/proc-macros/README.md
+++ b/rust/tracing/proc-macros/README.md
@@ -2,4 +2,7 @@
 
 This crate provides macros to help with instrumentation for the Micromegas observability platform.
 
-For more information, please see the main repository at [https://github.com/madesroches/micromegas](https://github.com/madesroches/micromegas).
+## Documentation
+
+- 📖 [Complete Documentation](https://madesroches.github.io/micromegas/)
+- 💻 [GitHub Repository](https://github.com/madesroches/micromegas)

--- a/rust/transit/derive/README.md
+++ b/rust/transit/derive/README.md
@@ -2,4 +2,7 @@
 
 This crate provides low overhead serialization derive macros for the Micromegas observability platform.
 
-For more information, please see the main repository at [https://github.com/madesroches/micromegas](https://github.com/madesroches/micromegas).
+## Documentation
+
+- 📖 [Complete Documentation](https://madesroches.github.io/micromegas/)
+- 💻 [GitHub Repository](https://github.com/madesroches/micromegas)


### PR DESCRIPTION
## Summary
- Add `documentation` field to workspace `Cargo.toml` pointing to https://madesroches.github.io/micromegas/
- Update `tracing-proc-macros` and `transit-derive` READMEs with doc site links (all other crate READMEs already had them)
- Add `homepage`, `documentation`, and `repository` URLs to PyPI `pyproject.toml` metadata

## Test plan
- [ ] Verify doc links render correctly on crates.io after next publish
- [ ] Verify PyPI metadata shows documentation link after next publish