### PR TITLE
Fix Perfetto trace generation missing data source

### DIFF
--- a/analytics-web-app/src/routes/PerformanceAnalysisPage.tsx
+++ b/analytics-web-app/src/routes/PerformanceAnalysisPage.tsx
@@ -625,6 +625,7 @@ function PerformanceAnalysisContent() {
         timeRange: currentTimeRange,
         onProgress: (message) => setProgress({ type: 'progress', message }),
         signal: traceAbortRef.current.signal,
+        dataSource: defaultDataSource,
       })
 
       setCachedTraceBuffer(buffer)
@@ -682,6 +683,7 @@ function PerformanceAnalysisContent() {
         timeRange: currentTimeRange,
         onProgress: (message) => setProgress({ type: 'progress', message }),
         signal: traceAbortRef.current.signal,
+        dataSource: defaultDataSource,
       })
 
       setCachedTraceBuffer(buffer)


### PR DESCRIPTION
## Summary
- Pass `dataSource` parameter to `fetchPerfettoTrace()` in both the open-in-Perfetto and download-trace handlers
- Without this, Perfetto trace generation used the wrong data source

Closes #803

## Test plan
- [ ] Open a process in performance analysis, click "Open in Perfetto" — verify trace loads correctly
- [ ] Click "Download Trace" — verify downloaded trace contains expected data