### PR TITLE
Stop column header sort click from opening cell editor

### DIFF
--- a/analytics-web-app/src/lib/screen-renderers/table-utils.tsx
+++ b/analytics-web-app/src/lib/screen-renderers/table-utils.tsx
@@ -304,7 +304,7 @@ export function SortHeader({
 
   if (!onHide) {
     return (
-      <th onClick={() => onSort(columnName)} className={thClass}>
+      <th onClick={(e) => { e.stopPropagation(); onSort(columnName); }} className={thClass}>
         {thContent}
       </th>
     )
@@ -313,7 +313,7 @@ export function SortHeader({
   return (
     <ContextMenu.Root>
       <ContextMenu.Trigger asChild>
-        <th onClick={() => onSort(columnName)} className={thClass}>
+        <th onClick={(e) => { e.stopPropagation(); onSort(columnName); }} className={thClass}>
           {thContent}
         </th>
       </ContextMenu.Trigger>


### PR DESCRIPTION
## Summary
- Add `stopPropagation()` to SortHeader click handlers so sorting a column doesn't bubble up to `CellContainer.onClick` and open the cell editor

## Test plan
- [ ] Click a column header in a notebook table cell — should sort without opening the editor panel
- [ ] Right-click a column header — context menu (sort ascending/descending/hide) still works
- [ ] Sort still works on ProcessesPage and other non-notebook tables