### PR TITLE
Document implicit time filtering and WASM registration

### DIFF
--- a/mkdocs/docs/web-app/notebooks/cell-types.md
+++ b/mkdocs/docs/web-app/notebooks/cell-types.md
@@ -69,10 +69,10 @@ Dropdown populated by a SQL query. Single-column queries produce simple string o
 
 ```sql
 -- Single column: options are strings
-SELECT DISTINCT name FROM measures WHERE time >= '$begin' AND time < '$end'
+SELECT DISTINCT name FROM measures
 
 -- Multi-column: options are objects with .name and .unit fields
-SELECT DISTINCT name, unit FROM measures WHERE time >= '$begin' AND time < '$end'
+SELECT DISTINCT name, unit FROM measures
 ```
 
 After execution, the current value is validated against available options. If invalid, the default value or first option is auto-selected.
@@ -135,6 +135,7 @@ SQL query results displayed in a sortable, paginated table.
 - Client-side pagination with configurable page size
 - Sort column available as `$order_by` macro in SQL for server-side sorting
 - Column format overrides with markdown and row macros (`$row.columnName`)
+- Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
 
 **Column format overrides:**
 
@@ -151,7 +152,6 @@ This renders the `exe` column as a link to the process page.
 ```sql
 SELECT process_id, exe, start_time, username, computer
 FROM processes
-WHERE start_time >= '$begin' AND start_time < '$end'
 ORDER BY $order_by
 LIMIT 100
 ```
@@ -173,6 +173,12 @@ Same as Table — `sql`, `dataSource`, and options for hidden rows, page size, a
 | `pageSize` | number | Page size for scrolling |
 | `hiddenRows` | string[] | Hidden row names (original column names) |
 | `overrides` | array | Row rendering overrides |
+
+**Features:**
+
+- Row hiding via right-click context menu, with a restoration bar to unhide
+- Row format overrides with markdown and row macros (same syntax as table column overrides)
+- Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
 
 **Example:**
 
@@ -227,7 +233,7 @@ Multi-query time-series charts supporting line and bar chart types.
 ```sql
 SELECT time, value
 FROM measures
-WHERE name = '$metric' AND time >= '$begin' AND time < '$end'
+WHERE name = '$metric'
 ORDER BY time
 ```
 
@@ -261,6 +267,8 @@ The renderer auto-classifies columns by name:
 
 Additional columns are rendered as fixed-width monospace text.
 
+- Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
+
 **Level coloring:**
 
 | Level | Color |
@@ -275,7 +283,6 @@ Additional columns are rendered as fixed-width monospace text.
 ```sql
 SELECT time, level, target, msg
 FROM log_entries
-WHERE time >= '$begin' AND time < '$end'
 ORDER BY time DESC
 LIMIT 500
 ```
@@ -306,6 +313,7 @@ Visualizes how JSON properties change over time as horizontal timeline segments.
 - Interactive key selection — add or remove property keys from the display
 - Time range zoom via drag selection
 - Fills time gaps with "no value" state
+- Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
 
 **Expected columns:**
 
@@ -342,6 +350,7 @@ Multiple rows with the same `id` create multiple segments in one lane. Lanes are
 - Horizontal time bars in the center
 - Drag-to-zoom time selection
 - Time axis with formatted tick marks
+- Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
 
 **Example SQL:**
 

--- a/mkdocs/docs/web-app/notebooks/execution.md
+++ b/mkdocs/docs/web-app/notebooks/execution.md
@@ -56,14 +56,32 @@ The time range controls which time window is queried. It is managed at the page 
 - **Relative**: `now-5m`, `now-1h`, `now-7d` — evaluated fresh at each execution, so results always reflect the latest data.
 - **Absolute**: specific ISO 8601 timestamps — fixed time window that doesn't change on re-execution.
 
-### In Queries
+### Implicit Time Filtering
 
-Use `$begin` and `$end` macros in SQL to reference the resolved time range:
+When a query is sent to the server, the current time range is passed as **separate metadata** alongside the SQL. The server's query planner automatically injects time filters into the execution plan for all materialized views — you do not need to write `WHERE time >= '$begin' AND time < '$end'` in your SQL.
+
+Each view defines which columns are filtered:
+
+| View | Filtered Columns |
+|------|-----------------|
+| Metrics, logs, async events | `time BETWEEN begin AND end` |
+| Blocks | `begin_time <= end AND insert_time >= begin` |
+| Export logs | Configurable time column |
+
+This means a simple query like `SELECT time, value FROM measures WHERE name = '$metric'` is automatically scoped to the selected time range.
+
+### Explicit Time References
+
+The `$begin` and `$end` macros are still available for cases where you need the time range values explicitly — for example, in markdown content, link URLs, or `date_bin()` aggregations:
 
 ```sql
-SELECT time, value FROM measures
-WHERE time >= '$begin' AND time < '$end'
-ORDER BY time
+SELECT
+  date_bin('$bin_interval', time) as time,
+  avg(value) as value
+FROM measures
+WHERE name = '$metric'
+GROUP BY 1
+ORDER BY 1
 ```
 
 The macros are replaced with absolute ISO 8601 timestamps after resolving any relative expressions.
@@ -107,7 +125,7 @@ Every notebook has a local [DataFusion](https://datafusion.apache.org/) query en
 
 ### How It Works
 
-1. When a data cell (table, chart, log, etc.) executes a remote SQL query, the result is automatically **registered as a named table** in the local WASM engine under the cell's name.
+1. When a data cell (table, transposed table, chart, log, etc.) executes a remote SQL query, the result is automatically **registered as a named table** in the local WASM engine under the cell's name.
 2. Any downstream cell can query upstream results locally using `SELECT ... FROM cell_name` — no round-trip to the server.
 3. This enables interactive data transformation: fetch data once from the server, then reshape, filter, join, and aggregate locally.
 
@@ -146,7 +164,6 @@ This avoids redundant server round-trips and enables rapid iteration on data sha
 ```
 Cell 1: "raw_data" (Table)
   SQL: SELECT time, name, value FROM measures
-       WHERE time >= '$begin' AND time < '$end'
 
 Cell 2: "thresholds" (Reference Table)
   CSV: name,warn,error

--- a/mkdocs/docs/web-app/notebooks/variables.md
+++ b/mkdocs/docs/web-app/notebooks/variables.md
@@ -60,7 +60,6 @@ SQL queries, markdown content, and chart unit labels all support macro substitut
 -- Simple variable
 SELECT * FROM measures
 WHERE name = '$metric'
-  AND time >= '$begin' AND time < '$end'
 
 -- Multi-column variable (combobox returning name + unit columns)
 SELECT time, value
@@ -136,7 +135,6 @@ SELECT
   avg(value) as value
 FROM measures
 WHERE name = '$metric'
-  AND time >= '$begin' AND time < '$end'
 GROUP BY 1
 ORDER BY 1
 ```


### PR DESCRIPTION
## Summary
- Document that time filtering is applied implicitly by the server query planner, removing misleading `WHERE time >= '$begin'` clauses from SQL examples
- Add table showing how each view type is filtered (metrics/logs use BETWEEN, blocks use overlap logic, export logs use configurable column)
- Clarify that `$begin`/`$end` macros are still available for explicit use cases (date_bin, markdown, URLs)
- Add WASM query engine registration notes to all data cell types (transposed table, log, timeline, spans)

## Test plan
- Verify mkdocs builds: `mkdocs serve` from `mkdocs/` directory
- Review rendered docs for accuracy against actual query behavior