### PR TITLE
Enable SHOW TABLES in WASM query engine

### DIFF
--- a/rust/datafusion-wasm/src/lib.rs
+++ b/rust/datafusion-wasm/src/lib.rs
@@ -53,7 +53,9 @@ impl WasmQueryEngine {
             })
             .collect::<Vec<_>>();
 
+        let config = SessionConfig::default().with_information_schema(true);
         let state = SessionStateBuilder::new()
+            .with_config(config)
             .with_default_features()
             .with_physical_optimizer_rules(filtered_rules)
             .build();


### PR DESCRIPTION
## Summary
- Enable `information_schema` in WASM `SessionConfig` so `SHOW TABLES` and `information_schema.tables` queries work
- Lets notebook users inspect available cell results for cross-cell references

## Test plan
- [x] Verify WASM integration tests pass with `wasm-pack test --node`
- [x] Test `SHOW TABLES` returns registered tables in the WASM query engine