### PR TITLE
Map: simplify navigation and remove heatmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@ This file documents the historical progress of the Micromegas project. For curre
   * Fix multi-series line chart rendering only points when series have sparsely-aligned X values
   * Resolve macros in chart series labels and chart cell titles
   * Defer notebook markdown cell render until sequential execution reaches it, preventing stale macro output on first paint (#1023)
-  * Add map notebook cell rendering spatial events on a GLB model with optional heatmap overlay (#1033)
+  * Add map notebook cell rendering spatial events on a GLB model (#1033)
   * Convert map cell to native UE coordinates (Z-up) with GLB-embedded perspective camera, `MM_ambient_light`, and Neutral tone mapping; replace "Fit to data" with GLB-camera-seeded Reset (#1036)
-  * Polish map interaction: cursor-anchored wheel zoom, right-mouse-drag orbit re-anchor, fix marker overlay visibility/picking and heatmap orientation, surface GLB contract errors in-cell (#1036)
+  * Polish map interaction: cursor-anchored wheel zoom, right-mouse-drag orbit re-anchor, fix marker overlay visibility/picking, surface GLB contract errors in-cell (#1036)
   * Remove map cell `groundSnap` and `heightOffset` options; markers render at their native `(x, y, z)` coordinates
+  * Simplify map navigation: WASD flies on hover (no right-click hold), Z resets view; remove right-scroll speed control, Q/E vertical movement, Shift boost, middle-mouse pan, and the speed/event-count overlays
   * Add `--remote-backend` flag to `start_analytics_web.py` for hybrid local-frontend + remote-backend setup (#1033)
 * **Python:**
   * Switch `bulk_ingest` to accept `pyarrow.Table` directly for native pass-through of struct/list/binary columns

--- a/analytics-web-app/src/components/map/MapViewer.tsx
+++ b/analytics-web-app/src/components/map/MapViewer.tsx
@@ -24,9 +24,6 @@ interface MapViewerProps {
   events: MapEvent[]
   selectedEventId?: string
   onSelectEvent: (event: MapEvent | null) => void
-  showHeatmap: boolean
-  heatmapRadius: number
-  heatmapIntensity: number
   markerColor?: string
   markerSize?: number
   resetViewTrigger?: number
@@ -224,90 +221,6 @@ function InstancedMarkers({
       onPointerOver={handlePointerOver}
       onPointerOut={handlePointerOut}
     />
-  )
-}
-
-interface HeatmapLayerProps {
-  events: MapEvent[]
-  radius: number
-  intensity: number
-}
-
-const HEATMAP_PADDING = 1000
-
-function HeatmapLayer({ events, radius, intensity }: HeatmapLayerProps) {
-  const meshRef = useRef<THREE.Mesh>(null)
-  const [texture, setTexture] = useState<THREE.CanvasTexture | null>(null)
-
-  // Single pass over events; spread-based Math.min(...arr) blows the stack at large counts.
-  const bounds = useMemo(() => {
-    if (events.length === 0) return null
-    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity
-    for (const e of events) {
-      if (e.x < minX) minX = e.x
-      if (e.x > maxX) maxX = e.x
-      if (e.y < minY) minY = e.y
-      if (e.y > maxY) maxY = e.y
-    }
-    return { minX, maxX, minY, maxY }
-  }, [events])
-
-  useEffect(() => {
-    if (!bounds) {
-      setTexture(null)
-      return
-    }
-
-    const canvas = document.createElement('canvas')
-    const size = 1024
-    canvas.width = size
-    canvas.height = size
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
-
-    ctx.clearRect(0, 0, size, size)
-
-    const rangeX = bounds.maxX - bounds.minX + HEATMAP_PADDING * 2
-    const rangeY = bounds.maxY - bounds.minY + HEATMAP_PADDING * 2
-
-    events.forEach((event) => {
-      const canvasX = ((event.x - bounds.minX + HEATMAP_PADDING) / rangeX) * size
-      const canvasY = ((event.y - bounds.minY + HEATMAP_PADDING) / rangeY) * size
-
-      const gradient = ctx.createRadialGradient(canvasX, canvasY, 0, canvasX, canvasY, radius)
-      gradient.addColorStop(0, `rgba(191, 54, 12, ${intensity})`)
-      gradient.addColorStop(0.5, `rgba(191, 54, 12, ${intensity * 0.5})`)
-      gradient.addColorStop(1, 'rgba(191, 54, 12, 0)')
-
-      ctx.fillStyle = gradient
-      ctx.fillRect(canvasX - radius, canvasY - radius, radius * 2, radius * 2)
-    })
-
-    const tex = new THREE.CanvasTexture(canvas)
-    // Canvas Y grows top-to-bottom; CanvasTexture's default flipY would map
-    // canvas-top to plane local +Y, which under Z-up sends events at world
-    // minY to world maxY on the plane (mirrored relative to the markers).
-    tex.flipY = false
-    tex.needsUpdate = true
-    setTexture(tex)
-
-    return () => {
-      tex.dispose()
-    }
-  }, [events, bounds, radius, intensity])
-
-  if (!texture || !bounds) return null
-
-  const width = bounds.maxX - bounds.minX + HEATMAP_PADDING * 2
-  const height = bounds.maxY - bounds.minY + HEATMAP_PADDING * 2
-  const centerX = (bounds.minX + bounds.maxX) / 2
-  const centerY = (bounds.minY + bounds.maxY) / 2
-
-  return (
-    <mesh ref={meshRef} position={[centerX, centerY, 10]}>
-      <planeGeometry args={[width, height]} />
-      <meshBasicMaterial map={texture} transparent opacity={0.7} depthWrite={false} />
-    </mesh>
   )
 }
 
@@ -782,9 +695,6 @@ export function MapViewer({
   events,
   selectedEventId,
   onSelectEvent,
-  showHeatmap,
-  heatmapRadius,
-  heatmapIntensity,
   markerColor,
   markerSize,
   resetViewTrigger = 0,
@@ -897,10 +807,6 @@ export function MapViewer({
             <PlaceholderGrid />
           )}
         </Suspense>
-
-        {showHeatmap && (
-          <HeatmapLayer events={events} radius={heatmapRadius} intensity={heatmapIntensity} />
-        )}
 
         <InstancedMarkers
           events={events}

--- a/analytics-web-app/src/components/map/MapViewer.tsx
+++ b/analytics-web-app/src/components/map/MapViewer.tsx
@@ -250,7 +250,6 @@ function zUpOffsetToSphericalInput(offset: THREE.Vector3, out: THREE.Vector3): T
 interface UnrealCameraControllerProps {
   mapBounds: THREE.Box3 | null
   mapScene: THREE.Object3D | null
-  onSpeedChange?: (speed: number) => void
   resetViewTrigger: number
   glbCamera: THREE.PerspectiveCamera | null
 }
@@ -258,7 +257,6 @@ interface UnrealCameraControllerProps {
 function UnrealCameraController({
   mapBounds,
   mapScene,
-  onSpeedChange,
   resetViewTrigger,
   glbCamera,
 }: UnrealCameraControllerProps) {
@@ -273,9 +271,9 @@ function UnrealCameraController({
     spherical: { radius: number; phi: number; theta: number }
   } | null>(null)
 
-  const baseSpeedRef = useRef(2000)
-  const MIN_SPEED = 10
-  const MAX_SPEED = 50000
+  // WASD speed derives from the current orbit radius so flying feels the same
+  // at every zoom level — one camera-to-target distance per ~2 seconds.
+  const SPEED_PER_RADIUS = 0.5
 
   const fitRadiusRef = useRef(5000)
   const zoomFactorRef = useRef(1.0)
@@ -284,25 +282,14 @@ function UnrealCameraController({
   const isLeftDraggingRef = useRef(false)
   const leftMouseStartRef = useRef({ x: 0, y: 0 })
   const isRightMouseDownRef = useRef(false)
-  const isMiddleMouseDownRef = useRef(false)
+  const isHoveredRef = useRef(false)
   const lastMouseRef = useRef({ x: 0, y: 0 })
   const keysRef = useRef({
     w: false,
     a: false,
     s: false,
     d: false,
-    q: false,
-    e: false,
-    shift: false,
   })
-
-  // Route speed updates through a ref so the DOM event-binding effect below
-  // doesn't need to rebind when the parent's callback identity changes.
-  const onSpeedChangeRef = useRef(onSpeedChange)
-  useEffect(() => {
-    onSpeedChangeRef.current = onSpeedChange
-    onSpeedChange?.(baseSpeedRef.current)
-  }, [onSpeedChange])
 
   // Track latest mapScene through a ref so mousedown can raycast against it
   // without rebinding the DOM event handlers when the scene changes.
@@ -429,11 +416,6 @@ function UnrealCameraController({
             targetRef.current.copy(newTarget)
           }
         }
-      } else if (e.button === 1) {
-        isMiddleMouseDownRef.current = true
-        lastMouseRef.current = { x: e.clientX, y: e.clientY }
-        domElement.style.cursor = 'move'
-        e.preventDefault()
       }
     }
 
@@ -446,9 +428,6 @@ function UnrealCameraController({
         isLeftDraggingRef.current = false
       } else if (e.button === 2) {
         isRightMouseDownRef.current = false
-        domElement.style.cursor = 'auto'
-      } else if (e.button === 1) {
-        isMiddleMouseDownRef.current = false
         domElement.style.cursor = 'auto'
       }
     }
@@ -503,23 +482,10 @@ function UnrealCameraController({
         )
       }
 
-      if (isMiddleMouseDownRef.current) {
-        panCamera(deltaX, deltaY)
-      }
     }
 
     const onWheel = (e: WheelEvent) => {
       e.preventDefault()
-
-      if (isRightMouseDownRef.current) {
-        const speedMultiplier = e.deltaY > 0 ? 0.8 : 1.25
-        baseSpeedRef.current = Math.max(
-          MIN_SPEED,
-          Math.min(MAX_SPEED, baseSpeedRef.current * speedMultiplier)
-        )
-        onSpeedChangeRef.current?.(baseSpeedRef.current)
-        return
-      }
 
       const zoomSpeed = 0.1
       const zoomMultiplier = e.deltaY > 0 ? (1 + zoomSpeed) : (1 - zoomSpeed)
@@ -564,37 +530,51 @@ function UnrealCameraController({
       e.preventDefault()
     }
 
+    const isFormTarget = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement | null
+      return !!t?.matches('input, textarea, select, [contenteditable="true"]')
+    }
+
     const onKeyDown = (e: KeyboardEvent) => {
+      if (isFormTarget(e)) return
       const key = e.key.toLowerCase()
       if (key in keysRef.current) {
         keysRef.current[key as keyof typeof keysRef.current] = true
       }
-      if (e.key === 'Shift') {
-        keysRef.current.shift = true
-      }
     }
 
     const onKeyUp = (e: KeyboardEvent) => {
+      // Don't filter form targets on keyup — we need to release any key that
+      // got pressed (e.g., focus moved into an input mid-hold).
       const key = e.key.toLowerCase()
       if (key in keysRef.current) {
         keysRef.current[key as keyof typeof keysRef.current] = false
       }
-      if (e.key === 'Shift') {
-        keysRef.current.shift = false
-      }
+    }
+
+    // Hover gates WASD/QE so multiple Map cells on a page don't all fly
+    // together and so flying stops when the pointer leaves the canvas.
+    const onMouseEnter = () => {
+      isHoveredRef.current = true
+    }
+    const onMouseLeave = () => {
+      isHoveredRef.current = false
+      keysRef.current.w = false
+      keysRef.current.a = false
+      keysRef.current.s = false
+      keysRef.current.d = false
     }
 
     // Safety net: if the browser/tab loses focus mid-drag (alt-tab, OS dialog),
     // the eventual mouseup may never reach us — clear all drag state so the
     // next interaction starts clean.
     const onWindowBlur = () => {
-      if (isLeftDraggingRef.current || isRightMouseDownRef.current || isMiddleMouseDownRef.current) {
+      if (isLeftDraggingRef.current || isRightMouseDownRef.current) {
         domElement.style.cursor = 'auto'
       }
       isLeftMouseDownRef.current = false
       isLeftDraggingRef.current = false
       isRightMouseDownRef.current = false
-      isMiddleMouseDownRef.current = false
     }
 
     // mousedown stays on the canvas (drags only start over the map), but
@@ -605,6 +585,8 @@ function UnrealCameraController({
     window.addEventListener('mousemove', onMouseMove)
     domElement.addEventListener('wheel', onWheel, { passive: false })
     domElement.addEventListener('contextmenu', onContextMenu)
+    domElement.addEventListener('mouseenter', onMouseEnter)
+    domElement.addEventListener('mouseleave', onMouseLeave)
     window.addEventListener('keydown', onKeyDown)
     window.addEventListener('keyup', onKeyUp)
     window.addEventListener('blur', onWindowBlur)
@@ -615,6 +597,8 @@ function UnrealCameraController({
       window.removeEventListener('mousemove', onMouseMove)
       domElement.removeEventListener('wheel', onWheel)
       domElement.removeEventListener('contextmenu', onContextMenu)
+      domElement.removeEventListener('mouseenter', onMouseEnter)
+      domElement.removeEventListener('mouseleave', onMouseLeave)
       window.removeEventListener('keydown', onKeyDown)
       window.removeEventListener('keyup', onKeyUp)
       window.removeEventListener('blur', onWindowBlur)
@@ -622,9 +606,8 @@ function UnrealCameraController({
   }, [camera, domElement])
 
   useFrame((_, delta) => {
-    if (isRightMouseDownRef.current) {
-      const speed = keysRef.current.shift ? baseSpeedRef.current * 2.5 : baseSpeedRef.current
-      const moveSpeed = speed * delta
+    if (isHoveredRef.current) {
+      const moveSpeed = sphericalRef.current.radius * SPEED_PER_RADIUS * delta
 
       const forward = new THREE.Vector3()
       camera.getWorldDirection(forward)
@@ -646,12 +629,6 @@ function UnrealCameraController({
       }
       if (keysRef.current.d) {
         targetRef.current.addScaledVector(right, moveSpeed)
-      }
-      if (keysRef.current.e) {
-        targetRef.current.z += moveSpeed
-      }
-      if (keysRef.current.q) {
-        targetRef.current.z -= moveSpeed
       }
     }
 
@@ -704,11 +681,6 @@ export function MapViewer({
   const [glbCamera, setGlbCamera] = useState<THREE.PerspectiveCamera | null>(null)
   const [ambientLight, setAmbientLight] = useState<MMAmbientLight | null>(null)
   const [contractErrors, setContractErrors] = useState<string[]>([])
-  const [currentSpeed, setCurrentSpeed] = useState(2000)
-
-  const handleSpeedChange = useCallback((speed: number) => {
-    setCurrentSpeed(speed)
-  }, [])
 
   const handleMapLoaded = useCallback(
     (payload: MapLoadPayload) => {
@@ -788,7 +760,6 @@ export function MapViewer({
         <UnrealCameraController
           mapBounds={mapBounds}
           mapScene={mapScene}
-          onSpeedChange={handleSpeedChange}
           resetViewTrigger={resetViewTrigger}
           glbCamera={glbCamera}
         />
@@ -834,12 +805,8 @@ export function MapViewer({
         <div>Left-click + drag: Pan</div>
         <div>Right-click + drag: Rotate</div>
         <div>Scroll: Zoom</div>
-        <div>Right-click + Scroll: Speed</div>
-        <div>WASD + Right-click: Fly</div>
-        <div>Q/E: Up/Down | Shift: Boost</div>
-        <div className="mt-2 pt-2 border-t border-theme-border text-theme-text-secondary">
-          Speed: <span className="font-mono text-accent-link">{currentSpeed.toLocaleString()}</span>
-        </div>
+        <div>WASD: Fly</div>
+        <div>Z: Reset view</div>
       </div>
     </div>
   )

--- a/analytics-web-app/src/components/map/MapViewer.tsx
+++ b/analytics-web-app/src/components/map/MapViewer.tsx
@@ -481,7 +481,6 @@ function UnrealCameraController({
           Math.min(Math.PI / 2 - 0.05, sphericalRef.current.phi)
         )
       }
-
     }
 
     const onWheel = (e: WheelEvent) => {
@@ -552,8 +551,8 @@ function UnrealCameraController({
       }
     }
 
-    // Hover gates WASD/QE so multiple Map cells on a page don't all fly
-    // together and so flying stops when the pointer leaves the canvas.
+    // Hover gates WASD so multiple Map cells on a page don't all fly together
+    // and so flying stops when the pointer leaves the canvas.
     const onMouseEnter = () => {
       isHoveredRef.current = true
     }

--- a/analytics-web-app/src/lib/screen-renderers/__test-utils__/cell-registry-mock.ts
+++ b/analytics-web-app/src/lib/screen-renderers/__test-utils__/cell-registry-mock.ts
@@ -96,7 +96,7 @@ const BASE_METADATA = {
   map: {
     label: 'Map',
     icon: 'M',
-    description: '3D map visualization with heatmap overlay',
+    description: '3D map visualization of spatial events',
     showTypeBadge: true,
     defaultHeight: 500,
     canBlockDownstream: true,

--- a/analytics-web-app/src/lib/screen-renderers/cells/MapCell.tsx
+++ b/analytics-web-app/src/lib/screen-renderers/cells/MapCell.tsx
@@ -140,9 +140,6 @@ export function MapCell({ data, status, options }: CellRendererProps) {
         >
           Reset
         </button>
-        <span className="text-xs text-theme-text-muted bg-app-panel/90 px-2 py-1 rounded border border-theme-border">
-          {events.length.toLocaleString()} events
-        </span>
       </div>
 
       <MapViewer

--- a/analytics-web-app/src/lib/screen-renderers/cells/MapCell.tsx
+++ b/analytics-web-app/src/lib/screen-renderers/cells/MapCell.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect } from 'react'
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import { Table } from 'apache-arrow'
 import type {
   CellTypeMetadata,
@@ -112,6 +112,22 @@ export function MapCell({ data, status, options }: CellRendererProps) {
     setSelectedEvent(event)
   }, [])
 
+  // Z resets the view, scoped to the hovered cell so multiple Map cells on a
+  // page don't all reset together and typing 'z' in a text/query cell is ignored.
+  const containerRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'z' && e.key !== 'Z') return
+      if (e.ctrlKey || e.metaKey || e.altKey) return
+      const target = e.target as HTMLElement | null
+      if (target?.matches('input, textarea, select, [contenteditable="true"]')) return
+      if (!containerRef.current?.matches(':hover')) return
+      setResetViewTrigger((t) => t + 1)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+
   if (status === 'loading') {
     return (
       <div className="flex items-center justify-center h-full">
@@ -130,18 +146,7 @@ export function MapCell({ data, status, options }: CellRendererProps) {
   }
 
   return (
-    <div className="relative w-full h-full overflow-hidden">
-      {/* Toolbar overlay */}
-      <div className="absolute top-2 left-2 z-10 flex items-center gap-2">
-        <button
-          onClick={() => setResetViewTrigger((t) => t + 1)}
-          className="px-2 py-1 bg-app-panel/90 border border-theme-border rounded text-xs text-theme-text-secondary hover:text-theme-text-primary"
-          title="Reset view"
-        >
-          Reset
-        </button>
-      </div>
-
+    <div ref={containerRef} className="relative w-full h-full overflow-hidden">
       <MapViewer
         mapUrl={mapUrl}
         events={events}

--- a/analytics-web-app/src/lib/screen-renderers/cells/MapCell.tsx
+++ b/analytics-web-app/src/lib/screen-renderers/cells/MapCell.tsx
@@ -91,7 +91,7 @@ function useMapCatalog(): MapCatalogEntry[] {
 // Renderer Component
 // =============================================================================
 
-export function MapCell({ data, status, options, onOptionsChange }: CellRendererProps) {
+export function MapCell({ data, status, options }: CellRendererProps) {
   // Transform Arrow data to MapEvent[] (memoized on table reference)
   const events = useMemo(() => {
     const table = data[0]
@@ -105,23 +105,12 @@ export function MapCell({ data, status, options, onOptionsChange }: CellRenderer
 
   // Read visual options with defaults
   const mapUrl = options?.mapUrl as string | undefined
-  const showHeatmap = (options?.showHeatmap as boolean) ?? false
-  const heatmapRadius = (options?.heatmapRadius as number) ?? 50
-  const heatmapIntensity = (options?.heatmapIntensity as number) ?? 0.5
   const markerColor = (options?.markerColor as string) ?? '#bf360c'
   const markerSize = (options?.markerSize as number) ?? 10
 
   const handleSelectEvent = useCallback((event: MapEvent | null) => {
     setSelectedEvent(event)
   }, [])
-
-  // Allow toggling heatmap/markers from keyboard or future toolbar
-  const updateOption = useCallback(
-    (key: string, value: unknown) => {
-      onOptionsChange({ ...options, [key]: value })
-    },
-    [options, onOptionsChange]
-  )
 
   if (status === 'loading') {
     return (
@@ -151,17 +140,6 @@ export function MapCell({ data, status, options, onOptionsChange }: CellRenderer
         >
           Reset
         </button>
-        <button
-          onClick={() => updateOption('showHeatmap', !showHeatmap)}
-          className={`px-2 py-1 border border-theme-border rounded text-xs transition-colors ${
-            showHeatmap
-              ? 'bg-accent-link/20 text-accent-link border-accent-link/50'
-              : 'bg-app-panel/90 text-theme-text-secondary hover:text-theme-text-primary'
-          }`}
-          title="Toggle heatmap"
-        >
-          Heatmap
-        </button>
         <span className="text-xs text-theme-text-muted bg-app-panel/90 px-2 py-1 rounded border border-theme-border">
           {events.length.toLocaleString()} events
         </span>
@@ -172,9 +150,6 @@ export function MapCell({ data, status, options, onOptionsChange }: CellRenderer
         events={events}
         selectedEventId={selectedEvent?.id}
         onSelectEvent={handleSelectEvent}
-        showHeatmap={showHeatmap}
-        heatmapRadius={heatmapRadius}
-        heatmapIntensity={heatmapIntensity}
         markerColor={markerColor}
         markerSize={markerSize}
         resetViewTrigger={resetViewTrigger}
@@ -274,51 +249,6 @@ export function MapCellEditor({
           </div>
         </div>
 
-        {/* Heatmap toggle */}
-        <div className="flex items-center gap-2">
-          <label className="text-xs text-theme-text-secondary w-24 shrink-0">Heatmap</label>
-          <input
-            type="checkbox"
-            checked={(mapConfig.options?.showHeatmap as boolean) ?? false}
-            onChange={(e) => updateOption('showHeatmap', e.target.checked)}
-          />
-        </div>
-
-        {/* Heatmap radius */}
-        {(mapConfig.options?.showHeatmap as boolean) && (
-          <>
-            <div className="flex items-center gap-2">
-              <label className="text-xs text-theme-text-secondary w-24 shrink-0">Radius</label>
-              <input
-                type="range"
-                min="20"
-                max="100"
-                value={(mapConfig.options?.heatmapRadius as number) ?? 50}
-                onChange={(e) => updateOption('heatmapRadius', Number(e.target.value))}
-                className="w-32 accent-accent-link"
-              />
-              <span className="text-xs text-theme-text-muted w-5">
-                {(mapConfig.options?.heatmapRadius as number) ?? 50}
-              </span>
-            </div>
-            <div className="flex items-center gap-2">
-              <label className="text-xs text-theme-text-secondary w-24 shrink-0">Intensity</label>
-              <input
-                type="range"
-                min="0.1"
-                max="1"
-                step="0.1"
-                value={(mapConfig.options?.heatmapIntensity as number) ?? 0.5}
-                onChange={(e) => updateOption('heatmapIntensity', Number(e.target.value))}
-                className="w-32 accent-accent-link"
-              />
-              <span className="text-xs text-theme-text-muted w-5">
-                {(mapConfig.options?.heatmapIntensity as number) ?? 0.5}
-              </span>
-            </div>
-          </>
-        )}
-
         {/* Marker color */}
         <div className="flex items-center gap-2">
           <label className="text-xs text-theme-text-secondary w-24 shrink-0">Marker Color</label>
@@ -369,7 +299,7 @@ export const mapMetadata: CellTypeMetadata = {
 
   label: 'Map',
   icon: <MapIcon />,
-  description: '3D map visualization with heatmap overlay',
+  description: '3D map visualization of spatial events',
   showTypeBadge: true,
   defaultHeight: 500,
 
@@ -379,7 +309,6 @@ export const mapMetadata: CellTypeMetadata = {
     type: 'map' as const,
     sql: DEFAULT_SQL.map,
     options: {
-      showHeatmap: false,
       markerColor: '#bf360c',
       markerSize: 10,
     },

--- a/mkdocs/docs/web-app/notebooks/cell-types.md
+++ b/mkdocs/docs/web-app/notebooks/cell-types.md
@@ -511,7 +511,7 @@ WHERE m.value > t.warn_threshold
 
 ## ![Map](../../assets/images/cell-icons/map.svg){ .cell-icon } Map
 
-3D map visualization that plots spatial events on a GLB model with optional heatmap overlay. Events are rendered as instanced sphere markers at their native `(x, y, z)` coordinates.
+3D map visualization that plots spatial events on a GLB model. Events are rendered as instanced sphere markers at their native `(x, y, z)` coordinates.
 
 **Configuration:**
 
@@ -543,9 +543,6 @@ All columns beyond the reserved names (`time`, `x`, `y`, `z`, `process_id`) are 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `mapUrl` | string | none | GLB model URL — select from the map catalog or enter a custom path |
-| `showHeatmap` | boolean | `false` | Show 2D heatmap overlay |
-| `heatmapRadius` | number | `50` | Heatmap point radius (20–100) |
-| `heatmapIntensity` | number | `0.5` | Heatmap opacity (0.1–1.0) |
 | `markerColor` | string | `#bf360c` | Marker color (hex) |
 | `markerSize` | number | `10` | Marker size — scaled proportionally to the map extent |
 
@@ -589,7 +586,6 @@ GLBs missing the camera log a console error and fall back to the default seed fr
 **Features:**
 
 - Instanced rendering — handles thousands of markers efficiently
-- Heatmap overlay — 2D canvas-based density visualization
 - Interactive markers — click to select, hover to highlight
 - Camera controls — left-drag to pan, right-drag to orbit, scroll to zoom, WASD to fly
 - Reset View toolbar button

--- a/mkdocs/docs/web-app/notebooks/cell-types.md
+++ b/mkdocs/docs/web-app/notebooks/cell-types.md
@@ -588,7 +588,7 @@ GLBs missing the camera log a console error and fall back to the default seed fr
 - Instanced rendering — handles thousands of markers efficiently
 - Interactive markers — click to select, hover to highlight
 - Camera controls — left-drag to pan, right-drag to orbit, scroll to zoom, WASD to fly
-- Reset View toolbar button
+- Reset view with the Z key
 - Event detail panel with properties and link to process logs
 - Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
 


### PR DESCRIPTION
## Summary
- Remove the heatmap overlay (canvas-based density layer was an extra mode that complicated the cell with limited use)
- Remove the event-count badge from the toolbar (event count is already visible from the underlying query)
- Simplify camera controls: WASD now flies on hover instead of requiring a right-click hold, Z resets the view, and the speed slider / Q/E vertical / Shift boost / middle-mouse pan / right-scroll speed modes are gone
- Update the changelog and cell-types documentation to match

## Test plan
- [ ] Open a notebook with a Map cell, hover the canvas, press WASD — camera flies; mouse-out stops flying
- [ ] Press Z while hovering the Map cell — view resets; press Z while focused in a SQL/text cell — no reset
- [ ] With multiple Map cells on a page, confirm only the hovered one responds to WASD/Z
- [ ] Left-drag pan, right-drag orbit, wheel zoom (cursor-anchored) still work
- [ ] Open an existing notebook that had \`showHeatmap: true\` stored — cell renders without the overlay and without errors