### PR TITLE
Release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,34 @@
 
 This file documents the historical progress of the Micromegas project. For current focus, please see the main [README.md](./README.md).
 
-## Unreleased
+## April 2026 - v0.24.0
 
 * **Analytics:**
-  * Add `parse_block` table UDF for generic block inspection with transit-to-JSONB conversion
+  * Add `parse_block` table UDF for generic block inspection with transit-to-JSONB conversion (#1001)
 * **CLI:**
-  * Add unified diff output to `micromegas-screens plan` and `apply` for updated screens
+  * Add unified diff output to `micromegas-screens plan` and `apply` for updated screens (#998)
 * **Bug Fixes:**
-  * Fix byteLength crash on 0-row Arrow tables in notebook status text
-  * Fix notebook variable URL desync on rapid updates and datasource reverting to default on change
-  * Fix flamechart WASD zoom continuing after key release in Chrome (#1012)
+  * Fix byteLength crash on 0-row Arrow tables in notebook status text (#1000)
+  * Fix notebook variable URL desync on rapid updates and datasource reverting to default on change (#1003)
+  * Fix flamechart WASD zoom continuing after key release in Chrome (#1013)
 * **Web App:**
   * Show flamechart span duration in nanoseconds when below 1 microsecond
+* **Docs:**
+  * Add `parse_block` to functions reference (#1002)
+  * Blog post: From Observability to Candor (#996)
+* **Repo:**
+  * Normalize line endings to LF for existing files (#997)
+* **Dependencies:**
+  * Update DataFusion to 52.5 (#1009)
+  * Update pyarrow to ^23.0.0 (#1006)
 * **Security:**
+  * Update `rand` to 0.9 to fix unsoundness in `rand::rng()` (Dependabot #201, #202)
+  * Bump protobufjs, protocol-buffers-schema, authlib, and rustls-webpki to fix Dependabot alerts (#205-209)
   * Bump dompurify to 3.4.0 to fix Dependabot alerts (#203, #204)
+  * Bump pytest, cryptography, and opentelemetry-go SDK to fix Dependabot alerts (#198, #199, #200)
   * Bump vite, lodash, and lodash-es to fix Dependabot alerts
-  * Bump picomatch, brace-expansion, yaml, and requests to fix Dependabot alerts
   * Bump serialize-javascript, handlebars, cryptography, and Pygments to fix Dependabot alerts
-  * Bump pytest, cryptography, and opentelemetry-go SDK to fix Dependabot alerts
+  * Bump picomatch, brace-expansion, yaml, and requests to fix Dependabot alerts
 
 ## March 2026 - v0.23.0
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ To get started with Micromegas, please refer to the [Getting Started](https://mi
 
 ## Current Status & Roadmap
 
+### v0.24.0 (April 2026)
+* `parse_block` table UDF for generic block inspection with transit-to-JSONB conversion
+* Unified diff output in `micromegas-screens plan`/`apply`
+* Flamechart WASD zoom fix for Chrome key-release edge cases
+* Sub-microsecond flamechart span durations in nanoseconds
+* Notebook variable URL desync and datasource revert fixes
+* DataFusion 52.5, `rand` 0.9 migration, pyarrow ^23
+* 20+ Dependabot security updates across Rust, Python, and JS dependencies
+
 ### v0.23.0 (March 2026)
 * JSONB array UDFs: `jsonb_array_elements` (UDTF) and `jsonb_array_length` (scalar)
 * CSV table provider with auto-discovery via `MICROMEGAS_STATIC_TABLES_URL`

--- a/analytics-web-app/package.json
+++ b/analytics-web-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytics-web-app",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/grafana/CHANGELOG.md
+++ b/grafana/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.24.0 (2026-04-17)
+
+Version sync release. Security fixes: upgrade opentelemetry-go SDK v1.43.0 (#198), protobufjs ^7.5.5 (#209), protocol-buffers-schema ^3.6.1 (#205), rustls-webpki 0.103.12 (#206, #207), dompurify 3.4.0 (#203, #204), vite, lodash, lodash-es, serialize-javascript, handlebars, picomatch.
+
 ## 0.23.0 (2026-03-26)
 
 Version sync release - no plugin-specific changes.

--- a/grafana/package.json
+++ b/grafana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micromegas-micromegas-datasource",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",

--- a/python/micromegas/pyproject.toml
+++ b/python/micromegas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "micromegas"
-version = "0.24.0"
+version = "0.25.0"
 description = "Python analytics client for the Micromegas observability platform"
 authors = ["Marc-Antoine Desroches <madesroches@gmail.com>"]
 homepage = "https://micromegas.info/"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "analytics-web-srv"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "arrow-ipc",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "flight-sql-srv"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "clap",
  "micromegas",
@@ -2644,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "http-gateway"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3325,7 +3325,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "arrow-flight",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-analytics"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "arrow-flight",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-auth"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-datafusion-extensions"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-derive-transit"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-ingestion"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3463,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-perfetto"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-proc-macros"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3485,7 +3485,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-telemetry"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3503,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-telemetry-sink"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-tracing"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-tracing-proc-macros"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3569,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-transit"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -5544,7 +5544,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "telemetry-admin"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-ingestion-srv"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6041,7 +6041,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uri-handler"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "micromegas",
@@ -6905,7 +6905,7 @@ dependencies = [
 
 [[package]]
 name = "write-perfetto"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 
 [workspace.package]
-version = "0.24.0"
+version = "0.25.0"
 edition = "2024"
 license = "Apache-2.0"
 homepage = "https://micromegas.info/"
@@ -16,16 +16,16 @@ keywords = ["observability", "telemetry", "analytics"]
 
 
 [workspace.dependencies]
-micromegas-analytics = { path = "analytics", version = "0.24.0" }
-micromegas-auth = { path = "auth", version = "0.24.0" }
-micromegas-datafusion-extensions = { path = "datafusion-extensions", version = "0.24.0" }
-micromegas-ingestion = { path = "ingestion", version = "0.24.0" }
-micromegas-proc-macros = { path = "micromegas-proc-macros", version = "0.24.0" }
-micromegas-telemetry = { path = "telemetry", version = "0.24.0" }
-micromegas-telemetry-sink = { path = "telemetry-sink", version = "0.24.0" }
-micromegas-tracing = { path = "tracing", version = "0.24.0", default-features = false }
-micromegas-transit = { path = "transit", version = "0.24.0" }
-micromegas-perfetto = { path = "perfetto", version = "0.24.0" }
+micromegas-analytics = { path = "analytics", version = "0.25.0" }
+micromegas-auth = { path = "auth", version = "0.25.0" }
+micromegas-datafusion-extensions = { path = "datafusion-extensions", version = "0.25.0" }
+micromegas-ingestion = { path = "ingestion", version = "0.25.0" }
+micromegas-proc-macros = { path = "micromegas-proc-macros", version = "0.25.0" }
+micromegas-telemetry = { path = "telemetry", version = "0.25.0" }
+micromegas-telemetry-sink = { path = "telemetry-sink", version = "0.25.0" }
+micromegas-tracing = { path = "tracing", version = "0.25.0", default-features = false }
+micromegas-transit = { path = "transit", version = "0.25.0" }
+micromegas-perfetto = { path = "perfetto", version = "0.25.0" }
 micromegas = { path = "public" }
 
 anyhow = "1.0"

--- a/rust/datafusion-wasm/Cargo.lock
+++ b/rust/datafusion-wasm/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-datafusion-extensions"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-datafusion-wasm"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -2343,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-derive-transit"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-telemetry"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-telemetry-sink"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-tracing"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-tracing-proc-macros"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-transit"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "lazy_static",

--- a/rust/datafusion-wasm/Cargo.toml
+++ b/rust/datafusion-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micromegas-datafusion-wasm"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2024"
 license = "Apache-2.0"
 homepage = "https://micromegas.info/"
@@ -19,9 +19,9 @@ arrow = { version = "57.3", default-features = false, features = ["ipc"] }
 chrono = { version = "0.4", default-features = false, features = ["wasmbind"] }
 datafusion = { version = "52.5", default-features = false, features = ["nested_expressions", "sql"] }
 getrandom = { version = "0.3", features = ["wasm_js"] }
-micromegas-datafusion-extensions = { path = "../datafusion-extensions", version = "0.24.0" }
-micromegas-telemetry-sink = { path = "../telemetry-sink", version = "0.24.0", default-features = false }
-micromegas-tracing = { path = "../tracing", version = "0.24.0", default-features = false }
+micromegas-datafusion-extensions = { path = "../datafusion-extensions", version = "0.25.0" }
+micromegas-telemetry-sink = { path = "../telemetry-sink", version = "0.25.0", default-features = false }
+micromegas-tracing = { path = "../tracing", version = "0.25.0", default-features = false }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 

--- a/rust/tracing/Cargo.toml
+++ b/rust/tracing/Cargo.toml
@@ -14,7 +14,7 @@ authors.workspace = true
 anyhow.workspace = true
 chrono = { workspace = true, features = ["wasmbind"] }
 lazy_static.workspace = true
-micromegas-tracing-proc-macros = { path = "./proc-macros", version = "^0.24" }
+micromegas-tracing-proc-macros = { path = "./proc-macros", version = "^0.25" }
 pin-project.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/rust/transit/Cargo.toml
+++ b/rust/transit/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 authors.workspace = true
 
 [dependencies]
-micromegas-derive-transit = { path = "derive", version = "^0.24" }
+micromegas-derive-transit = { path = "derive", version = "^0.25" }
 
 anyhow.workspace = true
 lazy_static.workspace = true

--- a/tasks/release_v0.24_plan.md
+++ b/tasks/release_v0.24_plan.md
@@ -1,0 +1,123 @@
+# Release Plan: Micromegas v0.24.0
+
+## Overview
+
+Release version 0.24.0 of Micromegas. This release features the `parse_block` table UDF, screens-as-code diff output, flamechart key-release fix, DataFusion 52.5, `rand` 0.9 migration, pyarrow ^23, and numerous Dependabot security updates. 19 commits since v0.23.0.
+
+## Current Status
+
+- **Version**: 0.24.0 (already bumped during v0.23.0 post-release)
+- **Last Release**: v0.23.0 (March 26, 2026)
+- **Branch**: release
+- **Commits since v0.23.0**: 19
+
+## New Crates in release.py
+
+None. No new published crates added since v0.23.0.
+
+## Pre-Release Checklist
+
+### 0. Verify release.py
+
+- [ ] No new crates to add — confirm
+
+### 1. Code Quality & Testing
+
+#### Rust Workspace (from `rust/` directory)
+- [ ] Run full CI pipeline: `python3 ../build/rust_ci.py`
+- [ ] WASM: `cd rust/datafusion-wasm && python3 build.py --test`
+
+#### Python Package (from `python/micromegas/` directory)
+- [ ] `poetry run black . --check`
+- [ ] `poetry run pytest`
+
+#### Grafana Plugin (from `grafana/` directory)
+- [ ] `yarn install`
+- [ ] `yarn lint:fix`
+- [ ] `yarn test:ci`
+- [ ] `yarn build`
+
+#### Analytics Web App (from `analytics-web-app/` directory)
+- [ ] `yarn install`
+- [ ] `yarn lint`
+- [ ] `yarn type-check`
+- [ ] `yarn test`
+- [ ] `yarn build`
+
+### 2. Version Verification
+
+- [ ] `rust/Cargo.toml` workspace version = 0.24.0
+- [ ] `rust/datafusion-wasm/Cargo.toml` version = 0.24.0
+- [ ] `python/micromegas/pyproject.toml` version = 0.24.0
+- [ ] `grafana/package.json` version = 0.24.0
+- [ ] `analytics-web-app/package.json` version = 0.24.0
+
+### 3. Documentation Updates
+
+- [ ] Update `CHANGELOG.md` — move Unreleased to `## April 2026 - v0.24.0`
+- [ ] Update `grafana/CHANGELOG.md` with version sync entry
+- [ ] Update `README.md` roadmap with v0.24.0 highlights
+
+### 4. Grafana Plugin Preparation
+
+- [ ] Build plugin archive: `./build-plugin.sh` (from `grafana/`)
+
+### 5. Git Preparation
+
+- [ ] Commit changelog and doc updates
+- [ ] Create release tag: `git tag v0.24.0`
+- [ ] Create grafana tag: `git tag grafana-v0.24.0`
+- [ ] Push: `git push origin release && git push origin v0.24.0 grafana-v0.24.0`
+
+## Release Process
+
+### Phase 1: Rust Crates
+
+```bash
+cd /home/mad/micromegas/build
+python3 release.py
+```
+
+### Phase 2: Python Library
+
+```bash
+cd /home/mad/micromegas/python/micromegas
+poetry build
+poetry publish
+```
+
+### Phase 3: GitHub & Grafana Release
+
+```bash
+gh release create v0.24.0 \
+  --title "Micromegas v0.24.0" \
+  --notes "See CHANGELOG.md for details" \
+  grafana/micromegas-micromegas-datasource.zip
+```
+
+### Phase 4: Post-Release Version Bump to 0.25.0
+
+#### Rust
+- `rust/Cargo.toml`: workspace version and all dependency versions to 0.25.0
+- `rust/tracing/Cargo.toml`: proc-macros dep to `^0.25`
+- `rust/transit/Cargo.toml`: derive-transit dep to `^0.25`
+- `rust/datafusion-wasm/Cargo.toml`: version to 0.25.0, all micromegas deps to `^0.25`
+
+#### Other packages
+- `python/micromegas/pyproject.toml`: 0.25.0
+- `grafana/package.json`: 0.25.0
+- `analytics-web-app/package.json`: 0.25.0
+
+#### Lock files
+- `cargo update` (from `rust/`)
+- `yarn install` (from `grafana/`)
+- `yarn install` (from `analytics-web-app/`)
+- `cd rust/datafusion-wasm && python3 build.py --test`
+
+- [ ] Commit version bump
+- [ ] Push to release branch
+
+### Phase 5: Merge to Main
+
+- [ ] Create PR from release to main
+- [ ] Merge after CI passes


### PR DESCRIPTION
## Summary

- Update changelog, README roadmap, and grafana changelog for v0.24.0
- Post-release version bump to 0.25.0 (all Rust crates, Python, Grafana, analytics web app)

## Published

- 14 Rust crates to crates.io
- Python package to PyPI
- GitHub release with Grafana plugin: https://github.com/madesroches/micromegas/releases/tag/v0.24.0