### PR TITLE
Map: require Ctrl/Cmd modifier for wheel zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This file documents the historical progress of the Micromegas project. For curre
   * Refine map navigation: WASD pans horizontally (no elevation), add Q/E keyboard zoom, suppress the browser context menu when a right-drag releases off-canvas, and auto-size the event detail panel with the title rendered via the Markdown template
   * Remove admin-oriented `MICROMEGAS_MAPS_OBJECT_STORE_URI` / `.glb` drop hint from the map cell editor (admins use the Maps management UI)
   * Resolve `$var` macros in map cell primitive scalar bindings (size, scaleX/Y/Z, color); editor swaps the legacy number/color inputs for a text field with local-draft commit (Enter/blur commits, Escape cancels)
+  * Require Ctrl/Cmd modifier for map cell wheel zoom so plain wheel scrolls the surrounding notebook page
 * **Python:**
   * Switch `bulk_ingest` to accept `pyarrow.Table` directly for native pass-through of struct/list/binary columns
   * Resolve CLI connection settings from `~/.micromegas/config.json` with env-var override (#1033)

--- a/analytics-web-app/src/components/map/MapViewer.tsx
+++ b/analytics-web-app/src/components/map/MapViewer.tsx
@@ -725,6 +725,10 @@ function UnrealCameraController({
     }
 
     const onWheel = (e: WheelEvent) => {
+      // Gate zoom on Ctrl/Cmd so plain wheel scrolls the surrounding page
+      // (notebooks embed Map cells in a scrollable container). QE keys remain
+      // an unmodified zoom path for users already on the keyboard.
+      if (!e.ctrlKey && !e.metaKey) return
       e.preventDefault()
 
       const zoomSpeed = 0.1
@@ -1036,7 +1040,7 @@ export function MapViewer({
         <div className="font-semibold text-theme-text-secondary mb-1">Controls</div>
         <div>Left-click + drag: Pan</div>
         <div>Right-click + drag: Rotate</div>
-        <div>Scroll: Zoom</div>
+        <div>Ctrl + Scroll: Zoom</div>
         <div>WASD: Pan</div>
         <div>QE: Zoom</div>
         <div>Z: Reset view</div>


### PR DESCRIPTION
## Summary

- Map cell's wheel handler now early-returns when neither Ctrl nor Cmd is held, so plain wheel events propagate to the surrounding notebook page scroll.
- Only Ctrl/Cmd + wheel calls `preventDefault` and runs the cursor-anchored zoom.
- QE keys remain an unmodified keyboard zoom path.
- Controls hint updated from `Scroll: Zoom` to `Ctrl + Scroll: Zoom`.

The previous behavior trapped every wheel event on the canvas, which made the surrounding notebook page unscrollable when the pointer was over a Map cell. Matches the web-embed convention (Google Maps, Mapbox, Sketchfab) rather than the DCC convention (Unreal, Blender, Maya, 3ds Max) — the relevant precedent here is "3D viewer embedded in a scroll container", not "3D viewer owns the window."

## Test plan

- [ ] Open a notebook page with a Map cell and content above/below it.
- [ ] Hover the Map canvas, scroll the wheel: the page scrolls, the map does not zoom.
- [ ] Hover the Map canvas, hold Ctrl (or Cmd on Mac) and scroll: the map zooms with cursor-anchored anchoring; the page does not scroll.
- [ ] Press Q / E while hovering the canvas: map zooms in / out as before (no modifier needed).
- [ ] Verify the on-canvas Controls overlay reads `Ctrl + Scroll: Zoom`.