### PR TITLE
Tighten Biggest Difference / What This Unlocks slides

### DIFF
--- a/doc/intro-micromegas/src/slides/presentation.md
+++ b/doc/intro-micromegas/src/slides/presentation.md
@@ -201,25 +201,19 @@ graph LR
 
 <div style="font-size: 0.65em;">
 
-Modern observability stacks share an unstated assumption:
+Modern observability stacks share an unstated assumption — events are <strong>expensive</strong>:
 
 <ul>
-<li class="fragment">Events are <strong>expensive</strong> — pay per event, allocate/format/serialize per event, sampling mandatory at scale</li>
-<li class="fragment">Tuned for <strong>service-level</strong> telemetry at ~1k events/sec/process</li>
-<li class="fragment">Always-on detail tracing is <strong>infeasible</strong> in production</li>
+<li class="fragment">Allocate, format, serialize per event</li>
+<li class="fragment">Sampling is mandatory at scale</li>
+<li class="fragment">Tuned for service-level telemetry, not high-frequency capture</li>
 </ul>
 
-<p class="fragment" style="margin-top: 1em;">Micromegas was built on the opposite assumption:</p>
-
-<ul>
-<li class="fragment">Events should be <strong>cheap enough to never sample by default</strong></li>
-<li class="fragment">Designed for <strong>60k–200k events/sec/process</strong>, sub-microsecond spans</li>
-<li class="fragment">Always-on tracing in production is the <strong>default</strong>, not a special mode</li>
-</ul>
+<p class="fragment" style="margin-top: 1em;">Micromegas was built on the opposite assumption — events should be <strong>cheap</strong>.</p>
 
 </div>
 
-<p class="fragment" style="margin-top: 1em; font-size: 0.8em;">Same goals. Very different cost model. Everything else follows from that.</p>
+<p class="fragment" style="margin-top: 1.5em; font-size: 0.8em;">Same goals. Very different cost model. Everything else follows from that.</p>
 
 ---
 
@@ -242,9 +236,9 @@ Modern observability stacks share an unstated assumption:
 ## What This Unlocks
 
 <ul>
-<li class="fragment"><strong>100k events/second per process</strong> without breaking the host app</li>
+<li class="fragment"><strong>60k–200k events/second per process</strong> without breaking the host app</li>
 <li class="fragment"><strong>Always-on tracing</strong> in production — not just in dev or under flag</li>
-<li class="fragment">Sub-microsecond span durations are visible — you can see what your inner loop is doing</li>
+<li class="fragment">Sub-microsecond spans are visible — you can see what your inner loop is doing</li>
 </ul>
 
 --


### PR DESCRIPTION
## Summary

- Slide 11 ("The Biggest Difference") now stays on the philosophical assumption flip — events are expensive vs. events are cheap. Removed the concrete throughputs, the "sub-microsecond spans" claim, and the "always-on tracing is the default" line, since slide 13 was already restating all of them.
- Slide 13 ("What This Unlocks") now owns the concrete payoff. Bumped "100k events/second" to "60k–200k events/second" to match what slide 11 had been claiming and what the platform actually targets.
- Slide 12 ("How: Sub-microsecond Instrumentation") untouched — it's the mechanism and didn't overlap.

Follow-up polish to #1026; the deck is still in `Unreleased` so no separate changelog entry.

## Test plan

- [ ] `yarn build` in `doc/intro-micromegas/` succeeds (verified locally).
- [ ] After merge, https://micromegas.info/intro-micromegas/ renders slides 11–13 without the removed bullets and with the updated 60k–200k figure on slide 13.