### PR TITLE
Hide data source selector for reference table cells

### DIFF
--- a/analytics-web-app/src/components/CellEditor.tsx
+++ b/analytics-web-app/src/components/CellEditor.tsx
@@ -78,7 +78,7 @@ export function CellEditor({
 
   // Determine if this cell should show a data source selector
   // Variable cells handle their own data source selector internally
-  const shouldShowDataSource = cell.type !== 'markdown' && cell.type !== 'variable'
+  const shouldShowDataSource = cell.type !== 'markdown' && cell.type !== 'variable' && cell.type !== 'referencetable'
 
   // Determine if this cell can run
   const canRun = !!meta.execute


### PR DESCRIPTION
## Summary
- Remove the data source selector from the reference table cell editor since reference tables contain inline CSV data and don't query external data sources

## Test plan
- [ ] Open a notebook with a reference table cell
- [ ] Click to edit the cell and verify no data source field is shown
- [ ] Verify other cell types (query, chart, etc.) still show the data source selector