### PR TITLE
Add Send + Sync bounds to MergerMaker type alias

### DIFF
--- a/rust/analytics/src/lakehouse/sql_batch_view.rs
+++ b/rust/analytics/src/lakehouse/sql_batch_view.rs
@@ -32,7 +32,8 @@ use std::hash::Hasher;
 use std::{hash::DefaultHasher, sync::Arc};
 
 /// A type alias for a function that creates a `PartitionMerger`.
-pub type MergerMaker = dyn Fn(Arc<RuntimeEnv>, Arc<Schema>) -> Arc<dyn PartitionMerger>;
+pub type MergerMaker =
+    dyn Fn(Arc<RuntimeEnv>, Arc<Schema>) -> Arc<dyn PartitionMerger> + Send + Sync;
 
 /// SQL-defined view updated in batch
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
- Adds `Send + Sync` bounds to the `MergerMaker` type alias in `sql_batch_view.rs`
- This makes `SqlBatchView` (and `ViewFactory`) `Send` when held across `.await` points, enabling `FlightSqlServer::builder().with_view_factory_fn(...)` to work with async view factory functions

Fixes #971