### PR TITLE
Map: remove groundSnap and heightOffset options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This file documents the historical progress of the Micromegas project. For curre
   * Add map notebook cell rendering spatial events on a GLB model with optional heatmap overlay (#1033)
   * Convert map cell to native UE coordinates (Z-up) with GLB-embedded perspective camera, `MM_ambient_light`, and Neutral tone mapping; replace "Fit to data" with GLB-camera-seeded Reset (#1036)
   * Polish map interaction: cursor-anchored wheel zoom, right-mouse-drag orbit re-anchor, fix marker overlay visibility/picking and heatmap orientation, surface GLB contract errors in-cell (#1036)
+  * Remove map cell `groundSnap` and `heightOffset` options; markers render at their native `(x, y, z)` coordinates
   * Add `--remote-backend` flag to `start_analytics_web.py` for hybrid local-frontend + remote-backend setup (#1033)
 * **Python:**
   * Switch `bulk_ingest` to accept `pyarrow.Table` directly for native pass-through of struct/list/binary columns

--- a/analytics-web-app/src/components/map/MapViewer.tsx
+++ b/analytics-web-app/src/components/map/MapViewer.tsx
@@ -29,9 +29,7 @@ interface MapViewerProps {
   heatmapIntensity: number
   markerColor?: string
   markerSize?: number
-  groundSnap?: boolean
   resetViewTrigger?: number
-  heightOffset?: number
 }
 
 function LoadingIndicator() {
@@ -102,9 +100,6 @@ interface InstancedMarkersProps {
   onSelect: (event: MapEvent | null) => void
   markerColor?: string
   markerSize?: number
-  heightOffset?: number
-  mapScene?: THREE.Object3D | null
-  groundSnap?: boolean
 }
 
 const DEFAULT_MARKER_COLOR = '#bf360c'
@@ -119,53 +114,11 @@ function InstancedMarkers({
   onSelect,
   markerColor = DEFAULT_MARKER_COLOR,
   markerSize = DEFAULT_MARKER_SIZE,
-  heightOffset = 0,
-  mapScene = null,
-  groundSnap = false,
 }: InstancedMarkersProps) {
   const meshRef = useRef<THREE.InstancedMesh>(null)
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
 
   const tempObject = useMemo(() => new THREE.Object3D(), [])
-
-  const raycaster = useMemo(() => new THREE.Raycaster(), [])
-  const rayOrigin = useMemo(() => new THREE.Vector3(), [])
-  const rayDirection = useMemo(() => new THREE.Vector3(0, 0, -1), [])
-
-  const snappedPositions = useMemo(() => {
-    if (!groundSnap || !mapScene || events.length === 0) {
-      return null
-    }
-
-    const positions: { x: number; y: number; z: number }[] = []
-
-    const mapBox = new THREE.Box3().setFromObject(mapScene)
-    const rayStartHeight = mapBox.max.z + 1000
-
-    events.forEach((event) => {
-      rayOrigin.set(event.x, event.y, rayStartHeight)
-      raycaster.set(rayOrigin, rayDirection)
-
-      const intersects = raycaster.intersectObject(mapScene, true)
-
-      if (intersects.length > 0) {
-        const hit = intersects[0]
-        positions.push({
-          x: event.x,
-          y: event.y,
-          z: hit.point.z + heightOffset
-        })
-      } else {
-        positions.push({
-          x: event.x,
-          y: event.y,
-          z: event.z + heightOffset
-        })
-      }
-    })
-
-    return positions
-  }, [groundSnap, mapScene, events, raycaster, rayOrigin, rayDirection, heightOffset])
 
   const geometry = useMemo(() => new THREE.SphereGeometry(1, 16, 16), [])
   // Overlay semantics: markers should remain visible regardless of where
@@ -203,10 +156,7 @@ function InstancedMarkers({
       const finalScale = markerSize * scaleMultiplier
 
       const event = events[i]
-      const pos = snappedPositions
-        ? snappedPositions[i]
-        : { x: event.x, y: event.y, z: event.z + heightOffset }
-      tempObject.position.set(pos.x, pos.y, pos.z)
+      tempObject.position.set(event.x, event.y, event.z)
       tempObject.scale.setScalar(finalScale)
       tempObject.updateMatrix()
       mesh.setMatrixAt(i, tempObject.matrix)
@@ -221,7 +171,7 @@ function InstancedMarkers({
     mesh.computeBoundingSphere()
     mesh.instanceMatrix.needsUpdate = true
     attr.needsUpdate = true
-  }, [events, selectedIndex, hoveredIndex, tempObject, markerColor, markerSize, heightOffset, snappedPositions])
+  }, [events, selectedIndex, hoveredIndex, tempObject, markerColor, markerSize])
 
   useEffect(() => {
     return () => {
@@ -837,9 +787,7 @@ export function MapViewer({
   heatmapIntensity,
   markerColor,
   markerSize,
-  groundSnap = false,
   resetViewTrigger = 0,
-  heightOffset: heightOffsetProp,
 }: MapViewerProps) {
   const [mapBounds, setMapBounds] = useState<THREE.Box3 | null>(null)
   const [mapScene, setMapScene] = useState<THREE.Object3D | null>(null)
@@ -884,22 +832,10 @@ export function MapViewer({
     return markerSize ?? DEFAULT_MARKER_SIZE
   }, [markerSize, mapBounds])
 
-  const heightOffset = useMemo(() => {
-    if (mapBounds) {
-      const size = mapBounds.getSize(new THREE.Vector3())
-      const extent = Math.max(size.x, size.y)
-      if (heightOffsetProp !== undefined) {
-        return heightOffsetProp * extent * 0.01
-      }
-      return extent * 0.005
-    }
-    return heightOffsetProp ?? 50
-  }, [mapBounds, heightOffsetProp])
-
   // Clear loaded-GLB state whenever mapUrl changes (including the A→B case
-  // where both are truthy). Without this, InstancedMarkers' ground-snap
-  // raycasts against the previous scene during Suspense, since the markers
-  // render as a sibling of the suspended MapModel, not a child.
+  // where both are truthy), so transient consumers (UnrealCameraController,
+  // marker sizing from mapBounds) don't see stale scene state during the
+  // Suspense gap.
   //
   // Done as a render-phase state derivation rather than an effect: an
   // effect-based clear races against MapModel's load effect when the new GLB
@@ -972,9 +908,6 @@ export function MapViewer({
           onSelect={onSelectEvent}
           markerColor={markerColor}
           markerSize={effectiveMarkerSize}
-          heightOffset={heightOffset}
-          mapScene={mapScene}
-          groundSnap={groundSnap}
         />
       </Canvas>
 

--- a/analytics-web-app/src/lib/screen-renderers/cells/MapCell.tsx
+++ b/analytics-web-app/src/lib/screen-renderers/cells/MapCell.tsx
@@ -110,8 +110,6 @@ export function MapCell({ data, status, options, onOptionsChange }: CellRenderer
   const heatmapIntensity = (options?.heatmapIntensity as number) ?? 0.5
   const markerColor = (options?.markerColor as string) ?? '#bf360c'
   const markerSize = (options?.markerSize as number) ?? 10
-  const groundSnap = (options?.groundSnap as boolean) ?? false
-  const heightOffset = options?.heightOffset as number | undefined
 
   const handleSelectEvent = useCallback((event: MapEvent | null) => {
     setSelectedEvent(event)
@@ -179,8 +177,6 @@ export function MapCell({ data, status, options, onOptionsChange }: CellRenderer
         heatmapIntensity={heatmapIntensity}
         markerColor={markerColor}
         markerSize={markerSize}
-        groundSnap={groundSnap}
-        heightOffset={heightOffset}
         resetViewTrigger={resetViewTrigger}
       />
 
@@ -350,32 +346,6 @@ export function MapCellEditor({
           </span>
         </div>
 
-        {/* Ground snap */}
-        <div className="flex items-center gap-2">
-          <label className="text-xs text-theme-text-secondary w-24 shrink-0">Ground Snap</label>
-          <input
-            type="checkbox"
-            checked={(mapConfig.options?.groundSnap as boolean) ?? false}
-            onChange={(e) => updateOption('groundSnap', e.target.checked)}
-          />
-        </div>
-
-        {/* Height offset */}
-        <div className="flex items-center gap-2">
-          <label className="text-xs text-theme-text-secondary w-24 shrink-0">Height Offset</label>
-          <input
-            type="range"
-            min="-5"
-            max="10"
-            step="0.1"
-            value={(mapConfig.options?.heightOffset as number) ?? 0.5}
-            onChange={(e) => updateOption('heightOffset', Number(e.target.value))}
-            className="w-32 accent-accent-link"
-          />
-          <span className="text-xs text-theme-text-muted w-8">
-            {(mapConfig.options?.heightOffset as number) ?? 0.5}
-          </span>
-        </div>
       </div>
 
       <AvailableVariablesPanel
@@ -413,7 +383,6 @@ export const mapMetadata: CellTypeMetadata = {
       showHeatmap: false,
       markerColor: '#bf360c',
       markerSize: 10,
-      groundSnap: false,
     },
   }),
 

--- a/analytics-web-app/src/lib/screen-renderers/cells/MapCell.tsx
+++ b/analytics-web-app/src/lib/screen-renderers/cells/MapCell.tsx
@@ -345,7 +345,6 @@ export function MapCellEditor({
             {(mapConfig.options?.markerSize as number) ?? 10}
           </span>
         </div>
-
       </div>
 
       <AvailableVariablesPanel

--- a/mkdocs/docs/web-app/notebooks/cell-types.md
+++ b/mkdocs/docs/web-app/notebooks/cell-types.md
@@ -548,8 +548,6 @@ All columns beyond the reserved names (`time`, `x`, `y`, `z`, `process_id`) are 
 | `heatmapIntensity` | number | `0.5` | Heatmap opacity (0.1–1.0) |
 | `markerColor` | string | `#bf360c` | Marker color (hex) |
 | `markerSize` | number | `10` | Marker size — scaled proportionally to the map extent |
-| `groundSnap` | boolean | `false` | Raycast markers onto the map mesh surface |
-| `heightOffset` | number | `0.5` | Vertical offset above the surface (-5 to 10) — scaled proportionally to the map extent |
 
 **Map catalog:**
 
@@ -591,7 +589,6 @@ GLBs missing the camera log a console error and fall back to the default seed fr
 **Features:**
 
 - Instanced rendering — handles thousands of markers efficiently
-- Ground snap — raycasts each marker onto the mesh surface for accurate placement
 - Heatmap overlay — 2D canvas-based density visualization
 - Interactive markers — click to select, hover to highlight
 - Camera controls — left-drag to pan, right-drag to orbit, scroll to zoom, WASD to fly

--- a/mkdocs/docs/web-app/notebooks/cell-types.md
+++ b/mkdocs/docs/web-app/notebooks/cell-types.md
@@ -511,7 +511,7 @@ WHERE m.value > t.warn_threshold
 
 ## ![Map](../../assets/images/cell-icons/map.svg){ .cell-icon } Map
 
-3D map visualization that plots spatial events on a GLB model with optional heatmap overlay. Events are rendered as instanced sphere markers with ground-snap raycasting for accurate surface placement.
+3D map visualization that plots spatial events on a GLB model with optional heatmap overlay. Events are rendered as instanced sphere markers at their native `(x, y, z)` coordinates.
 
 **Configuration:**
 


### PR DESCRIPTION
## Summary

* Drop `groundSnap` and `heightOffset` from `MapViewer` and `MapCell` — markers now render unconditionally at their native `(x, y, z)` coordinates.
* Remove the ground-snap raycasting machinery from `InstancedMarkers` (raycaster, `mapBox` ray origin/direction, `snappedPositions` memo) and the `mapBounds`-driven `heightOffset` auto-scale from `MapViewer`.
* Strip the "Ground Snap" checkbox and "Height Offset" slider from `MapCellEditor`; drop the corresponding default from `createDefaultOptions`.
* Update `cell-types.md` to reflect the simplified rendering model and trim the now-stale Suspense-gap comment to mention only the still-live consumers (`UnrealCameraController`, marker sizing).

## Test plan

* `yarn lint`, `yarn type-check`, `yarn test` (899 tests) all green from `analytics-web-app/`.
* Verified no remaining references to the removed names anywhere in `analytics-web-app/src/`, `mkdocs/docs/`, `rust/`, or `python/micromegas/`.
* Persisted notebook cells that still carry `groundSnap` / `heightOffset` in their options remain valid: options are read with `?? default` and the renderer no longer touches these keys.