### PR TITLE
Deprecate non-notebook screen types for creation

### DIFF
--- a/rust/analytics-web-srv/src/screen_types.rs
+++ b/rust/analytics-web-srv/src/screen_types.rs
@@ -24,12 +24,16 @@ impl std::error::Error for ParseScreenTypeError {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ScreenType {
-    /// Deprecated: no longer available for creation, kept for backward compatibility with existing screens.
+    /// Deprecated: kept for backward compatibility with existing screens.
     ProcessList,
+    /// Deprecated: kept for backward compatibility with existing screens.
     Metrics,
+    /// Deprecated: kept for backward compatibility with existing screens.
     Log,
+    /// Deprecated: kept for backward compatibility with existing screens.
     Table,
     Notebook,
+    /// Deprecated: kept for backward compatibility with existing screens.
     LocalQuery,
 }
 
@@ -52,15 +56,10 @@ impl FromStr for ScreenType {
 }
 
 impl ScreenType {
-    /// Returns all available screen types.
+    /// Returns all available screen types for creation.
+    /// Non-notebook types are deprecated but kept for backward compatibility with existing screens.
     pub fn all() -> Vec<ScreenType> {
-        vec![
-            ScreenType::Metrics,
-            ScreenType::Log,
-            ScreenType::Table,
-            ScreenType::Notebook,
-            ScreenType::LocalQuery,
-        ]
+        vec![ScreenType::Notebook]
     }
 
     /// Returns the string identifier for this screen type.

--- a/rust/analytics-web-srv/tests/screen_types_tests.rs
+++ b/rust/analytics-web-srv/tests/screen_types_tests.rs
@@ -84,13 +84,14 @@ fn test_screen_type_from_str() {
 #[test]
 fn test_all_screen_types() {
     let all = ScreenType::all();
-    assert_eq!(all.len(), 5);
-    assert!(!all.contains(&ScreenType::ProcessList));
-    assert!(all.contains(&ScreenType::Metrics));
-    assert!(all.contains(&ScreenType::Log));
-    assert!(all.contains(&ScreenType::Table));
+    assert_eq!(all.len(), 1);
     assert!(all.contains(&ScreenType::Notebook));
-    assert!(all.contains(&ScreenType::LocalQuery));
+    // Deprecated types should not be available for creation
+    assert!(!all.contains(&ScreenType::ProcessList));
+    assert!(!all.contains(&ScreenType::Metrics));
+    assert!(!all.contains(&ScreenType::Log));
+    assert!(!all.contains(&ScreenType::Table));
+    assert!(!all.contains(&ScreenType::LocalQuery));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `ScreenType::all()` now returns only `Notebook`, preventing creation of deprecated screen types (ProcessList, Metrics, Log, Table, LocalQuery)
- Deprecated types are preserved in the enum with doc comments for backward compatibility — existing screens of these types continue to work
- Updated tests to verify only Notebook is available for creation

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test` passes — including updated `test_all_screen_types` assertions
- Verify existing screens of deprecated types still load correctly in the web app