### PR TITLE
Add .gitattributes for LF line endings, ignore .claude settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ grafana/coverage/
 rust/datafusion-wasm/pkg/
 analytics-web-app/src/lib/datafusion-wasm/micromegas_datafusion_wasm_bg.wasm
 analytics-web-app/src/lib/datafusion-wasm/micromegas_datafusion_wasm_bg.wasm.d.ts
+
+# Claude Code
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add `.gitattributes` with `* text=auto eol=lf` to enforce Unix line endings across the repo
- Add `.claude/settings.local.json` to `.gitignore` to keep local Claude Code settings out of source control

## Test plan
- [x] Verify `git status` is clean after the change (no spurious line-ending diffs)