### PR TITLE
Add Bevy/Optimism references to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Micromegas is an observability system designed to provide unified insights into 
 
 Micromegas consists of several key components:
 
-1.  **Instrumentation Libraries:** Lightweight libraries for your applications (available in Rust, Unreal Engine, and [Bevy](https://github.com/madesroches/optimism)) to send telemetry data.
+1.  **Instrumentation Libraries:** Lightweight libraries for your applications (available in Rust and Unreal Engine) to send telemetry data. See [Optimism](https://github.com/madesroches/optimism) for an example Bevy project using Micromegas.
 2.  **Ingestion Service (`telemetry-ingestion-srv`):** A scalable service that receives telemetry data and writes it to blob storage.
 3.  **Analytics Service (`flight-sql-srv`):** A DataFusion-powered service that exposes a FlightSQL endpoint for running queries against your data.
 4.  **PostgreSQL Database:** Stores metadata about processes, streams, and data blocks, keeping the object storage indexable and fast to query.

--- a/mkdocs/docs/getting-started.md
+++ b/mkdocs/docs/getting-started.md
@@ -172,7 +172,7 @@ If you see a DataFrame with log entries (or an empty DataFrame if no data has be
 Now that you have Micromegas running locally, you can:
 
 1. **[Unreal Engine Integration](unreal/index.md)** - Add observability to your Unreal Engine games
-2. **[Bevy Integration](https://github.com/madesroches/optimism)** - Add observability to your Bevy games
+2. **[Optimism](https://github.com/madesroches/optimism)** - Example Bevy project using Micromegas
 3. **[Learn to Query Data](query-guide/index.md)** - Explore the SQL interface and available data
 4. **[Understand the Architecture](architecture/index.md)** - Learn how Micromegas components work together
 5. **[Instrument Your Application](query-guide/python-api.md)** - Start collecting telemetry from your own applications

--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -49,14 +49,14 @@ Get started with Micromegas in just a few steps:
 
 1. **[Getting Started Guide](getting-started.md)** - Set up your first Micromegas installation
 2. **[Unreal Engine Integration](unreal/index.md)** - Add observability to your Unreal Engine games
-3. **[Bevy Integration](https://github.com/madesroches/optimism)** - Add observability to your Bevy games
+3. **[Optimism](https://github.com/madesroches/optimism)** - Example Bevy project using Micromegas
 4. **[Query Guide](query-guide/index.md)** - Learn how to query your observability data
 5. **[Architecture Overview](architecture/index.md)** - Understand the system design
 
 ## Use Cases
 
 ### Game Development
-Monitor Unreal Engine and [Bevy](https://github.com/madesroches/optimism) games with integrated telemetry for performance, player behavior, and system health.
+Monitor Unreal Engine and Bevy games with integrated telemetry for performance, player behavior, and system health. See [Optimism](https://github.com/madesroches/optimism) for a Bevy example.
 
 ### Application Performance Monitoring
 Monitor your applications with detailed performance metrics, error tracking, and distributed tracing.


### PR DESCRIPTION
## Summary
- Add links to the [Optimism](https://github.com/madesroches/optimism) example Bevy project across README, getting-started guide, and docs index
- Update Game Development section to mention Bevy alongside Unreal Engine