### PR TITLE
Bump dependencies for 6 Dependabot alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This file documents the historical progress of the Micromegas project. For curre
 * **Security:**
   * Bump rustls-webpki, rand, and uuid to fix Dependabot alerts (#210-213)
   * Bump postcss and uuid to fix Dependabot alerts (#214-221)
+  * Bump urllib3, fast-uri, @babel/plugin-transform-modules-systemjs, and apache/thrift to fix Dependabot alerts (#222, #225-229)
 
 ## April 2026 - v0.24.0
 

--- a/analytics-web-app/package.json
+++ b/analytics-web-app/package.json
@@ -47,6 +47,7 @@
     "uplot": "^1.6.32"
   },
   "resolutions": {
+    "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "ajv": "6.14.0",
     "baseline-browser-mapping": "^2.9.16",
     "flatted": "^3.4.2",

--- a/analytics-web-app/yarn.lock
+++ b/analytics-web-app/yarn.lock
@@ -601,10 +601,10 @@
     "@babel/helper-module-transforms" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"
 
-"@babel/plugin-transform-modules-systemjs@^7.29.0":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz#e458a95a17807c415924106a3ff188a3b8dee964"
-  integrity sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==
+"@babel/plugin-transform-modules-systemjs@^7.29.0", "@babel/plugin-transform-modules-systemjs@^7.29.4":
+  version "7.29.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz#f621105da99919c15cf4bde6fcc7346ef95e7b20"
+  integrity sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==
   dependencies:
     "@babel/helper-module-transforms" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"

--- a/grafana/go.mod
+++ b/grafana/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/apache/arrow-go/v18 v18.4.1 // indirect
-	github.com/apache/thrift v0.22.0 // indirect
+	github.com/apache/thrift v0.23.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/grafana/go.sum
+++ b/grafana/go.sum
@@ -9,8 +9,8 @@ github.com/apache/arrow-go/v18 v18.4.1 h1:q/jVkBWCJOB9reDgaIZIdruLQUb1kbkvOnOFez
 github.com/apache/arrow-go/v18 v18.4.1/go.mod h1:tLyFubsAl17bvFdUAy24bsSvA/6ww95Iqi67fTpGu3E=
 github.com/apache/arrow/go/v12 v12.0.0-20230215210516-4550c9b35e67 h1:79oDv340NynRpDXgAwPaxsNLiEiAWmjVV/A/QXt7Gjg=
 github.com/apache/arrow/go/v12 v12.0.0-20230215210516-4550c9b35e67/go.mod h1:qwJWRMGOu/SUTlFiQBgCjtOoxYqdG2KqXiDB3+e7BNA=
-github.com/apache/thrift v0.22.0 h1:r7mTJdj51TMDe6RtcmNdQxgn9XcyfGDOzegMDRg47uc=
-github.com/apache/thrift v0.22.0/go.mod h1:1e7J/O1Ae6ZQMTYdy9xa3w9k+XHWPfRvdPyJeynQ+/g=
+github.com/apache/thrift v0.23.0 h1:wKR6YnefQSEnxpEfmgTPuJibNG4bF0p2TK34tHLWi3s=
+github.com/apache/thrift v0.23.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "diff": "^8.0.3",
     "dompurify": "^3.4.0",
     "eslint/ajv": "6.14.0",
+    "fast-uri": "^3.1.2",
     "flatted": "^3.4.2",
     "immutable": "^5.1.5",
     "js-yaml": "^4.1.1",

--- a/python/micromegas/poetry.lock
+++ b/python/micromegas/poetry.lock
@@ -1075,14 +1075,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4304,10 +4304,10 @@ fast-shallow-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz#d4dcaf6472440dcefa6f88b98e3251e27f25628b"
   integrity sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==
 
-fast-uri@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
-  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+fast-uri@^3.0.1, fast-uri@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fast_array_intersect@1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Summary
- Bump `urllib3` 2.6.3 → 2.7.0 in `python/micromegas/poetry.lock` (#228, #229)
- Bump `@babel/plugin-transform-modules-systemjs` 7.29.0 → 7.29.4 in `analytics-web-app/yarn.lock` via resolution (#227)
- Bump `fast-uri` 3.1.0 → 3.1.2 in root `yarn.lock` via resolution (#225, #226)
- Bump `github.com/apache/thrift` 0.22.0 → 0.23.0 in `grafana/go.mod` (#222)

Rust `thrift` alerts (#223, #224) are not addressed here — latest crates.io version (0.17.0) is below the advisory's `≤ 0.22.0` range and no patched crate has been published yet. Per project policy these remain open until upstream ships a fix.

## Test plan
- [x] `poetry run pytest` — 53 unit tests pass; integration failures are pre-existing (require local flight-sql)
- [x] `go build ./... && go test ./...` in `grafana/` — passes with thrift 0.23.0
- [x] `yarn lint` in `analytics-web-app/` — clean (only pre-existing warnings)
- [x] `yarn workspace micromegas-micromegas-datasource lint` — clean
- [x] `yarn build` in `analytics-web-app/` — succeeds