### PR TITLE
Fix multi-series line chart and add adaptive scaling for bits/s, bytes/s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This file documents the historical progress of the Micromegas project. For curre
   * Add `net_spans` JIT view materializing Connection/Object/Property/RPC bandwidth spans with cumulative bit offsets
 * **Web App:**
   * Extend flame graph cell to render bit-axis spans for `net_spans` and add bit-unit support to XYChart
+  * Apply adaptive scaling to `bits/s` and `bytes/s` chart axes
+  * Fix multi-series line chart rendering only points when series have sparsely-aligned X values
   * Resolve macros in chart series labels and chart cell titles
   * Defer notebook markdown cell render until sequential execution reaches it, preventing stale macro output on first paint (#1023)
 * **Python:**

--- a/analytics-web-app/src/components/XYChart.tsx
+++ b/analytics-web-app/src/components/XYChart.tsx
@@ -670,6 +670,7 @@ export function XYChart({
             : undefined,
           points: { show: chartType !== 'bar' },
           show: seriesVisibility ? seriesVisibility[i] : true,
+          spanGaps: chartType === 'line',
         })
 
         seriesInfoForTooltip.push({ label: s.label, unit: s.unit, color })

--- a/analytics-web-app/src/components/XYChart.tsx
+++ b/analytics-web-app/src/components/XYChart.tsx
@@ -67,7 +67,7 @@ function formatValue(
     return formatAdaptiveTime(value, adaptiveTimeUnit, abbreviated)
   }
 
-  // Size units - use adaptive formatting
+  // Size units (incl. bytes/s) - use adaptive formatting
   if (isSizeUnit(unit)) {
     const adaptive = getAdaptiveSizeUnit(value, unit)
     const displayValue = value * adaptive.conversionFactor
@@ -75,28 +75,12 @@ function formatValue(
     return displayValue.toFixed(decimals) + ' ' + adaptive.abbrev
   }
 
-  // Rate units - bytes per second (uses same adaptive logic)
-  if (unit === 'bytes/s') {
-    const adaptive = getAdaptiveSizeUnit(value, 'bytes')
-    const displayValue = value * adaptive.conversionFactor
-    const decimals = adaptive.unit === 'bytes' ? 0 : 1
-    return displayValue.toFixed(decimals) + ' ' + adaptive.abbrev + '/s'
-  }
-
-  // Bit units - networking, decimal scaling
+  // Bit units (incl. bits/s) - networking, decimal scaling
   if (isBitUnit(unit)) {
     const adaptive = getAdaptiveBitUnit(value, unit)
     const displayValue = value * adaptive.conversionFactor
     const decimals = adaptive.unit === 'bits' ? 0 : 1
     return displayValue.toFixed(decimals) + ' ' + adaptive.abbrev
-  }
-
-  // Rate units - bits per second
-  if (unit === 'bits/s') {
-    const adaptive = getAdaptiveBitUnit(value, 'bits')
-    const displayValue = value * adaptive.conversionFactor
-    const decimals = adaptive.unit === 'bits' ? 0 : 1
-    return displayValue.toFixed(decimals) + ' ' + adaptive.abbrev + '/s'
   }
 
   // Other units

--- a/analytics-web-app/src/lib/__tests__/units.test.ts
+++ b/analytics-web-app/src/lib/__tests__/units.test.ts
@@ -1,4 +1,4 @@
-import { normalizeUnit, UNIT_ALIASES, TIME_UNIT_NAMES, SIZE_UNIT_NAMES, isSizeUnit, getAdaptiveSizeUnit } from '../units'
+import { normalizeUnit, UNIT_ALIASES, TIME_UNIT_NAMES, SIZE_UNIT_NAMES, isSizeUnit, getAdaptiveSizeUnit, isBitUnit, getAdaptiveBitUnit } from '../units'
 
 describe('normalizeUnit', () => {
   describe('time units', () => {
@@ -260,6 +260,91 @@ describe('getAdaptiveSizeUnit', () => {
       const result = getAdaptiveSizeUnit(5 * GB, 'Bytes')
       expect(result.unit).toBe('gigabytes')
       expect(result.abbrev).toBe('GB')
+    })
+  })
+
+  describe('bytes/s rate', () => {
+    it('scales bytes/s and appends /s suffix', () => {
+      const result = getAdaptiveSizeUnit(5 * MB, 'bytes/s')
+      expect(result.unit).toBe('megabytes')
+      expect(result.abbrev).toBe('MB/s')
+      expect(result.conversionFactor).toBe(1 / MB)
+    })
+
+    it('stays in B/s for small rates', () => {
+      const result = getAdaptiveSizeUnit(500, 'bytes/s')
+      expect(result.abbrev).toBe('B/s')
+      expect(result.conversionFactor).toBe(1)
+    })
+  })
+})
+
+describe('isBitUnit', () => {
+  it('recognizes canonical bit units', () => {
+    expect(isBitUnit('bits')).toBe(true)
+    expect(isBitUnit('kilobits')).toBe(true)
+    expect(isBitUnit('megabits')).toBe(true)
+    expect(isBitUnit('gigabits')).toBe(true)
+    expect(isBitUnit('terabits')).toBe(true)
+  })
+
+  it('recognizes the bits/s rate variant', () => {
+    expect(isBitUnit('bits/s')).toBe(true)
+    expect(isBitUnit('bps')).toBe(true)
+    expect(isBitUnit('bit/s')).toBe(true)
+  })
+
+  it('rejects non-bit units', () => {
+    expect(isBitUnit('bytes')).toBe(false)
+    expect(isBitUnit('seconds')).toBe(false)
+  })
+})
+
+describe('isSizeUnit bytes/s', () => {
+  it('recognizes the bytes/s rate variant', () => {
+    expect(isSizeUnit('bytes/s')).toBe(true)
+    expect(isSizeUnit('B/s')).toBe(true)
+    expect(isSizeUnit('BytesPerSecond')).toBe(true)
+  })
+})
+
+describe('getAdaptiveBitUnit', () => {
+  const KBIT = 1000
+  const MBIT = KBIT * 1000
+  const GBIT = MBIT * 1000
+
+  it('stays in bits for small values', () => {
+    const result = getAdaptiveBitUnit(500, 'bits')
+    expect(result.unit).toBe('bits')
+    expect(result.abbrev).toBe('bit')
+    expect(result.conversionFactor).toBe(1)
+  })
+
+  it('scales to Mbit for values around 5,000,000 bits', () => {
+    const result = getAdaptiveBitUnit(5 * MBIT, 'bits')
+    expect(result.unit).toBe('megabits')
+    expect(result.abbrev).toBe('Mbit')
+    expect(result.conversionFactor).toBe(1 / MBIT)
+  })
+
+  it('scales to Gbit for values >= 1 Gbit', () => {
+    const result = getAdaptiveBitUnit(2 * GBIT, 'bits')
+    expect(result.unit).toBe('gigabits')
+    expect(result.abbrev).toBe('Gbit')
+  })
+
+  describe('bits/s rate', () => {
+    it('scales bits/s and appends /s suffix', () => {
+      const result = getAdaptiveBitUnit(5 * MBIT, 'bits/s')
+      expect(result.unit).toBe('megabits')
+      expect(result.abbrev).toBe('Mbit/s')
+      expect(result.conversionFactor).toBe(1 / MBIT)
+    })
+
+    it('uses kbit/s for kilobit-range rates', () => {
+      const result = getAdaptiveBitUnit(50 * KBIT, 'bits/s')
+      expect(result.abbrev).toBe('kbit/s')
+      expect(result.conversionFactor).toBe(1 / KBIT)
     })
   })
 })

--- a/analytics-web-app/src/lib/units.ts
+++ b/analytics-web-app/src/lib/units.ts
@@ -114,10 +114,12 @@ export const SIZE_UNIT_NAMES = new Set([
 ])
 
 /**
- * Check if a unit (or its alias) is a size-based unit
+ * Check if a unit (or its alias) is a size-based unit.
+ * Includes the `bytes/s` rate variant so adaptive scaling works on bandwidth axes.
  */
 export function isSizeUnit(unit: string): boolean {
-  return SIZE_UNIT_NAMES.has(normalizeUnit(unit))
+  const normalized = normalizeUnit(unit)
+  return SIZE_UNIT_NAMES.has(normalized) || normalized === 'bytes/s'
 }
 
 /**
@@ -132,10 +134,12 @@ export const BIT_UNIT_NAMES = new Set([
 ])
 
 /**
- * Check if a unit (or its alias) is a bit-based unit
+ * Check if a unit (or its alias) is a bit-based unit.
+ * Includes the `bits/s` rate variant so adaptive scaling works on bandwidth axes.
  */
 export function isBitUnit(unit: string): boolean {
-  return BIT_UNIT_NAMES.has(normalizeUnit(unit))
+  const normalized = normalizeUnit(unit)
+  return BIT_UNIT_NAMES.has(normalized) || normalized === 'bits/s'
 }
 
 export type SizeUnit = 'bytes' | 'kilobytes' | 'megabytes' | 'gigabytes' | 'terabytes'
@@ -193,8 +197,10 @@ export function getAdaptiveSizeUnit(
   referenceValue: number,
   originalUnit: SizeUnit | string
 ): AdaptiveSizeUnit {
-  const normalizedUnit = normalizeUnit(originalUnit) as SizeUnit
-  const refBytes = toBytes(referenceValue, normalizedUnit)
+  const normalized = normalizeUnit(originalUnit)
+  const isRate = normalized === 'bytes/s'
+  const baseUnit = (isRate ? 'bytes' : normalized) as SizeUnit
+  const refBytes = toBytes(referenceValue, baseUnit)
 
   // Find the best unit where the value is >= 1 (prefer larger units)
   let bestUnit = SIZE_UNITS[0]
@@ -208,13 +214,13 @@ export function getAdaptiveSizeUnit(
   }
 
   // Calculate the conversion factor from original unit to best unit
-  const originalFactor = getSizeUnitFactor(normalizedUnit)
+  const originalFactor = getSizeUnitFactor(baseUnit)
   const bestFactor = bestUnit.factor
   const conversionFactor = originalFactor / bestFactor
 
   return {
     unit: bestUnit.unit,
-    abbrev: bestUnit.abbrev,
+    abbrev: isRate ? bestUnit.abbrev + '/s' : bestUnit.abbrev,
     conversionFactor,
   }
 }
@@ -264,8 +270,10 @@ export function getAdaptiveBitUnit(
   referenceValue: number,
   originalUnit: BitUnit | string
 ): AdaptiveBitUnit {
-  const normalizedUnit = normalizeUnit(originalUnit) as BitUnit
-  const refBits = toBits(referenceValue, normalizedUnit)
+  const normalized = normalizeUnit(originalUnit)
+  const isRate = normalized === 'bits/s'
+  const baseUnit = (isRate ? 'bits' : normalized) as BitUnit
+  const refBits = toBits(referenceValue, baseUnit)
 
   let bestUnit = BIT_UNITS[0]
   for (let i = BIT_UNITS.length - 1; i >= 0; i--) {
@@ -277,12 +285,12 @@ export function getAdaptiveBitUnit(
     }
   }
 
-  const originalFactor = getBitUnitFactor(normalizedUnit)
+  const originalFactor = getBitUnitFactor(baseUnit)
   const conversionFactor = originalFactor / bestUnit.factor
 
   return {
     unit: bestUnit.unit,
-    abbrev: bestUnit.abbrev,
+    abbrev: isRate ? bestUnit.abbrev + '/s' : bestUnit.abbrev,
     conversionFactor,
   }
 }


### PR DESCRIPTION
## Summary
* Adaptive scaling for `bits/s` and `bytes/s` chart axes — fold the rate variants into `isSizeUnit` / `isBitUnit` and have `getAdaptiveSizeUnit` / `getAdaptiveBitUnit` detect the rate, scale on the base unit, and append `/s` to the abbreviation. Removes the previously duplicated rate-only branches in `XYChart.formatValue`.
* Fix multi-series line chart rendering only points (visible on the net-perf screen). The multi-series path builds a union of X values across series and fills `null` everywhere a series doesn't own a point; uPlot's default `spanGaps: false` was breaking the line at every null. Set `spanGaps: chartType === 'line'` on each series so lines connect through gaps. Bar mode is unaffected.
* Add unit tests covering the new rate-aware `isSizeUnit` / `isBitUnit` and the rate paths in `getAdaptiveSizeUnit` / `getAdaptiveBitUnit`.

## Test plan
* `yarn test src/lib/__tests__/units.test.ts` — 46 tests pass, including the new `bytes/s` / `bits/s` cases
* `yarn lint` — clean
* `yarn type-check` — clean
* Manual: open the net-perf screen, verify multi-series bandwidth chart draws connected lines (not just points) and that the Y-axis label adapts to `KB/s`, `MB/s`, `Mbit/s`, etc. depending on the data range