### PR TITLE
Bump vite, lodash, and lodash-es for Dependabot alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This file documents the historical progress of the Micromegas project. For curre
   * Fix byteLength crash on 0-row Arrow tables in notebook status text
   * Fix notebook variable URL desync on rapid updates and datasource reverting to default on change
 * **Security:**
-  * Bump vite and lodash-es to fix Dependabot alerts
+  * Bump vite, lodash, and lodash-es to fix Dependabot alerts
   * Bump picomatch, brace-expansion, yaml, and requests to fix Dependabot alerts
   * Bump serialize-javascript, handlebars, cryptography, and Pygments to fix Dependabot alerts
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "dependencies": {
     "js-yaml": "^4.1.1",
-    "lodash": "^4.17.23"
+    "lodash": "^4.18.0"
   },
   "resolutions": {
     "@remix-run/router": "^1.23.2",
@@ -30,7 +30,7 @@
     "flatted": "^3.4.2",
     "immutable": "^5.1.5",
     "js-yaml": "^4.1.1",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.0",
     "minimatch": "^10.2.1",
     "qs": "^6.14.2",
     "react-router": "^6.30.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5866,10 +5866,10 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@4.17.21, lodash@^4.1.1, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.23, lodash@^4.17.4:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
-  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+lodash@4.17.21, lodash@^4.1.1, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.18.0:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 long@^5.0.0:
   version "5.3.2"


### PR DESCRIPTION
## Summary

* Bump `lodash` from 4.17.23 to 4.18.0 (root dependency + resolutions) to fix prototype pollution and code injection alerts
* Bump `vite` and `lodash-es` across analytics-web-app, doc sites, and welcome app via lock file updates
* Updates lock files in analytics-web-app, doc/high-frequency-observability, doc/notebooks, doc/unified-observability-for-games, and welcome

## Test plan

- [ ] Verify Dependabot alerts are resolved after merge
- [ ] `yarn lint` passes in analytics-web-app (confirmed)
- [ ] `yarn type-check` passes in analytics-web-app (confirmed)
- [ ] No source code changes — only dependency version bumps