### PR TITLE
Fix CVE-2025-69873: upgrade ajv 8.17.1 to 8.18.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2404,9 +2404,9 @@ ajv@^6.12.4, ajv@^6.12.5:
     uri-js "^4.2.2"
 
 ajv@^8.0.0, ajv@^8.9.0:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
-  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
+  integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
   dependencies:
     fast-deep-equal "^3.1.3"
     fast-uri "^3.0.1"


### PR DESCRIPTION
## Summary
- Upgrades ajv from 8.17.1 to 8.18.0 to fix CVE-2025-69873
- Lockfile-only change, no code modifications

## Test plan
- [ ] Verify `yarn install` resolves correctly
- [ ] Confirm analytics-web-app builds successfully