### PR TITLE
Fix wasm-builder to copy full Rust workspace

### DIFF
--- a/docker/wasm-builder.Dockerfile
+++ b/docker/wasm-builder.Dockerfile
@@ -15,8 +15,8 @@ COPY rust/datafusion-wasm/Cargo.lock ./
 RUN WASM_BINDGEN_VERSION=$(grep -A1 'name = "wasm-bindgen"' Cargo.lock | grep version | head -1 | sed 's/.*"\(.*\)".*/\1/') && \
     cargo install wasm-bindgen-cli --version "$WASM_BINDGEN_VERSION"
 
-# Copy source and build
-COPY rust/datafusion-wasm/ ./
+# Copy full Rust source (datafusion-wasm has path deps on workspace crates)
+COPY rust/ /build/rust/
 RUN cargo build --target wasm32-unknown-unknown --release
 
 # Generate JS bindings (Rust release profile already optimizes with lto + opt-level=s)


### PR DESCRIPTION
## Summary
- Fix `wasm-builder.Dockerfile` to copy the full `rust/` workspace instead of only `rust/datafusion-wasm/`, since `datafusion-wasm` has path dependencies on other workspace crates.

## Test plan
- [x] Verify Docker build of wasm-builder succeeds with the updated COPY path