### PR TITLE
Map cell:  macros in primitive scalar bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This file documents the historical progress of the Micromegas project. For curre
   * Enlarge SQL query editors across the app: screen-level editors to 384px and per-cell editors to 240px; trim the flame chart cell description for new-cell dialog consistency
   * Refine map navigation: WASD pans horizontally (no elevation), add Q/E keyboard zoom, suppress the browser context menu when a right-drag releases off-canvas, and auto-size the event detail panel with the title rendered via the Markdown template
   * Remove admin-oriented `MICROMEGAS_MAPS_OBJECT_STORE_URI` / `.glb` drop hint from the map cell editor (admins use the Maps management UI)
+  * Resolve `$var` macros in map cell primitive scalar bindings (size, scaleX/Y/Z, color); editor swaps the legacy number/color inputs for a text field with local-draft commit (Enter/blur commits, Escape cancels)
 * **Python:**
   * Switch `bulk_ingest` to accept `pyarrow.Table` directly for native pass-through of struct/list/binary columns
   * Resolve CLI connection settings from `~/.micromegas/config.json` with env-var override (#1033)

--- a/analytics-web-app/src/components/map/overlay.ts
+++ b/analytics-web-app/src/components/map/overlay.ts
@@ -6,7 +6,11 @@ import {
   isStringType,
   unwrapDictionary,
 } from '@/lib/arrow-utils'
-import { formatArrowValue } from '@/lib/screen-renderers/notebook-utils'
+import {
+  formatArrowValue,
+  substituteMacrosRaw,
+} from '@/lib/screen-renderers/notebook-utils'
+import type { VariableValue } from '@/lib/screen-renderers/notebook-types'
 
 /** A single row of the SQL result, formatted to strings for template substitution. */
 export type Row = Record<string, string>
@@ -16,10 +20,16 @@ export type Shape = 'sphere' | 'box'
 /**
  * One channel of an overlay mapping: either a literal value to apply to every
  * row (`scalar`), or the name of a column to read per-row values from (`column`).
+ *
+ * The `scalar` may also be a raw `string` — for numeric channels (size/scale/
+ * color), the string is user-entered text that may contain `$var` macros and
+ * is resolved to a number by `resolveMappingScalars`. Legacy notebooks store
+ * `scalar` as the typed value (`number` for size/scale, RGBA u32 for color);
+ * both forms load.
  */
 export type ChannelBinding<T = number> =
   | { column: string }
-  | { scalar: T }
+  | { scalar: T | string }
 
 /**
  * Per-channel column-or-scalar bindings. Channel semantics depend on `shape`:
@@ -122,6 +132,22 @@ export function hexFromRgba(rgba: number): string {
   const u = rgba >>> 0
   const hex = u.toString(16).padStart(8, '0')
   return `#${hex}`
+}
+
+/** Narrows a (possibly templated) scalar binding to a number. Falls back to
+ *  `fallback` for column-bound channels, missing bindings, or any scalar that
+ *  isn't already a finite number. `resolveMappingScalars` is expected to have
+ *  converted any string scalars upstream — this is the runtime safety net so
+ *  buildOverlay/resolveOverlayConstants can't silently coerce a `"$mySize"`
+ *  string into NaN. */
+function numericScalarOr(
+  b: ChannelBinding | undefined,
+  fallback: number,
+): number {
+  if (!b || !('scalar' in b)) return fallback
+  return typeof b.scalar === 'number' && Number.isFinite(b.scalar)
+    ? b.scalar
+    : fallback
 }
 
 /** Writes a 4-byte RGBA value into a per-instance buffer at row `i`. */
@@ -291,15 +317,15 @@ export function buildOverlay(
     ? [scaleXIsColumn, scaleYIsColumn, scaleZIsColumn]
     : undefined
 
-  const scaleXScalar = m.scaleX && 'scalar' in m.scaleX ? m.scaleX.scalar : DEFAULT_BOX_SCALE[0]
-  const scaleYScalar = m.scaleY && 'scalar' in m.scaleY ? m.scaleY.scalar : DEFAULT_BOX_SCALE[1]
-  const scaleZScalar = m.scaleZ && 'scalar' in m.scaleZ ? m.scaleZ.scalar : DEFAULT_BOX_SCALE[2]
+  const scaleXScalar = numericScalarOr(m.scaleX, DEFAULT_BOX_SCALE[0])
+  const scaleYScalar = numericScalarOr(m.scaleY, DEFAULT_BOX_SCALE[1])
+  const scaleZScalar = numericScalarOr(m.scaleZ, DEFAULT_BOX_SCALE[2])
 
   // Color: only materialize a per-instance buffer when column-bound. Scalar
   // color flows through `constants.color` so editor scrubbing doesn't
   // invalidate the overlay reference.
   const colorIsColumn = !!m.color && 'column' in m.color
-  const colorScalar = m.color && 'scalar' in m.color ? (m.color.scalar as number) : DEFAULT_RGBA
+  const colorScalar = numericScalarOr(m.color, DEFAULT_RGBA)
   const colorsRGBA = colorIsColumn ? new Uint8Array(numRows * 4) : undefined
   const colorCol = colorIsColumn ? table.getChild((m.color as { column: string }).column) : null
 
@@ -404,7 +430,7 @@ export function buildOverlay(
   }
 
   const constants: OverlayConstants = {
-    size: m.size && 'scalar' in m.size ? m.size.scalar : DEFAULT_SPHERE_SIZE,
+    size: numericScalarOr(m.size, DEFAULT_SPHERE_SIZE),
     scale: [scaleXScalar, scaleYScalar, scaleZScalar],
     color: colorScalar >>> 0,
   }
@@ -416,20 +442,110 @@ export function buildOverlay(
   }
 }
 
+/**
+ * Resolves any string scalars in a mapping into their numeric (or RGBA u32 for
+ * color) form. String scalars are user-entered text — possibly containing
+ * `$var` macros — and are substituted against the notebook macro context, then
+ * parsed. Number scalars pass through unchanged (legacy notebooks). Column
+ * bindings pass through unchanged.
+ *
+ * Returns the resolved mapping on success; on failure returns the first
+ * channel that couldn't be resolved (e.g. macro substitution left a value
+ * that isn't a finite number, or a color string isn't `#rrggbb[aa]`).
+ */
+export type MappingResolveResult =
+  | { ok: true; mapping: OverlayMapping }
+  | { ok: false; error: string }
+
+export interface MappingResolveContext {
+  variables: Record<string, VariableValue>
+  timeRange: { begin: string; end: string }
+  cellResults: Record<string, Table>
+  cellSelections: Record<string, Record<string, unknown>>
+}
+
+export function resolveMappingScalars(
+  mapping: OverlayMapping,
+  ctx: MappingResolveContext,
+): MappingResolveResult {
+  const resolved: OverlayMapping = { ...mapping }
+
+  const resolveNumeric = (
+    label: string,
+    b: ChannelBinding | undefined,
+  ): { ok: true; binding: ChannelBinding | undefined } | { ok: false; error: string } => {
+    if (!b || !('scalar' in b)) return { ok: true, binding: b }
+    if (typeof b.scalar === 'number') return { ok: true, binding: b }
+    const raw = substituteMacrosRaw(
+      b.scalar,
+      ctx.variables,
+      ctx.timeRange,
+      ctx.cellResults,
+      ctx.cellSelections,
+    )
+    // Trim+empty check: `Number("")` is 0, which silently turns an unset
+    // scalar into zero. Surface it as an error instead so an empty field is
+    // visible rather than a render-time mystery.
+    const trimmed = raw.trim()
+    const num = trimmed === '' ? NaN : Number(trimmed)
+    if (!Number.isFinite(num)) {
+      return {
+        ok: false,
+        error: `Channel '${label}': '${b.scalar}' resolved to '${raw}', which is not a number.`,
+      }
+    }
+    return { ok: true, binding: { scalar: num } }
+  }
+
+  for (const label of ['size', 'scaleX', 'scaleY', 'scaleZ'] as const) {
+    const r = resolveNumeric(label, mapping[label])
+    if (!r.ok) return r
+    if (r.binding === undefined) {
+      delete resolved[label]
+    } else {
+      resolved[label] = r.binding
+    }
+  }
+
+  // Color: macro string must resolve to a hex (#rrggbb[aa]) value; reuse
+  // rgbaFromHex so the parsing matches what string-typed color columns accept.
+  if (mapping.color && 'scalar' in mapping.color) {
+    const s = mapping.color.scalar
+    if (typeof s === 'string') {
+      const raw = substituteMacrosRaw(
+        s,
+        ctx.variables,
+        ctx.timeRange,
+        ctx.cellResults,
+        ctx.cellSelections,
+      )
+      const rgba = rgbaFromHex(raw)
+      if (rgba === null) {
+        return {
+          ok: false,
+          error: `Channel 'color': '${s}' resolved to '${raw}', which is not a #rrggbb or #rrggbbaa hex color.`,
+        }
+      }
+      resolved.color = { scalar: rgba }
+    }
+  }
+
+  return { ok: true, mapping: resolved }
+}
+
 /** Resolves the scalar fallbacks for size and color channels without touching
  *  the table. Cheap to call on every render so cell-level useMemo can key on
  *  scalar values without invalidating the heavyweight `buildOverlay` memo. */
 export function resolveOverlayConstants(mapping?: OverlayMapping): OverlayConstants {
   const m = mapping ?? defaultMappingFor('sphere')
   return {
-    size: m.size && 'scalar' in m.size ? m.size.scalar : DEFAULT_SPHERE_SIZE,
+    size: numericScalarOr(m.size, DEFAULT_SPHERE_SIZE),
     scale: [
-      m.scaleX && 'scalar' in m.scaleX ? m.scaleX.scalar : DEFAULT_BOX_SCALE[0],
-      m.scaleY && 'scalar' in m.scaleY ? m.scaleY.scalar : DEFAULT_BOX_SCALE[1],
-      m.scaleZ && 'scalar' in m.scaleZ ? m.scaleZ.scalar : DEFAULT_BOX_SCALE[2],
+      numericScalarOr(m.scaleX, DEFAULT_BOX_SCALE[0]),
+      numericScalarOr(m.scaleY, DEFAULT_BOX_SCALE[1]),
+      numericScalarOr(m.scaleZ, DEFAULT_BOX_SCALE[2]),
     ],
-    color:
-      (m.color && 'scalar' in m.color ? (m.color.scalar as number) : DEFAULT_RGBA) >>> 0,
+    color: numericScalarOr(m.color, DEFAULT_RGBA) >>> 0,
   }
 }
 

--- a/analytics-web-app/src/components/map/overlay.ts
+++ b/analytics-web-app/src/components/map/overlay.ts
@@ -464,11 +464,36 @@ export interface MappingResolveContext {
   cellSelections: Record<string, Record<string, unknown>>
 }
 
+/** Fast scan: returns true iff at least one channel has a string scalar that
+ *  may need macro substitution. Used to skip the entire resolution pass for
+ *  legacy mappings with purely numeric scalars. */
+function hasStringScalar(m: OverlayMapping): boolean {
+  for (const ch of ['size', 'scaleX', 'scaleY', 'scaleZ', 'color'] as const) {
+    const b = m[ch]
+    if (b && 'scalar' in b && typeof b.scalar === 'string') return true
+  }
+  return false
+}
+
 export function resolveMappingScalars(
   mapping: OverlayMapping,
   ctx: MappingResolveContext,
 ): MappingResolveResult {
+  // Fast path: legacy mappings store scalars as raw numbers — nothing to
+  // resolve. Returning the input by reference lets the caller's memo stay
+  // stable across parent re-renders that pass unstable ctx identities.
+  if (!hasStringScalar(mapping)) return { ok: true, mapping }
+
   const resolved: OverlayMapping = { ...mapping }
+
+  // Macro substitution only runs when the scalar text actually contains a
+  // `$`. Literal strings like `"10"` or `"#bf360cff"` bypass the regex passes
+  // entirely — keeps the hot path cheap when MapCell re-renders per keystroke
+  // in an unrelated SQL editor.
+  const substitute = (s: string): string =>
+    s.includes('$')
+      ? substituteMacrosRaw(s, ctx.variables, ctx.timeRange, ctx.cellResults, ctx.cellSelections)
+      : s
 
   const resolveNumeric = (
     label: string,
@@ -476,13 +501,7 @@ export function resolveMappingScalars(
   ): { ok: true; binding: ChannelBinding | undefined } | { ok: false; error: string } => {
     if (!b || !('scalar' in b)) return { ok: true, binding: b }
     if (typeof b.scalar === 'number') return { ok: true, binding: b }
-    const raw = substituteMacrosRaw(
-      b.scalar,
-      ctx.variables,
-      ctx.timeRange,
-      ctx.cellResults,
-      ctx.cellSelections,
-    )
+    const raw = substitute(b.scalar)
     // Trim+empty check: `Number("")` is 0, which silently turns an unset
     // scalar into zero. Surface it as an error instead so an empty field is
     // visible rather than a render-time mystery.
@@ -512,13 +531,7 @@ export function resolveMappingScalars(
   if (mapping.color && 'scalar' in mapping.color) {
     const s = mapping.color.scalar
     if (typeof s === 'string') {
-      const raw = substituteMacrosRaw(
-        s,
-        ctx.variables,
-        ctx.timeRange,
-        ctx.cellResults,
-        ctx.cellSelections,
-      )
+      const raw = substitute(s)
       const rgba = rgbaFromHex(raw)
       if (rgba === null) {
         return {

--- a/analytics-web-app/src/lib/screen-renderers/cells/MapCell.tsx
+++ b/analytics-web-app/src/lib/screen-renderers/cells/MapCell.tsx
@@ -456,7 +456,8 @@ export function MapCell({
  * scalars stored as raw numbers/RGBA-u32 still load — they're rendered in
  * their canonical string form (`"10"` or `"#bf360cff"`) on first edit.
  */
-function ChannelBindingControl({
+// eslint-disable-next-line react-refresh/only-export-components
+export function ChannelBindingControl({
   label,
   kind,
   binding,
@@ -515,7 +516,16 @@ function ChannelBindingControl({
     lastSyncedScalarRef.current = scalarString
     setDraft(scalarString)
   }
+  // Escape resets the draft and then blurs the input — but React batches the
+  // `setDraft` so the immediately-following `onBlur` reads the stale typed
+  // value from the closure and would commit it. This ref tells commitDraft
+  // to skip the next call, so Escape reliably cancels.
+  const skipNextCommitRef = useRef(false)
   const commitDraft = () => {
+    if (skipNextCommitRef.current) {
+      skipNextCommitRef.current = false
+      return
+    }
     if (draft !== scalarString) {
       onChange({ scalar: draft })
     }
@@ -575,7 +585,11 @@ function ChannelBindingControl({
               // single-sourced so Enter and click-away behave identically.
               e.currentTarget.blur()
             } else if (e.key === 'Escape') {
-              // Cancel the in-flight edit, restoring the committed value.
+              // Cancel the in-flight edit, restoring the committed value. The
+              // flag is required because React batches `setDraft` — without
+              // it, the synchronous `onBlur` would still see the stale typed
+              // draft from this render's closure and commit it.
+              skipNextCommitRef.current = true
               setDraft(scalarString)
               e.currentTarget.blur()
             }

--- a/analytics-web-app/src/lib/screen-renderers/cells/MapCell.tsx
+++ b/analytics-web-app/src/lib/screen-renderers/cells/MapCell.tsx
@@ -22,6 +22,7 @@ import {
   defaultMappingFor,
   hexFromRgba,
   materializeRow,
+  resolveMappingScalars,
   resolveOverlayConstants,
   rgbaFromHex,
   type ChannelBinding,
@@ -203,7 +204,7 @@ export function MapCell({
   const scaleZCol = bindingColumn(mappingObj?.scaleZ)
   const colorCol = bindingColumn(mappingObj?.color)
 
-  const overlayResult = useMemo(
+  const overlayBuildResult = useMemo(
     () => {
       if (!sourceTable) return null
       const { mapping } = resolveMapping(options)
@@ -227,14 +228,46 @@ export function MapCell({
   // mapping). When `buildOverlay` skipped allocating `overlay.colorsRGBA`
   // because color is scalar, the renderer reads `constants.color` from here
   // instead.
-  const constants = useMemo(
+  //
+  // `resolveMappingScalars` expands any `$macro` strings stored in scalar
+  // bindings against the notebook macro context. Decoupled from the heavy
+  // buildOverlay memo: a macro that drives a scalar (e.g. `$mySize`) changes
+  // the scalar value without changing which column the channel reads from,
+  // so we re-resolve constants but skip the row walk.
+  const resolvedMappingResult = useMemo(
     () => {
       const { mapping } = resolveMapping(options)
-      return resolveOverlayConstants(mapping)
+      return resolveMappingScalars(mapping, {
+        variables,
+        timeRange,
+        cellResults,
+        cellSelections,
+      })
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [options?.shape, options?.mapping, options?.markerColor, options?.markerSize],
+    [
+      options?.shape,
+      options?.mapping,
+      options?.markerColor,
+      options?.markerSize,
+      variables,
+      timeRange.begin,
+      timeRange.end,
+      cellResults,
+      cellSelections,
+    ],
   )
+  const constants = useMemo(
+    () =>
+      resolvedMappingResult.ok
+        ? resolveOverlayConstants(resolvedMappingResult.mapping)
+        : resolveOverlayConstants(undefined),
+    [resolvedMappingResult],
+  )
+  // Surface a macro-resolution failure as if it were a build failure — same
+  // error rendering surface, so the user sees one consistent place for
+  // mapping problems whether they're column-, scalar-, or macro-driven.
+  const overlayResult = resolvedMappingResult.ok ? overlayBuildResult : resolvedMappingResult
   const overlay = overlayResult?.ok ? overlayResult.overlay : null
   const shape: Shape = (options?.shape as Shape) === 'box' ? 'box' : 'sphere'
 
@@ -415,13 +448,19 @@ export function MapCell({
  * One channel-binding row in the Primitive section. The radio toggles between
  * a literal value (`scalar`) and a column reference (`column`); the inline
  * editor swaps to match.
+ *
+ * Scalar input is a plain text field — whatever the user types is stored as
+ * a string and passed through macro substitution at render time, then parsed
+ * to a number (for numeric channels) or `#rrggbb[aa]` (for color). This is
+ * what lets `$mySize` or `$cell.selected.radius` drive the value. Legacy
+ * scalars stored as raw numbers/RGBA-u32 still load — they're rendered in
+ * their canonical string form (`"10"` or `"#bf360cff"`) on first edit.
  */
 function ChannelBindingControl({
   label,
   kind,
   binding,
   fallbackScalar,
-  numericRange,
   columns,
   onChange,
 }: {
@@ -429,18 +468,20 @@ function ChannelBindingControl({
   kind: 'numeric' | 'color'
   binding: ChannelBinding | undefined
   fallbackScalar: number
-  numericRange?: { min: number; max: number; step: number }
   columns: string[]
   onChange: (next: ChannelBinding) => void
 }) {
   const isColumn = !!binding && 'column' in binding
   const mode: 'scalar' | 'column' = isColumn ? 'column' : 'scalar'
 
+  const formatScalar = (value: number): string =>
+    kind === 'color' ? hexFromRgba(value) : String(value)
+
   const noColumns = columns.length === 0
   const setMode = (next: 'scalar' | 'column') => {
     if (next === mode) return
     if (next === 'scalar') {
-      onChange({ scalar: fallbackScalar })
+      onChange({ scalar: formatScalar(fallbackScalar) })
     } else {
       // Guard: writing `{column: ''}` produces an unresolvable binding that
       // fails buildOverlay with `Column '' not found`. Force scalar mode
@@ -450,17 +491,49 @@ function ChannelBindingControl({
     }
   }
 
-  const scalarValue =
-    binding && 'scalar' in binding ? (binding.scalar as number) : fallbackScalar
+  // Render legacy numeric scalars (number / RGBA u32) in their string form so
+  // the text input can edit them; future edits roundtrip as strings.
+  const scalarString: string = (() => {
+    if (!binding || !('scalar' in binding)) return formatScalar(fallbackScalar)
+    if (typeof binding.scalar === 'string') return binding.scalar
+    if (typeof binding.scalar === 'number') return formatScalar(binding.scalar)
+    return formatScalar(fallbackScalar)
+  })()
 
-  // Split RGBA u32 into hex (#rrggbb) + alpha byte for the picker widgets.
-  const colorHex = kind === 'color' ? hexFromRgba(scalarValue).slice(0, 7) : '#000000'
-  const alphaByte = kind === 'color' ? scalarValue & 0xff : 0xff
-
-  const packRgba = (hex: string, alpha: number): number => {
-    const rgba = rgbaFromHex(`${hex}${alpha.toString(16).padStart(2, '0')}`)
-    return rgba ?? 0
+  // Decouple typing from the model. The text input owns an in-flight `draft`
+  // and only commits to `onChange` on blur or Enter. Without this, every
+  // keystroke would round-trip through `updateMappingChannel` (which wraps
+  // the parent update in `startTransition`); the deferred re-render then
+  // resyncs `value` mid-typing and the browser resets the cursor position.
+  //
+  // The ref-guarded sync block adopts the prop value when it changes from
+  // outside this control — mode switch, color-picker pick, saved-config
+  // reload — so external updates win over uncommitted typing.
+  const [draft, setDraft] = useState(scalarString)
+  const lastSyncedScalarRef = useRef(scalarString)
+  if (lastSyncedScalarRef.current !== scalarString) {
+    lastSyncedScalarRef.current = scalarString
+    setDraft(scalarString)
   }
+  const commitDraft = () => {
+    if (draft !== scalarString) {
+      onChange({ scalar: draft })
+    }
+  }
+
+  const placeholder =
+    kind === 'color' ? '#bf360cff or $myColor' : 'e.g. 10 or $mySize'
+
+  // For the color channel, parse the current text into an RGBA u32 so the
+  // picker swatch reflects literal hex values. Macros and invalid text fall
+  // back to the channel's default — clicking the picker then writes a fresh
+  // `#rrggbbff`, replacing whatever non-hex string was there. Read from the
+  // committed `scalarString`, not the in-flight `draft`, so the swatch
+  // doesn't strobe through partially-typed hex codes.
+  const parsedRgba =
+    kind === 'color' ? rgbaFromHex(scalarString) ?? fallbackScalar : 0
+  const colorPickerHex = hexFromRgba(parsedRgba).slice(0, 7)
+  const currentAlpha = parsedRgba & 0xff
 
   return (
     <div className="flex items-center gap-2 flex-wrap">
@@ -488,42 +561,46 @@ function ChannelBindingControl({
         </label>
       </div>
 
-      {mode === 'scalar' && kind === 'numeric' && (
+      {mode === 'scalar' && (
         <input
-          type="number"
-          value={Number.isFinite(scalarValue) ? scalarValue : 0}
-          min={numericRange?.min}
-          max={numericRange?.max}
-          step={numericRange?.step ?? 1}
-          onChange={(e) => {
-            const v = Number(e.target.value)
-            onChange({ scalar: Number.isFinite(v) ? v : 0 })
+          type="text"
+          value={draft}
+          placeholder={placeholder}
+          spellCheck={false}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commitDraft}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              // Blur triggers commitDraft via onBlur — keeps the commit path
+              // single-sourced so Enter and click-away behave identically.
+              e.currentTarget.blur()
+            } else if (e.key === 'Escape') {
+              // Cancel the in-flight edit, restoring the committed value.
+              setDraft(scalarString)
+              e.currentTarget.blur()
+            }
           }}
-          className="w-24 bg-app-card border border-theme-border rounded px-2 py-1 text-sm text-theme-text-primary focus:outline-none focus:border-accent-link"
+          className="flex-1 min-w-[10rem] bg-app-card border border-theme-border rounded px-2 py-1 text-sm font-mono text-theme-text-primary focus:outline-none focus:border-accent-link"
         />
       )}
 
       {mode === 'scalar' && kind === 'color' && (
-        <>
-          <input
-            type="color"
-            value={colorHex}
-            onChange={(e) => onChange({ scalar: packRgba(e.target.value, alphaByte) })}
-            className="w-7 h-7 rounded cursor-pointer border border-theme-border bg-transparent"
-          />
-          <label className="text-xs text-theme-text-muted">alpha</label>
-          <input
-            type="range"
-            min="0"
-            max="255"
-            value={alphaByte}
-            onChange={(e) =>
-              onChange({ scalar: packRgba(colorHex, Number(e.target.value)) })
-            }
-            className="w-24 accent-accent-link"
-          />
-          <span className="text-xs text-theme-text-muted w-7">{alphaByte}</span>
-        </>
+        <input
+          type="color"
+          value={colorPickerHex}
+          // HTML <input type="color"> doesn't carry alpha, so preserve the
+          // current text's alpha byte (or 0xff for non-hex inputs) when the
+          // picker fires. Picking always replaces the text with a fresh hex,
+          // so a macro typed into the field will be overwritten — that's the
+          // intended affordance for "switch back to a literal color".
+          onChange={(e) => {
+            const alphaHex = currentAlpha.toString(16).padStart(2, '0')
+            onChange({ scalar: `${e.target.value}${alphaHex}` })
+          }}
+          aria-label={`${label} color picker`}
+          title="Pick a color (replaces the text value)"
+          className="w-7 h-7 rounded cursor-pointer border border-theme-border bg-transparent shrink-0"
+        />
       )}
 
       {mode === 'column' && (
@@ -729,7 +806,6 @@ export function MapCellEditor({
               kind="numeric"
               binding={channelBinding('size')}
               fallbackScalar={10}
-              numericRange={{ min: 0, max: 10000, step: 1 }}
               columns={availableColumns ?? []}
               onChange={(b) => updateMappingChannel('size', b)}
             />
@@ -751,7 +827,6 @@ export function MapCellEditor({
               kind="numeric"
               binding={channelBinding('scaleX')}
               fallbackScalar={100}
-              numericRange={{ min: 0, max: 100000, step: 1 }}
               columns={availableColumns ?? []}
               onChange={(b) => updateMappingChannel('scaleX', b)}
             />
@@ -760,7 +835,6 @@ export function MapCellEditor({
               kind="numeric"
               binding={channelBinding('scaleY')}
               fallbackScalar={100}
-              numericRange={{ min: 0, max: 100000, step: 1 }}
               columns={availableColumns ?? []}
               onChange={(b) => updateMappingChannel('scaleY', b)}
             />
@@ -769,7 +843,6 @@ export function MapCellEditor({
               kind="numeric"
               binding={channelBinding('scaleZ')}
               fallbackScalar={100}
-              numericRange={{ min: 0, max: 100000, step: 1 }}
               columns={availableColumns ?? []}
               onChange={(b) => updateMappingChannel('scaleZ', b)}
             />

--- a/analytics-web-app/src/lib/screen-renderers/cells/__tests__/MapCell.test.tsx
+++ b/analytics-web-app/src/lib/screen-renderers/cells/__tests__/MapCell.test.tsx
@@ -10,7 +10,11 @@ import {
   vectorFromArray,
 } from 'apache-arrow'
 import { mapMetadata } from '../MapCell'
-import { buildOverlay, materializeRow } from '@/components/map/overlay'
+import {
+  buildOverlay,
+  materializeRow,
+  resolveMappingScalars,
+} from '@/components/map/overlay'
 import { DEFAULT_MAP_DETAIL_TEMPLATE } from '../../notebook-utils'
 
 describe('buildOverlay', () => {
@@ -271,6 +275,114 @@ describe('buildOverlay', () => {
     if (result.ok) return
     expect(result.error).toMatch(/Row 1/)
     expect(result.error).toMatch(/non-finite/)
+  })
+})
+
+describe('resolveMappingScalars', () => {
+  const emptyCtx = {
+    variables: {},
+    timeRange: { begin: '', end: '' },
+    cellResults: {},
+    cellSelections: {},
+  }
+
+  it('passes legacy numeric scalars through unchanged', () => {
+    const r = resolveMappingScalars(
+      { size: { scalar: 10 }, color: { scalar: 0xbf360cff } },
+      emptyCtx,
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.mapping.size).toEqual({ scalar: 10 })
+    expect(r.mapping.color).toEqual({ scalar: 0xbf360cff })
+  })
+
+  it('parses a literal numeric string scalar', () => {
+    const r = resolveMappingScalars({ size: { scalar: '42' } }, emptyCtx)
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.mapping.size).toEqual({ scalar: 42 })
+  })
+
+  it('expands a $variable macro into a numeric scalar', () => {
+    const r = resolveMappingScalars(
+      { size: { scalar: '$mySize' } },
+      { ...emptyCtx, variables: { mySize: '75' } },
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.mapping.size).toEqual({ scalar: 75 })
+  })
+
+  it('expands a $cell.selected.column macro into a numeric scalar', () => {
+    const tbl = tableFromArrays({ radius: new Float64Array([25]) })
+    const r = resolveMappingScalars(
+      { size: { scalar: '$tbl.selected.radius' } },
+      {
+        ...emptyCtx,
+        cellResults: { tbl },
+        cellSelections: { tbl: { radius: 25 } },
+      },
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.mapping.size).toEqual({ scalar: 25 })
+  })
+
+  it('returns an error when a numeric macro resolves to non-numeric text', () => {
+    const r = resolveMappingScalars(
+      { size: { scalar: '$label' } },
+      { ...emptyCtx, variables: { label: 'big' } },
+    )
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.error).toMatch(/size/)
+    expect(r.error).toMatch(/not a number/)
+  })
+
+  it('rejects an empty/whitespace scalar as not a number', () => {
+    // Number('') is 0 in JS — guard against silently producing zero from an
+    // unset field by surfacing it as an error.
+    const r = resolveMappingScalars({ size: { scalar: '   ' } }, emptyCtx)
+    expect(r.ok).toBe(false)
+  })
+
+  it('parses a hex color scalar literal', () => {
+    const r = resolveMappingScalars({ color: { scalar: '#bf360cff' } }, emptyCtx)
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.mapping.color).toEqual({ scalar: 0xbf360cff })
+  })
+
+  it('expands a $variable macro into a hex color scalar', () => {
+    const r = resolveMappingScalars(
+      { color: { scalar: '$theme' } },
+      { ...emptyCtx, variables: { theme: '#0080ffff' } },
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.mapping.color).toEqual({ scalar: 0x0080ffff })
+  })
+
+  it('returns an error when a color macro resolves to non-hex text', () => {
+    const r = resolveMappingScalars(
+      { color: { scalar: '$broken' } },
+      { ...emptyCtx, variables: { broken: 'red' } },
+    )
+    expect(r.ok).toBe(false)
+    if (r.ok) return
+    expect(r.error).toMatch(/color/)
+  })
+
+  it('passes column bindings through unchanged', () => {
+    const r = resolveMappingScalars(
+      { size: { column: 'radius' }, color: { column: 'tint' } },
+      emptyCtx,
+    )
+    expect(r.ok).toBe(true)
+    if (!r.ok) return
+    expect(r.mapping.size).toEqual({ column: 'radius' })
+    expect(r.mapping.color).toEqual({ column: 'tint' })
   })
 })
 

--- a/analytics-web-app/src/lib/screen-renderers/cells/__tests__/MapCell.test.tsx
+++ b/analytics-web-app/src/lib/screen-renderers/cells/__tests__/MapCell.test.tsx
@@ -1,3 +1,4 @@
+import { render, screen, fireEvent } from '@testing-library/react'
 import {
   Binary,
   Dictionary,
@@ -9,11 +10,12 @@ import {
   tableFromArrays,
   vectorFromArray,
 } from 'apache-arrow'
-import { mapMetadata } from '../MapCell'
+import { ChannelBindingControl, mapMetadata } from '../MapCell'
 import {
   buildOverlay,
   materializeRow,
   resolveMappingScalars,
+  type ChannelBinding,
 } from '@/components/map/overlay'
 import { DEFAULT_MAP_DETAIL_TEMPLATE } from '../../notebook-utils'
 
@@ -447,5 +449,151 @@ describe('mapMetadata', () => {
 
   it('declares single-row selection mode by default', () => {
     expect(mapMetadata.defaultSelectionMode).toBe('single')
+  })
+})
+
+describe('ChannelBindingControl', () => {
+  // Common props for the numeric variant. Tests override `binding` and `onChange`.
+  const baseProps = {
+    label: 'Size',
+    kind: 'numeric' as const,
+    fallbackScalar: 10,
+    columns: ['x', 'y', 'radius'],
+  }
+
+  it('does not fire onChange while the user types', () => {
+    const onChange = jest.fn()
+    render(
+      <ChannelBindingControl
+        {...baseProps}
+        binding={{ scalar: '10' }}
+        onChange={onChange}
+      />,
+    )
+    const input = screen.getByDisplayValue('10') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '42' } })
+    fireEvent.change(input, { target: { value: '425' } })
+    // The text input is local-draft; nothing should reach the model yet.
+    expect(onChange).not.toHaveBeenCalled()
+    expect(input.value).toBe('425')
+  })
+
+  it('commits the draft on blur', () => {
+    const onChange = jest.fn()
+    render(
+      <ChannelBindingControl
+        {...baseProps}
+        binding={{ scalar: '10' }}
+        onChange={onChange}
+      />,
+    )
+    const input = screen.getByDisplayValue('10') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '42' } })
+    fireEvent.blur(input)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith({ scalar: '42' })
+  })
+
+  it('commits the draft on Enter', () => {
+    const onChange = jest.fn()
+    render(
+      <ChannelBindingControl
+        {...baseProps}
+        binding={{ scalar: '10' }}
+        onChange={onChange}
+      />,
+    )
+    const input = screen.getByDisplayValue('10') as HTMLInputElement
+    // Focus is required for `.blur()` to actually fire a blur event in jsdom.
+    input.focus()
+    fireEvent.change(input, { target: { value: '99' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith({ scalar: '99' })
+  })
+
+  it('Escape discards the draft without committing', () => {
+    // Regression: keydown's setDraft is batched in React 18+, so the
+    // synchronous blur triggered by `.blur()` reads the typed value from
+    // closure. A skip-next-commit flag is required.
+    const onChange = jest.fn()
+    render(
+      <ChannelBindingControl
+        {...baseProps}
+        binding={{ scalar: '10' }}
+        onChange={onChange}
+      />,
+    )
+    const input = screen.getByDisplayValue('10') as HTMLInputElement
+    input.focus()
+    fireEvent.change(input, { target: { value: 'foo' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(onChange).not.toHaveBeenCalled()
+    expect(input.value).toBe('10')
+  })
+
+  it('does not fire onChange on blur when the draft equals the prop', () => {
+    const onChange = jest.fn()
+    render(
+      <ChannelBindingControl
+        {...baseProps}
+        binding={{ scalar: '10' }}
+        onChange={onChange}
+      />,
+    )
+    const input = screen.getByDisplayValue('10') as HTMLInputElement
+    fireEvent.focus(input)
+    fireEvent.blur(input)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('adopts an external prop change over the in-flight draft', () => {
+    // Mode switches, color-picker picks, and saved-config reloads update
+    // the binding from outside. The text input should pick up the new
+    // value instead of keeping a stale uncommitted draft.
+    const onChange = jest.fn()
+    const { rerender } = render(
+      <ChannelBindingControl
+        {...baseProps}
+        binding={{ scalar: '10' }}
+        onChange={onChange}
+      />,
+    )
+    const input = screen.getByDisplayValue('10') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'typing...' } })
+    expect(input.value).toBe('typing...')
+    rerender(
+      <ChannelBindingControl
+        {...baseProps}
+        binding={{ scalar: '50' }}
+        onChange={onChange}
+      />,
+    )
+    expect(input.value).toBe('50')
+  })
+
+  it('renders legacy numeric scalar in canonical string form', () => {
+    render(
+      <ChannelBindingControl
+        {...baseProps}
+        binding={{ scalar: 25 } as ChannelBinding}
+        onChange={jest.fn()}
+      />,
+    )
+    expect(screen.getByDisplayValue('25')).toBeInTheDocument()
+  })
+
+  it('renders legacy numeric color scalar as #rrggbbaa', () => {
+    render(
+      <ChannelBindingControl
+        label="Color"
+        kind="color"
+        fallbackScalar={0xbf360cff}
+        columns={[]}
+        binding={{ scalar: 0xbf360cff } as ChannelBinding}
+        onChange={jest.fn()}
+      />,
+    )
+    expect(screen.getByDisplayValue('#bf360cff')).toBeInTheDocument()
   })
 })

--- a/analytics-web-app/src/lib/screen-renderers/notebook-utils.ts
+++ b/analytics-web-app/src/lib/screen-renderers/notebook-utils.ts
@@ -325,11 +325,37 @@ export function substituteMacros(
   cellResults: Record<string, Table>,
   cellSelections: Record<string, Record<string, unknown>>,
 ): string {
-  let result = sql
+  return substituteMacrosImpl(sql, variables, timeRange, cellResults, cellSelections, escapeSqlValue)
+}
+
+/**
+ * Substitutes macros without SQL escaping — returns the raw resolved value.
+ * Used by non-SQL contexts (e.g. parsing a macro-driven scalar into a number
+ * or a hex color). Same regex/lookup rules as `substituteMacros`.
+ */
+export function substituteMacrosRaw(
+  input: string,
+  variables: Record<string, VariableValue>,
+  timeRange: { begin: string; end: string },
+  cellResults: Record<string, Table>,
+  cellSelections: Record<string, Record<string, unknown>>,
+): string {
+  return substituteMacrosImpl(input, variables, timeRange, cellResults, cellSelections, (s) => s)
+}
+
+function substituteMacrosImpl(
+  input: string,
+  variables: Record<string, VariableValue>,
+  timeRange: { begin: string; end: string },
+  cellResults: Record<string, Table>,
+  cellSelections: Record<string, Record<string, unknown>>,
+  escape: (value: string) => string,
+): string {
+  let result = input
 
   // 1. Substitute $from and $to (user controls quoting, like other variables)
-  result = result.replace(/\$from\b/g, escapeSqlValue(timeRange.begin))
-  result = result.replace(/\$to\b/g, escapeSqlValue(timeRange.end))
+  result = result.replace(/\$from\b/g, escape(timeRange.begin))
+  result = result.replace(/\$to\b/g, escape(timeRange.end))
 
   // 2. Cell result row references: $cell[N].column
   //    Must process before dotted/simple variables to avoid partial matches
@@ -341,7 +367,7 @@ export function substituteMacros(
     const row = table.get(rowIdx)
     if (!row || row[colName] === undefined || row[colName] === null) return match
     const field = table.schema.fields.find((f) => f.name === colName)
-    return escapeSqlValue(formatArrowValue(row[colName], field?.type))
+    return escape(formatArrowValue(row[colName], field?.type))
   })
 
   // 2b. Selected row references: $cell.selected.column
@@ -354,7 +380,7 @@ export function substituteMacros(
     if (value === undefined || value === null) return ''
     const table = cellResults[cellName]
     const field = table?.schema.fields.find((f) => f.name === colName)
-    return escapeSqlValue(formatArrowValue(value, field?.type))
+    return escape(formatArrowValue(value, field?.type))
   })
 
   // 3. Handle dotted variable references first: $variable.column
@@ -373,7 +399,7 @@ export function substituteMacros(
       return match
     }
 
-    return escapeSqlValue(colValue)
+    return escape(colValue)
   })
 
   // 3. Handle simple variable references: $variable
@@ -384,11 +410,11 @@ export function substituteMacros(
     const regex = new RegExp(`\\$${name}\\b(?![.\\[])`, 'g')
 
     if (typeof value === 'string') {
-      result = result.replace(regex, escapeSqlValue(value))
+      result = result.replace(regex, escape(value))
     } else {
       // Multi-column variable referenced without column - use first column value
       const firstValue = getVariableString(value)
-      result = result.replace(regex, escapeSqlValue(firstValue))
+      result = result.replace(regex, escape(firstValue))
     }
   }
 


### PR DESCRIPTION
## Summary
- Resolve `$var`/`$cell.selected.col`/`$cell[N].col` macros in map cell primitive scalar bindings (size, scaleX/Y/Z, color), so the same notebook macro context that drives SQL can drive overlay scalars.
- Swap the legacy `<input type="number">` and color-picker-with-alpha-slider for a single text field per scalar channel, with the color picker preserved alongside as a swatch (writes back as `#rrggbbaa`).
- Decouple typing from the model: the text input owns an in-flight `draft` and commits on blur or Enter (Escape cancels). Without this, every keystroke would round-trip through a `startTransition`-wrapped parent update and the deferred re-render would reset the cursor mid-typing.
- Surface macro-resolution failures through the same error-render path as `buildOverlay` so the user sees one consistent surface whether the mapping problem is column-, scalar-, or macro-driven.
- Factor `substituteMacrosRaw` out of `substituteMacros` (shared implementation, identity escape vs. SQL escape) so non-SQL contexts can reuse the macro engine.
- Add `numericScalarOr` as a runtime safety net so `buildOverlay`/`resolveOverlayConstants` can't silently coerce a `"$mySize"` string into NaN — `resolveMappingScalars` is expected to have converted upstream, but the legacy two-form scalar (`number | string`) makes the guard cheap and worth keeping.
- Test coverage: `resolveMappingScalars` (numeric/color/macro success and error paths, column passthrough, legacy numeric passthrough); `ChannelBindingControl` (typing doesn't fire onChange, blur/Enter commits, Escape cancels, no-op blur skipped, external prop adoption over in-flight draft, legacy number/RGBA rendering in canonical string form).

## Test plan
- [x] `yarn lint`, `yarn type-check`, `yarn test` (43 suites / 969 tests pass)
- [ ] Open a map cell, set Size scalar to `$mySize` with a `mySize` notebook variable — the overlay sphere size tracks the variable.
- [ ] Set Color scalar to `$cell.selected.color` where another cell selects a row with a `#rrggbbaa` column — overlay tint reacts to selection.
- [ ] Type a macro that resolves to non-numeric/non-hex text — cell shows a single error message naming the channel and offending text.
- [ ] Type in a scalar field at speed — cursor stays put, no per-keystroke commit; click away or press Enter to commit; Escape restores the previous value.
- [ ] Pick a color via the swatch when the field holds a macro — the macro is replaced with a fresh literal `#rrggbbff`.
- [ ] Open a notebook saved before this change — legacy `{scalar: 10}` / `{scalar: 0xbf360cff}` bindings render as `"10"` / `"#bf360cff"` in the new text input and roundtrip as strings on first edit.