### PR TITLE
Map: refine navigation, context-menu, and event detail panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This file documents the historical progress of the Micromegas project. For curre
   * Refactor map cell to keep SQL results in Arrow Table format through the render path: replace eager `MapEvent[]` materialization with an `Overlay` struct (positions `Float32Array` + table) and on-demand row materialization; split InstancedMesh layout from selection/hover diff so selection changes touch O(1) instances; reject non-finite x/y/z at build time to avoid `InstancedMesh` bounding-sphere poisoning (#1035)
   * Generalize map cell to primitive overlays with shape dispatch (sphere/box), per-instance RGBA via an `instanceColorRGBA` attribute, and column-or-scalar bindings per visual channel (size, scaleX/Y/Z, color); color column accepts integer (packed RGBA u32), `#rrggbb[aa]` string, or 4-byte binary (DataFusion's `0xrrggbbaa` literal); fix SyntaxEditor cursor/overlay alignment in SQL mode (#1055)
   * Enlarge SQL query editors across the app: screen-level editors to 384px and per-cell editors to 240px; trim the flame chart cell description for new-cell dialog consistency
+  * Refine map navigation: WASD pans horizontally (no elevation), add Q/E keyboard zoom, suppress the browser context menu when a right-drag releases off-canvas, and auto-size the event detail panel with the title rendered via the Markdown template
 * **Python:**
   * Switch `bulk_ingest` to accept `pyarrow.Table` directly for native pass-through of struct/list/binary columns
   * Resolve CLI connection settings from `~/.micromegas/config.json` with env-var override (#1033)

--- a/analytics-web-app/src/components/map/EventDetailPanel.tsx
+++ b/analytics-web-app/src/components/map/EventDetailPanel.tsx
@@ -60,18 +60,15 @@ export function EventDetailPanel({
   }, [template, row, variables, timeRange, cellResults, cellSelections])
 
   return (
-    <div className="absolute bottom-4 left-4 w-80 max-h-[60%] overflow-y-auto bg-app-panel border border-theme-border rounded-lg shadow-lg z-10">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-theme-border">
-        <h3 className="text-sm font-semibold text-theme-text-primary">Event Details</h3>
-        <button
-          onClick={onClose}
-          className="p-1 rounded hover:bg-theme-border transition-colors"
-          title="Close"
-        >
-          <X className="w-4 h-4 text-theme-text-muted" />
-        </button>
-      </div>
-      <div className="prose prose-invert prose-sm max-w-none p-4 prose-headings:text-theme-text-primary prose-p:text-theme-text-secondary prose-a:text-accent-link prose-strong:text-theme-text-primary prose-code:text-accent-highlight prose-code:bg-app-card prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:before:content-none prose-code:after:content-none prose-pre:bg-app-card prose-li:text-theme-text-secondary">
+    <div className="absolute bottom-4 left-4 w-fit max-w-[50%] max-h-[60%] overflow-auto bg-app-panel border border-theme-border rounded-lg shadow-lg z-10">
+      <button
+        onClick={onClose}
+        className="absolute top-2 right-2 p-1 rounded hover:bg-theme-border transition-colors z-10"
+        title="Close"
+      >
+        <X className="w-4 h-4 text-theme-text-muted" />
+      </button>
+      <div className="prose prose-invert prose-sm max-w-none px-4 py-3 prose-headings:text-theme-text-primary prose-headings:mt-0 prose-p:text-theme-text-secondary prose-a:text-accent-link prose-strong:text-theme-text-primary prose-code:text-accent-highlight prose-code:bg-app-card prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:before:content-none prose-code:after:content-none prose-pre:bg-app-card prose-li:text-theme-text-secondary prose-hr:border-theme-border prose-hr:my-3">
         <Markdown remarkPlugins={[remarkGfm]} components={{ a: MarkdownLink }}>
           {rendered}
         </Markdown>

--- a/analytics-web-app/src/components/map/MapViewer.tsx
+++ b/analytics-web-app/src/components/map/MapViewer.tsx
@@ -615,6 +615,14 @@ function UnrealCameraController({
   useEffect(() => {
     const DRAG_THRESHOLD = 4
 
+    // Arm-and-fire flag for the contextmenu that follows a right-mousedown on
+    // the canvas. Set on right-mousedown, consumed by the window-level
+    // contextmenu handler. A window listener is required because if the
+    // mouseup happens off-canvas, the contextmenu fires on whatever element
+    // is under the cursor — not the canvas — so a canvas-bound listener
+    // would miss it.
+    let suppressNextContextMenu = false
+
     const onMouseDown = (e: MouseEvent) => {
       if (e.button === 0) {
         isLeftMouseDownRef.current = true
@@ -623,6 +631,7 @@ function UnrealCameraController({
         lastMouseRef.current = { x: e.clientX, y: e.clientY }
       } else if (e.button === 2) {
         isRightMouseDownRef.current = true
+        suppressNextContextMenu = true
         lastMouseRef.current = { x: e.clientX, y: e.clientY }
         domElement.style.cursor = 'grabbing'
 
@@ -758,7 +767,10 @@ function UnrealCameraController({
     }
 
     const onContextMenu = (e: MouseEvent) => {
-      e.preventDefault()
+      if (suppressNextContextMenu) {
+        e.preventDefault()
+        suppressNextContextMenu = false
+      }
     }
 
     const isFormTarget = (e: KeyboardEvent) => {
@@ -808,6 +820,7 @@ function UnrealCameraController({
       isLeftMouseDownRef.current = false
       isLeftDraggingRef.current = false
       isRightMouseDownRef.current = false
+      suppressNextContextMenu = false
     }
 
     // mousedown stays on the canvas (drags only start over the map), but
@@ -817,7 +830,7 @@ function UnrealCameraController({
     window.addEventListener('mouseup', onMouseUp)
     window.addEventListener('mousemove', onMouseMove)
     domElement.addEventListener('wheel', onWheel, { passive: false })
-    domElement.addEventListener('contextmenu', onContextMenu)
+    window.addEventListener('contextmenu', onContextMenu)
     domElement.addEventListener('mouseenter', onMouseEnter)
     domElement.addEventListener('mouseleave', onMouseLeave)
     window.addEventListener('keydown', onKeyDown)
@@ -829,7 +842,7 @@ function UnrealCameraController({
       window.removeEventListener('mouseup', onMouseUp)
       window.removeEventListener('mousemove', onMouseMove)
       domElement.removeEventListener('wheel', onWheel)
-      domElement.removeEventListener('contextmenu', onContextMenu)
+      window.removeEventListener('contextmenu', onContextMenu)
       domElement.removeEventListener('mouseenter', onMouseEnter)
       domElement.removeEventListener('mouseleave', onMouseLeave)
       window.removeEventListener('keydown', onKeyDown)

--- a/analytics-web-app/src/components/map/MapViewer.tsx
+++ b/analytics-web-app/src/components/map/MapViewer.tsx
@@ -519,6 +519,8 @@ function UnrealCameraController({
     a: false,
     s: false,
     d: false,
+    q: false,
+    e: false,
   })
 
   // Track latest mapScene through a ref so mousedown can raycast against it
@@ -792,6 +794,8 @@ function UnrealCameraController({
       keysRef.current.a = false
       keysRef.current.s = false
       keysRef.current.d = false
+      keysRef.current.q = false
+      keysRef.current.e = false
     }
 
     // Safety net: if the browser/tab loses focus mid-drag (alt-tab, OS dialog),
@@ -838,14 +842,12 @@ function UnrealCameraController({
     if (isHoveredRef.current) {
       const moveSpeed = sphericalRef.current.radius * SPEED_PER_RADIUS * delta
 
-      const forward = new THREE.Vector3()
-      camera.getWorldDirection(forward)
-      forward.normalize()
-
-      // Theta-based right, same reason as panCamera: cross(cameraForward, worldUp)
-      // collapses to zero at phi=0 and silently drops A/D strafe.
+      // Theta-based XY basis, same as panCamera: keeps WASD as a top-down pan
+      // (W/S no longer changes elevation), and avoids the cross-product
+      // collapse at phi=0 that would silently drop strafe.
       const theta = sphericalRef.current.theta
       const right = new THREE.Vector3(Math.cos(theta), Math.sin(theta), 0)
+      const forward = new THREE.Vector3(-Math.sin(theta), Math.cos(theta), 0)
 
       if (keysRef.current.w) {
         targetRef.current.addScaledVector(forward, moveSpeed)
@@ -858,6 +860,23 @@ function UnrealCameraController({
       }
       if (keysRef.current.d) {
         targetRef.current.addScaledVector(right, moveSpeed)
+      }
+
+      // Q/E zoom: time-based exponential so the per-frame step is independent
+      // of framerate. Mirrors the wheel handler's zoomFactor invariant but
+      // skips cursor-anchoring (no pointer to anchor against).
+      let zoomSign = 0
+      if (keysRef.current.q) zoomSign += 1
+      if (keysRef.current.e) zoomSign -= 1
+      if (zoomSign !== 0) {
+        const KEY_ZOOM_RATE_PER_SEC = 2.0
+        const zoomMultiplier = Math.pow(KEY_ZOOM_RATE_PER_SEC, zoomSign * delta)
+        const newZoomFactor = Math.max(
+          0.001,
+          Math.min(10.0, zoomFactorRef.current * zoomMultiplier)
+        )
+        zoomFactorRef.current = newZoomFactor
+        sphericalRef.current.radius = fitRadiusRef.current * newZoomFactor
       }
     }
 
@@ -1005,7 +1024,8 @@ export function MapViewer({
         <div>Left-click + drag: Pan</div>
         <div>Right-click + drag: Rotate</div>
         <div>Scroll: Zoom</div>
-        <div>WASD: Fly</div>
+        <div>WASD: Pan</div>
+        <div>QE: Zoom</div>
         <div>Z: Reset view</div>
       </div>
     </div>

--- a/analytics-web-app/src/lib/screen-renderers/notebook-utils.ts
+++ b/analytics-web-app/src/lib/screen-renderers/notebook-utils.ts
@@ -154,7 +154,9 @@ ORDER BY lane, begin`,
  * Renders the canonical x/y/z columns; authors extend this in the editor
  * to surface their own query columns (e.g. process_id, event_type).
  */
-export const DEFAULT_MAP_DETAIL_TEMPLATE = `### Event
+export const DEFAULT_MAP_DETAIL_TEMPLATE = `### Event Details
+
+---
 
 **Location:** ($x, $y, $z)
 `


### PR DESCRIPTION
## Summary

- **WASD now pans horizontally** (no elevation change) — same theta-based XY basis as drag-pan, avoids the cross-product collapse at phi=0.
- **Q/E adds keyboard zoom** — time-based exponential matching the wheel handler's invariant, without cursor anchoring.
- **Suppress the browser context menu when a right-drag releases off-canvas** — arm-and-fire flag set on right-mousedown, consumed by a window-level `contextmenu` listener so off-canvas releases are still caught.
- **Event detail panel auto-sizes** — replace fixed `w-80` with `w-fit max-w-[50%]`; remove the hardcoded "Event Details" header bar and float the close button so the markdown template controls the title and divider (default template now uses `### Event Details` + `---`).

## Test plan

- [ ] Open a notebook with a map cell, hover the canvas, press W/A/S/D — camera target pans horizontally only.
- [ ] Press Q to zoom in and E to zoom out; verify framerate-independent rate.
- [ ] Right-click + drag on the canvas, release off-canvas — no browser context menu appears.
- [ ] Right-click anywhere else on the page — context menu still appears normally.
- [ ] Click a map event with a long identifier — panel grows wider to fit, capped at 50% of the canvas; close button still works.
- [ ] Customize the detail template — heading and divider come from the user's markdown, not from chrome.