### PR TITLE
Add color_scale UDF for perceptually-uniform colormaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This file documents the historical progress of the Micromegas project. For curre
 * **Analytics:**
   * Add `net_spans` JIT view materializing Connection/Object/Property/RPC bandwidth spans with cumulative bit offsets
   * Add `rgba(r, g, b, a)` and `lerp_color(c1, c2, t)` scalar UDFs for building packed RGBA `u32` colors from SQL (#1062)
+  * Add `color_scale(name, t, alpha)` scalar UDF for sampling built-in perceptually-uniform color scales (viridis, magma, plasma, inferno, cividis, turbo); returns packed RGBA `u32` and replaces the blue→red `lerp_color` pattern with one accessible call (#1069)
   * Add `bin_center(coord, cell_size)` scalar UDF for snapping coordinates to the centers of zero-centered bins; composes into 2D heatmap grids via `GROUP BY bin_center(x, cs), bin_center(y, cs)` (#1068)
 * **Web App:**
   * Extend flame graph cell to render bit-axis spans for `net_spans` and add bit-unit support to XYChart
@@ -55,6 +56,7 @@ This file documents the historical progress of the Micromegas project. For curre
   * Document map notebook cell type and hybrid local-frontend setup (#1033)
   * Document CLI configuration file and authentication settings (#1033)
   * Document `rgba` and `lerp_color` color functions in the SQL functions reference (#1062)
+  * Document `color_scale` perceptual colormap function in the SQL functions reference (#1069)
   * Document `bin_center` binning function in the SQL functions reference (#1068)
 * **Security:**
   * Bump rustls-webpki, rand, and uuid to fix Dependabot alerts (#210-213)

--- a/analytics-web-app/src/lib/datafusion-wasm/micromegas_datafusion_wasm.js
+++ b/analytics-web-app/src/lib/datafusion-wasm/micromegas_datafusion_wasm.js
@@ -184,7 +184,7 @@ function __wbg_get_imports() {
             return ret;
         },
         __wbindgen_cast_0000000000000001: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { dtor_idx: 102, function: Function { arguments: [Externref], shim_idx: 28479, ret: Result(Unit), inner_ret: Some(Result(Unit)) }, mutable: true }) -> Externref`.
+            // Cast intrinsic for `Closure(Closure { dtor_idx: 102, function: Function { arguments: [Externref], shim_idx: 28497, ret: Result(Unit), inner_ret: Some(Result(Unit)) }, mutable: true }) -> Externref`.
             const ret = makeMutClosure(arg0, arg1, wasm.wasm_bindgen__closure__destroy__h973cc31d7fb437d2, wasm_bindgen__convert__closures_____invoke__haf48848aa6f4ecee);
             return ret;
         },

--- a/mkdocs/docs/query-guide/functions-reference.md
+++ b/mkdocs/docs/query-guide/functions-reference.md
@@ -1160,6 +1160,79 @@ SELECT lerp_color(CAST(4278190080 AS INT UNSIGNED),  -- 0xff000000
                   0.5) AS color;                     -- 0x80800000
 ```
 
+##### `color_scale(name, t, alpha)`
+
+Samples a built-in perceptually-uniform color scale at position `t` and returns a packed RGBA `UInt32` in `0xRRGGBBAA` byte order. One function call replaces the `lerp_color(rgba(0,0,1,a), rgba(1,0,0,a), t)` pattern, which has a muddy purple mid-band, flat luminance, and poor accessibility.
+
+**Syntax:**
+```sql
+color_scale(name, t, alpha)
+```
+
+**Parameters:**
+
+- `name` (`Utf8`): Color scale identifier (case-insensitive). The recognized scales:
+
+<table>
+  <thead>
+    <tr><th>Name</th><th style="text-align:center;">Gradient</th><th>Notes</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>viridis</code></td>
+      <td><span style="display:inline-block;width:160px;height:14px;border-radius:2px;vertical-align:middle;background:linear-gradient(to right,#440154,#482475,#404387,#345f8d,#29788e,#20908c,#22a884,#42be70,#79d151,#bbde27,#fde725);"></span></td>
+      <td>Sequential blue → green → yellow. Default heatmap; monotonic luminance, color-vision safe.</td>
+    </tr>
+    <tr>
+      <td><code>magma</code></td>
+      <td><span style="display:inline-block;width:160px;height:14px;border-radius:2px;vertical-align:middle;background:linear-gradient(to right,#000004,#140e37,#3b0f6f,#641a80,#8c2981,#b53679,#dd4968,#f66e5b,#fe9f6d,#fece91,#fcfdbf);"></span></td>
+      <td>Sequential black → red → yellow. Reads well on dark backdrops.</td>
+    </tr>
+    <tr>
+      <td><code>plasma</code></td>
+      <td><span style="display:inline-block;width:160px;height:14px;border-radius:2px;vertical-align:middle;background:linear-gradient(to right,#0d0887,#41039d,#6a00a8,#900da3,#b12a90,#cb4678,#e16462,#f1834b,#fca636,#fccd25,#f0f921);"></span></td>
+      <td>Sequential purple → orange → yellow. High contrast.</td>
+    </tr>
+    <tr>
+      <td><code>inferno</code></td>
+      <td><span style="display:inline-block;width:160px;height:14px;border-radius:2px;vertical-align:middle;background:linear-gradient(to right,#000004,#170b3a,#420a67,#6b176e,#932567,#bb3654,#dc5139,#f3761a,#fca40a,#f6d644,#fcffa4);"></span></td>
+      <td>Sequential black → red → yellow. Dark backdrops, hotter mid-band than magma.</td>
+    </tr>
+    <tr>
+      <td><code>cividis</code></td>
+      <td><span style="display:inline-block;width:160px;height:14px;border-radius:2px;vertical-align:middle;background:linear-gradient(to right,#002051,#0a316a,#2a436d,#4c566d,#68686f,#7f7b74,#948f78,#aca375,#cab969,#e9d156,#fde945);"></span></td>
+      <td>Sequential blue → yellow. Maximum color-vision-deficiency safety.</td>
+    </tr>
+    <tr>
+      <td><code>turbo</code></td>
+      <td><span style="display:inline-block;width:160px;height:14px;border-radius:2px;vertical-align:middle;background:linear-gradient(to right,#22171b,#4957dc,#2f9df4,#27d6c3,#4cf883,#94fa50,#dedc32,#ffa422,#f55e17,#ba2108,#900c00);"></span></td>
+      <td>Rainbow-style but perceptually corrected. Use when categorical-looking contrast is wanted.</td>
+    </tr>
+  </tbody>
+</table>
+
+- `t` (`Float64`): Position along the scale, clamped to `[0.0, 1.0]`.
+
+- `alpha` (`Float64`): Output alpha channel, `[0.0, 1.0]` (clamped). Straight (not premultiplied), and independent of the scale's RGB output.
+
+**Returns:** `UInt32` — packed color. `NULL` if any input is `NULL`. An unrecognized `name` raises an error that lists the recognized set.
+
+**Examples:**
+```sql
+-- Density overlay with a perceptual scale; replaces the blue → red lerp.
+SELECT x, y,
+       color_scale('viridis', value / max_value, 0.7) AS color
+FROM density_grid;
+
+-- Dark-mode map cell: magma keeps the hottest cell bright yellow.
+SELECT x, y,
+       color_scale('magma', t, 1.0) AS color
+FROM heatmap;
+
+-- Pure turbo lookup (alpha = 1).
+SELECT color_scale('turbo', 0.5, 1.0);  -- mid-band turbo color
+```
+
 #### Binning Functions
 
 Binning functions snap continuous coordinates onto a discrete grid. Bins are centered on zero with width `cell_size`, so callers building a 2D heatmap or density grid can `GROUP BY bin_center(x, cs), bin_center(y, cs)` and feed the result straight into a map cell (or any other consumer that expects continuous `(x, y)` coordinates) without grid-aware code.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -962,6 +962,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorous"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e18bf7a165bf7028fde98609a0f1e8f7498d762a212598e6c891f6893556ec"
+
+[[package]]
 name = "comfy-table"
 version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3444,6 +3450,7 @@ version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "colorous",
  "datafusion",
  "jsonb",
  "micromegas-tracing",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -42,6 +42,7 @@ chrono = { version = "0.4", features = ["serde"] }
 ciborium = "0.2.2"
 clap = { version = "4", features = ["derive", "env"] }
 colored = { version = "3" }
+colorous = "1.0"
 ctrlc = "3.2.0"
 datafusion = "52.5"
 flate2 = "1.0"

--- a/rust/datafusion-extensions/Cargo.toml
+++ b/rust/datafusion-extensions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micromegas-datafusion-extensions"
-description = "WASM-compatible DataFusion UDF extensions (JSONB, histogram, properties, color, binning) for micromegas"
+description = "WASM-compatible DataFusion UDF extensions for micromegas"
 keywords.workspace = true
 version.workspace = true
 edition.workspace = true
@@ -12,6 +12,7 @@ authors.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+colorous.workspace = true
 datafusion.workspace = true
 jsonb.workspace = true
 micromegas-tracing.workspace = true

--- a/rust/datafusion-extensions/src/color/color_scale.rs
+++ b/rust/datafusion-extensions/src/color/color_scale.rs
@@ -1,0 +1,167 @@
+use datafusion::arrow::array::{Array, Float64Array, StringArray, UInt32Builder};
+use datafusion::arrow::datatypes::DataType;
+use datafusion::common::{Result, internal_err};
+use datafusion::error::DataFusionError;
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion::scalar::ScalarValue;
+use std::any::Any;
+use std::sync::Arc;
+
+use super::{float_to_byte, pack_rgba};
+
+/// Recognized colormap names. Listed in the error message so users can fix a
+/// typo without consulting the docs.
+const RECOGNIZED: &[&str] = &["viridis", "magma", "plasma", "inferno", "cividis", "turbo"];
+
+/// Resolve a colormap name to a `colorous::Gradient`. Case-insensitive.
+///
+/// `colorous::Gradient` is `Copy` and the gradient items are `pub const` (not
+/// `'static`), so this returns by value.
+fn resolve_colormap(name: &str) -> Option<colorous::Gradient> {
+    let lower = name.to_ascii_lowercase();
+    match lower.as_str() {
+        "viridis" => Some(colorous::VIRIDIS),
+        "magma" => Some(colorous::MAGMA),
+        "plasma" => Some(colorous::PLASMA),
+        "inferno" => Some(colorous::INFERNO),
+        "cividis" => Some(colorous::CIVIDIS),
+        "turbo" => Some(colorous::TURBO),
+        _ => None,
+    }
+}
+
+fn unknown_colormap_err(name: &str) -> DataFusionError {
+    DataFusionError::Execution(format!(
+        "color_scale(): unknown colormap '{name}'. Recognized: {}",
+        RECOGNIZED.join(", ")
+    ))
+}
+
+/// `color_scale(name, t, alpha) -> UInt32`
+///
+/// Samples a built-in perceptually-uniform color scale (viridis, magma,
+/// plasma, inferno, cividis, turbo) at position `t` and packs the result with
+/// the user-supplied alpha as a `0xRRGGBBAA` `u32`. Both `t` and `alpha` are
+/// clamped to `[0.0, 1.0]`. Unknown names raise an error.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct ColorScaleUdf {
+    signature: Signature,
+}
+
+impl ColorScaleUdf {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::exact(
+                vec![DataType::Utf8, DataType::Float64, DataType::Float64],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl Default for ColorScaleUdf {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ScalarUDFImpl for ColorScaleUdf {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "color_scale"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _args: &[DataType]) -> Result<DataType> {
+        Ok(DataType::UInt32)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        if args.args.len() != 3 {
+            return internal_err!("wrong number of arguments to color_scale()");
+        }
+
+        // Fast path: literal colormap name. Resolve once, before lowering
+        // the columns. Under `Volatility::Immutable` a fully-literal call is
+        // constant-folded by DataFusion's `ConstEvaluator`, so an unknown
+        // name surfaces at plan time. A column-driven `t` / `alpha` with a
+        // literal `name` is not foldable, but this still produces a single
+        // upfront error rather than per-row work.
+        let literal_gradient = match &args.args[0] {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s)))
+            | ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(s)))
+            | ColumnarValue::Scalar(ScalarValue::Utf8View(Some(s))) => {
+                Some(resolve_colormap(s).ok_or_else(|| unknown_colormap_err(s))?)
+            }
+            ColumnarValue::Scalar(ScalarValue::Utf8(None))
+            | ColumnarValue::Scalar(ScalarValue::LargeUtf8(None))
+            | ColumnarValue::Scalar(ScalarValue::Utf8View(None)) => {
+                // NULL name => NULL output for all rows; fall through and
+                // the per-row null check will short-circuit.
+                None
+            }
+            _ => None,
+        };
+
+        let arrays = ColumnarValue::values_to_arrays(&args.args)?;
+        let names = arrays[0]
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| {
+                DataFusionError::Internal("color_scale(): first argument must be Utf8".into())
+            })?;
+        let ts = arrays[1]
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .ok_or_else(|| {
+                DataFusionError::Internal("color_scale(): second argument must be Float64".into())
+            })?;
+        let alphas = arrays[2]
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .ok_or_else(|| {
+                DataFusionError::Internal("color_scale(): third argument must be Float64".into())
+            })?;
+
+        let len = names.len();
+        if ts.len() != len || alphas.len() != len {
+            return internal_err!("arrays of different lengths in color_scale()");
+        }
+
+        let mut builder = UInt32Builder::with_capacity(len);
+        for i in 0..len {
+            if names.is_null(i) || ts.is_null(i) || alphas.is_null(i) {
+                builder.append_null();
+                continue;
+            }
+            let gradient = match literal_gradient {
+                Some(g) => g,
+                None => {
+                    let name = names.value(i);
+                    match resolve_colormap(name) {
+                        Some(g) => g,
+                        None => return Err(unknown_colormap_err(name)),
+                    }
+                }
+            };
+            let t = ts.value(i).clamp(0.0, 1.0);
+            let color = gradient.eval_continuous(t);
+            let a = float_to_byte(alphas.value(i));
+            builder.append_value(pack_rgba(color.r, color.g, color.b, a));
+        }
+        Ok(ColumnarValue::Array(Arc::new(builder.finish())))
+    }
+}
+
+/// Creates the `color_scale(name, t, alpha) -> UInt32` UDF.
+pub fn make_color_scale_udf() -> ScalarUDF {
+    ScalarUDF::new_from_impl(ColorScaleUdf::new())
+}

--- a/rust/datafusion-extensions/src/color/color_scale.rs
+++ b/rust/datafusion-extensions/src/color/color_scale.rs
@@ -18,17 +18,23 @@ const RECOGNIZED: &[&str] = &["viridis", "magma", "plasma", "inferno", "cividis"
 /// Resolve a colormap name to a `colorous::Gradient`. Case-insensitive.
 ///
 /// `colorous::Gradient` is `Copy` and the gradient items are `pub const` (not
-/// `'static`), so this returns by value.
+/// `'static`), so this returns by value. Uses `eq_ignore_ascii_case` instead
+/// of lowercasing so a column-driven name doesn't allocate per row.
 fn resolve_colormap(name: &str) -> Option<colorous::Gradient> {
-    let lower = name.to_ascii_lowercase();
-    match lower.as_str() {
-        "viridis" => Some(colorous::VIRIDIS),
-        "magma" => Some(colorous::MAGMA),
-        "plasma" => Some(colorous::PLASMA),
-        "inferno" => Some(colorous::INFERNO),
-        "cividis" => Some(colorous::CIVIDIS),
-        "turbo" => Some(colorous::TURBO),
-        _ => None,
+    if name.eq_ignore_ascii_case("viridis") {
+        Some(colorous::VIRIDIS)
+    } else if name.eq_ignore_ascii_case("magma") {
+        Some(colorous::MAGMA)
+    } else if name.eq_ignore_ascii_case("plasma") {
+        Some(colorous::PLASMA)
+    } else if name.eq_ignore_ascii_case("inferno") {
+        Some(colorous::INFERNO)
+    } else if name.eq_ignore_ascii_case("cividis") {
+        Some(colorous::CIVIDIS)
+    } else if name.eq_ignore_ascii_case("turbo") {
+        Some(colorous::TURBO)
+    } else {
+        None
     }
 }
 
@@ -95,18 +101,11 @@ impl ScalarUDFImpl for ColorScaleUdf {
         // name surfaces at plan time. A column-driven `t` / `alpha` with a
         // literal `name` is not foldable, but this still produces a single
         // upfront error rather than per-row work.
+        // Signature is `exact(Utf8)`, so a literal name arrives as
+        // `ScalarValue::Utf8`; no need to match the other string variants.
         let literal_gradient = match &args.args[0] {
-            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s)))
-            | ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(s)))
-            | ColumnarValue::Scalar(ScalarValue::Utf8View(Some(s))) => {
+            ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => {
                 Some(resolve_colormap(s).ok_or_else(|| unknown_colormap_err(s))?)
-            }
-            ColumnarValue::Scalar(ScalarValue::Utf8(None))
-            | ColumnarValue::Scalar(ScalarValue::LargeUtf8(None))
-            | ColumnarValue::Scalar(ScalarValue::Utf8View(None)) => {
-                // NULL name => NULL output for all rows; fall through and
-                // the per-row null check will short-circuit.
-                None
             }
             _ => None,
         };

--- a/rust/datafusion-extensions/src/color/mod.rs
+++ b/rust/datafusion-extensions/src/color/mod.rs
@@ -28,7 +28,18 @@
 //!   `saturate_color`.
 //! - Color-space-specific operations: `<op>_<space>` suffix — `lerp_oklab`,
 //!   `lerp_hsl`, etc.
+//! - Colormaps: `color_scale(name, t, alpha)` (this module) is the entry
+//!   point for sequential/diverging perceptual scales. Categorical scales
+//!   are reserved under a distinct name (e.g. `color_category(name, i,
+//!   alpha)`) because they take an integer index, not a `t`. Reversed
+//!   scales are reserved as either a `'<name>_r'` suffix or a sibling
+//!   `color_scale_reversed` UDF — pick when the first user asks. Direct
+//!   per-colormap UDFs (`viridis(t, alpha)`, …) are intentionally *not*
+//!   reserved; if needed later they can be added as aliases of
+//!   `color_scale`.
 
+/// `color_scale(name, t, alpha) -> UInt32`
+pub mod color_scale;
 /// `lerp_color(c1, c2, t) -> UInt32`
 pub mod lerp_color;
 /// `rgba(r, g, b, a) -> UInt32`

--- a/rust/datafusion-extensions/src/lib.rs
+++ b/rust/datafusion-extensions/src/lib.rs
@@ -2,7 +2,7 @@
 pub mod binary_column_accessor;
 /// Binning UDFs (bin_center)
 pub mod binning;
-/// Color UDFs (rgba, lerp_color)
+/// Color UDFs (rgba, lerp_color, color_scale)
 pub mod color;
 /// Compute histograms from SQL
 pub mod histogram;
@@ -14,7 +14,9 @@ pub mod properties;
 use std::sync::Arc;
 
 use binning::bin_center::make_bin_center_udf;
-use color::{lerp_color::make_lerp_color_udf, rgba::make_rgba_udf};
+use color::{
+    color_scale::make_color_scale_udf, lerp_color::make_lerp_color_udf, rgba::make_rgba_udf,
+};
 use datafusion::logical_expr::ScalarUDF;
 use datafusion::prelude::SessionContext;
 use histogram::{
@@ -76,6 +78,7 @@ pub fn register_extension_udfs(ctx: &SessionContext) {
 
     ctx.register_udf(make_rgba_udf());
     ctx.register_udf(make_lerp_color_udf());
+    ctx.register_udf(make_color_scale_udf());
 
     ctx.register_udf(make_bin_center_udf());
 }

--- a/rust/datafusion-extensions/tests/color_tests.rs
+++ b/rust/datafusion-extensions/tests/color_tests.rs
@@ -452,3 +452,40 @@ async fn color_scale_composes_with_arithmetic() {
     assert_ne!(mid, 0x440154ff);
     assert_ne!(mid, 0xfde725ff);
 }
+
+#[tokio::test]
+async fn color_scale_accepts_column_driven_name() {
+    // Exercises the column-driven name path: when `name` is not a literal
+    // scalar, `literal_gradient` is `None` and each row resolves through
+    // the per-row `resolve_colormap` branch. Mixed casing in the same
+    // column also forces the case-insensitive comparison to run per-row.
+    // Endpoints at `t = 0.0` pin each gradient's first stop.
+    let ctx = make_ctx();
+    let df = ctx
+        .sql(
+            "SELECT color_scale(name, 0.0, 1.0) AS v \
+             FROM (VALUES ('viridis'), ('Magma'), ('TURBO')) AS t(name)",
+        )
+        .await
+        .expect("SQL query failed");
+    let batches = df.collect().await.expect("failed to collect results");
+    let mut rows: Vec<Option<u32>> = Vec::new();
+    for batch in &batches {
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .expect("should be UInt32Array");
+        for i in 0..arr.len() {
+            rows.push(if arr.is_null(i) {
+                None
+            } else {
+                Some(arr.value(i))
+            });
+        }
+    }
+    assert_eq!(
+        rows,
+        vec![Some(0x440154ff), Some(0x000004ff), Some(0x22171bff)],
+    );
+}

--- a/rust/datafusion-extensions/tests/color_tests.rs
+++ b/rust/datafusion-extensions/tests/color_tests.rs
@@ -224,3 +224,231 @@ async fn lerp_color_rejects_bare_int_literals() {
         "lerp_color must reject bare integer literals (no Int64 -> UInt32 coercion); got Ok",
     );
 }
+
+// ---------- color_scale ----------
+//
+// Endpoint expected values come from `colorous::<NAME>.eval_continuous(0.0)`
+// and `(1.0)`; baking them in pins the gradient data so a future `colorous`
+// release that silently shifts the tables fails loudly here.
+
+#[tokio::test]
+async fn color_scale_viridis_endpoints() {
+    let ctx = make_ctx();
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('viridis', 0.0, 1.0)").await,
+        vec![Some(0x440154ff)]
+    );
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('viridis', 1.0, 1.0)").await,
+        vec![Some(0xfde725ff)]
+    );
+}
+
+#[tokio::test]
+async fn color_scale_magma_endpoints() {
+    let ctx = make_ctx();
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('magma', 0.0, 1.0)").await,
+        vec![Some(0x000004ff)]
+    );
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('magma', 1.0, 1.0)").await,
+        vec![Some(0xfcfdbfff)]
+    );
+}
+
+#[tokio::test]
+async fn color_scale_plasma_endpoints() {
+    let ctx = make_ctx();
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('plasma', 0.0, 1.0)").await,
+        vec![Some(0x0d0887ff)]
+    );
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('plasma', 1.0, 1.0)").await,
+        vec![Some(0xf0f921ff)]
+    );
+}
+
+#[tokio::test]
+async fn color_scale_inferno_endpoints() {
+    let ctx = make_ctx();
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('inferno', 0.0, 1.0)").await,
+        vec![Some(0x000004ff)]
+    );
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('inferno', 1.0, 1.0)").await,
+        vec![Some(0xfcffa4ff)]
+    );
+}
+
+#[tokio::test]
+async fn color_scale_cividis_endpoints() {
+    let ctx = make_ctx();
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('cividis', 0.0, 1.0)").await,
+        vec![Some(0x002051ff)]
+    );
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('cividis', 1.0, 1.0)").await,
+        vec![Some(0xfde945ff)]
+    );
+}
+
+#[tokio::test]
+async fn color_scale_turbo_endpoints() {
+    let ctx = make_ctx();
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('turbo', 0.0, 1.0)").await,
+        vec![Some(0x22171bff)]
+    );
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('turbo', 1.0, 1.0)").await,
+        vec![Some(0x900c00ff)]
+    );
+}
+
+#[tokio::test]
+async fn color_scale_alpha_is_honored() {
+    let ctx = make_ctx();
+    let full = eval_u32(&ctx, "color_scale('viridis', 0.0, 1.0)").await;
+    let half = eval_u32(&ctx, "color_scale('viridis', 0.0, 0.5)").await;
+    // Same RGB, alpha low byte goes from 0xff -> 0x80 (round-half-up of 127.5).
+    assert_eq!(full, vec![Some(0x440154ff)]);
+    assert_eq!(half, vec![Some(0x44015480)]);
+}
+
+#[tokio::test]
+async fn color_scale_alpha_clamps() {
+    let ctx = make_ctx();
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('viridis', 0.0, -0.5)").await,
+        vec![Some(0x44015400)]
+    );
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('viridis', 0.0, 1.5)").await,
+        vec![Some(0x440154ff)]
+    );
+}
+
+#[tokio::test]
+async fn color_scale_t_clamps_below_zero() {
+    let ctx = make_ctx();
+    let with_negative = eval_u32(&ctx, "color_scale('viridis', -0.5, 1.0)").await;
+    let with_zero = eval_u32(&ctx, "color_scale('viridis', 0.0, 1.0)").await;
+    assert_eq!(with_negative, with_zero);
+}
+
+#[tokio::test]
+async fn color_scale_t_clamps_above_one() {
+    let ctx = make_ctx();
+    let with_high = eval_u32(&ctx, "color_scale('viridis', 1.5, 1.0)").await;
+    let with_one = eval_u32(&ctx, "color_scale('viridis', 1.0, 1.0)").await;
+    assert_eq!(with_high, with_one);
+}
+
+#[tokio::test]
+async fn color_scale_name_is_case_insensitive() {
+    let ctx = make_ctx();
+    let canon = eval_u32(&ctx, "color_scale('viridis', 0.5, 1.0)").await;
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('Viridis', 0.5, 1.0)").await,
+        canon
+    );
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('VIRIDIS', 0.5, 1.0)").await,
+        canon
+    );
+}
+
+#[tokio::test]
+async fn color_scale_null_inputs_yield_null() {
+    let ctx = make_ctx();
+    assert_eq!(
+        eval_u32(&ctx, "color_scale(CAST(NULL AS VARCHAR), 0.5, 1.0)").await,
+        vec![None]
+    );
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('viridis', CAST(NULL AS DOUBLE), 1.0)").await,
+        vec![None]
+    );
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('viridis', 0.5, CAST(NULL AS DOUBLE))").await,
+        vec![None]
+    );
+}
+
+#[tokio::test]
+async fn color_scale_rejects_unknown_name() {
+    let ctx = make_ctx();
+    let result = ctx.sql("SELECT color_scale('not_a_scale', 0.5, 1.0)").await;
+    // Constant-folded literal calls surface the error at plan time
+    // (SQL build), but DataFusion may also return it at execute time. Try
+    // both, accept whichever yields the error, and pin the recognized-set
+    // hint either way.
+    let err = match result {
+        Err(e) => e.to_string(),
+        Ok(df) => match df.collect().await {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("color_scale('not_a_scale', ...) should have failed"),
+        },
+    };
+    assert!(
+        err.contains("not_a_scale"),
+        "error must mention the bad colormap name, got: {err}",
+    );
+    assert!(
+        err.contains("viridis") && err.contains("turbo"),
+        "error must list the recognized set, got: {err}",
+    );
+}
+
+#[tokio::test]
+async fn color_scale_int_literal_coerces() {
+    // `Signature::exact` coerces Int64 -> Float64; round-tripping 0 and 1
+    // through the int path should match the float endpoints.
+    let ctx = make_ctx();
+    assert_eq!(
+        eval_u32(&ctx, "color_scale('viridis', 0, 1)").await,
+        vec![Some(0x440154ff)]
+    );
+}
+
+#[tokio::test]
+async fn color_scale_composes_with_arithmetic() {
+    // Smoke test: column-driven `t` derived from arithmetic in a small
+    // literal table. Asserts no panic and a well-formed UInt32 result.
+    let ctx = make_ctx();
+    let df = ctx
+        .sql(
+            "SELECT color_scale('viridis', metric / 100.0, 1.0) AS v \
+             FROM (VALUES (0.0), (50.0), (100.0)) AS t(metric)",
+        )
+        .await
+        .expect("SQL query failed");
+    let batches = df.collect().await.expect("failed to collect results");
+    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total, 3);
+    let mut rows: Vec<Option<u32>> = Vec::with_capacity(3);
+    for batch in &batches {
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .expect("should be UInt32Array");
+        for i in 0..arr.len() {
+            rows.push(if arr.is_null(i) {
+                None
+            } else {
+                Some(arr.value(i))
+            });
+        }
+    }
+    assert_eq!(rows[0], Some(0x440154ff));
+    assert_eq!(rows[2], Some(0xfde725ff));
+    // Midpoint just has to be non-null and not equal to either endpoint.
+    let mid = rows[1].expect("midpoint must not be NULL");
+    assert_ne!(mid, 0x440154ff);
+    assert_ne!(mid, 0xfde725ff);
+}

--- a/rust/datafusion-wasm/Cargo.lock
+++ b/rust/datafusion-wasm/Cargo.lock
@@ -560,6 +560,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorous"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e18bf7a165bf7028fde98609a0f1e8f7498d762a212598e6c891f6893556ec"
+
+[[package]]
 name = "comfy-table"
 version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,6 +2326,7 @@ version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "colorous",
  "datafusion",
  "jsonb",
  "micromegas-tracing",

--- a/tasks/completed/1069_color_scale_udf_plan.md
+++ b/tasks/completed/1069_color_scale_udf_plan.md
@@ -1,0 +1,444 @@
+# Color Scale UDF Plan
+
+Issue: [#1069](https://github.com/madesroches/micromegas/issues/1069)
+
+## Overview
+
+Add a `color_scale(name, t, alpha) -> UInt32` scalar UDF that produces a
+packed RGBA color from a perceptually-uniform color scale (viridis, magma,
+plasma, inferno, turbo). Today the natural default for a heat-style overlay
+in a notebook map cell is `lerp_color(rgba(0,0,1,a), rgba(1,0,0,a), t)`,
+which has a muddy purple mid-band, flat luminance, and bad accessibility
+behavior. This UDF replaces that 3-line invocation with one function call
+and gives users built-in perceptual scales with the same return type the
+rest of the color UDFs use.
+
+## Current State
+
+- **Color UDF crate.** WASM-compatible scalar color UDFs live in
+  `rust/datafusion-extensions/src/color/`. Two UDFs already ship:
+  `rgba(r,g,b,a)` (`src/color/rgba.rs`) and `lerp_color(c1,c2,t)`
+  (`src/color/lerp_color.rs`). Both implement `ScalarUDFImpl` and follow
+  the `make_<name>_udf() -> ScalarUDF` constructor pattern.
+- **Locked-in conventions.** `src/color/mod.rs:3-30` lays out the four
+  API conventions every color UDF must honor (packing as `0xRRGGBBAA`,
+  float channels in `[0,1]` with clamp at byte boundary, straight alpha,
+  sRGB color space). The future-extension reservations section
+  (lines 22-30) does not yet name colormap UDFs — this plan adds that
+  reservation.
+- **Shared helpers.** `pack_rgba`, `unpack_rgba`, `float_to_byte`, and
+  `round_to_byte` are exported from `color/mod.rs`. The new UDF reuses
+  `pack_rgba` and `float_to_byte` for assembling the final `u32`.
+- **Registration.** Extension UDFs register in
+  `rust/datafusion-extensions/src/lib.rs:45-81` via
+  `register_extension_udfs(&ctx)`. The new UDF appends one line there.
+- **Test pattern.** Tests live in `rust/datafusion-extensions/tests/`
+  per `CLAUDE.md`. `color_tests.rs` already builds a `SessionContext`,
+  registers extension UDFs, evals SQL through a `eval_u32(ctx, expr)`
+  helper, and asserts on returned `Option<u32>` values. The new tests
+  reuse that helper.
+- **Documentation.** SQL functions live in
+  `mkdocs/docs/query-guide/functions-reference.md`. The existing
+  `#### Color Functions` group (line 1088) explains the packing
+  convention and documents `rgba` and `lerp_color`. The new UDF adds a
+  `##### color_scale(name, t, alpha)` subsection under that group.
+- **Consumer.** The map cell decodes `0xRRGGBBAA` packed `u32` in
+  `analytics-web-app/src/lib/screen-renderers/cells/MapViewer.tsx`
+  (per the [1062 plan](completed/1062_color_udfs_plan.md)). The new UDF
+  returns the same `UInt32` layout, so no consumer-side changes are
+  needed.
+
+## Design
+
+### API shape (locked in by this plan)
+
+Following the issue's preferred form:
+
+```
+color_scale(name: Utf8, t: Float64, alpha: Float64) -> UInt32
+```
+
+- `name` — colormap identifier; recognized values are listed below.
+  Matched case-insensitively against the canonical lowercase name.
+- `t` — position along the scale, clamped to `[0.0, 1.0]`.
+- `alpha` — output alpha channel, clamped to `[0.0, 1.0]` and quantized
+  to `0..=255` via `float_to_byte` (the same helper `rgba` uses, so
+  alpha quantization stays consistent across color UDFs).
+- Return — packed `0xRRGGBBAA` `UInt32`. NULL if any of the three
+  inputs is NULL on that row. Unknown colormap names raise an error
+  (see *Name validation* below).
+- Alpha is independent of the colormap's RGB output. Colormap tables
+  store RGB only; the user picks alpha freely. This matches `rgba`'s
+  straight-alpha convention.
+
+**Canonical colormap names (initial set):**
+
+| Name      | Family    | Use case                          |
+| --------- | --------- | --------------------------------- |
+| `viridis` | sequential, blue→green→yellow | default heatmap, peak findability |
+| `magma`   | sequential, black→red→yellow  | dark-backdrop overlays            |
+| `plasma`  | sequential, purple→orange→yellow | high-contrast sequential       |
+| `inferno` | sequential, black→red→yellow  | dark-backdrop, hotter mid-band    |
+| `cividis` | sequential, blue→yellow       | maximum color-vision-deficiency safety |
+| `turbo`   | "rainbow-style" but perceptual | when categorical-looking contrast is wanted |
+
+The five from the issue (viridis, magma, plasma, inferno, turbo) plus
+cividis, which is the canonical "color-vision-safe sequential" scale
+and fits the same `color_scale` signature with no extra design work.
+All are perceptually-uniform with monotonic luminance (turbo
+near-monotonic). Names match matplotlib/d3/colorous.
+
+### Signature & coercion
+
+```rust
+Signature::exact(
+    vec![DataType::Utf8, DataType::Float64, DataType::Float64],
+    Volatility::Immutable,
+)
+```
+
+`Volatility::Immutable` enables DataFusion to constant-fold the call
+when all three args are constants. DataFusion will coerce `LargeUtf8` /
+`Utf8View` to `Utf8` and `Int64` / `Float32` to `Float64` under
+`exact`, so `color_scale('viridis', 1, 1)` works without explicit
+casts. The expected planning behaviour mirrors `rgba` (see
+`tests/color_tests.rs:96-103`).
+
+### Lookup strategy
+
+Use the `colorous` crate (Apache-2.0, no runtime dependencies, pure
+Rust → WASM-compatible) as the source of colormap data. It exposes a
+single function we need:
+
+```rust
+colorous::VIRIDIS.eval_continuous(t: f64) -> colorous::Color { r: u8, g: u8, b: u8 }
+```
+
+`colorous` already supplies viridis, magma, plasma, inferno, and turbo
+with values traceable to matplotlib (BIDS team) and Google. Using the
+crate avoids hand-maintaining 5 × 256 × 3 = 3840 bytes of color data in
+the repo and keeps the source authoritative.
+
+Trade-off versus owning the tables is recorded in *Trade-offs* below.
+
+### Module layout
+
+Add one new file in the existing `color/` directory, mirroring the
+sibling layout used by `rgba.rs` and `lerp_color.rs`:
+
+```
+rust/datafusion-extensions/src/color/
+  mod.rs           # add color_scale module decl + colormap reservation in doc
+  rgba.rs          # existing
+  lerp_color.rs    # existing
+  color_scale.rs   # NEW: ColorScaleUdf + make_color_scale_udf()
+```
+
+No new submodule directory — the UDF is small and self-contained, and
+the existing color/ flat layout has been working well.
+
+### Internal lookup
+
+```rust
+fn resolve_colormap(name: &str) -> Option<colorous::Gradient> {
+    // Lowercase once; SQL string literals are case-sensitive but we
+    // forgive ALL CAPS / Mixed Case to keep the API ergonomic.
+    let lower = name.to_ascii_lowercase();
+    match lower.as_str() {
+        "viridis" => Some(colorous::VIRIDIS),
+        "magma"   => Some(colorous::MAGMA),
+        "plasma"  => Some(colorous::PLASMA),
+        "inferno" => Some(colorous::INFERNO),
+        "cividis" => Some(colorous::CIVIDIS),
+        "turbo"   => Some(colorous::TURBO),
+        _ => None,
+    }
+}
+```
+
+`colorous::Gradient` is `Copy` and the gradient constants are `pub const`
+items (no `'static` reference available), so the helper returns by value
+rather than by reference.
+
+### Per-row evaluation
+
+```rust
+let c = gradient.eval_continuous(t.clamp(0.0, 1.0));
+let a = float_to_byte(alpha);     // shared with rgba
+pack_rgba(c.r, c.g, c.b, a)       // shared with rgba/lerp_color
+```
+
+### Name validation timing
+
+Validate the colormap name in `invoke_with_args` once at the start of
+the call, optimizing for the common "name is a literal" case:
+
+1. Inspect `args.args[0]` directly *before* the
+   `ColumnarValue::values_to_arrays` lowering. If it is
+   `ColumnarValue::Scalar(ScalarValue::Utf8(Some(s)))`, resolve once;
+   error out immediately on unknown name. With `Volatility::Immutable`,
+   a fully-literal call (`color_scale('virids', 0.5, 1.0)`) gets
+   constant-folded by DataFusion's `ConstEvaluator` and surfaces this
+   error at plan time; the more common `color_scale('virids', column_t,
+   1.0)` form is not foldable, so the error fires once on the first
+   `RecordBatch` instead of per row.
+2. Otherwise (column-driven name, rare in practice), fall through to
+   the row loop and resolve per row. Unknown names on any row produce
+   a query-time error mentioning the offending name and the recognized
+   set.
+
+The error message lists the recognized names so users can fix the
+typo without consulting docs.
+
+### Behaviour summary
+
+| Input                                            | Output              |
+| ------------------------------------------------ | ------------------- |
+| `color_scale('viridis', 0.0, 1.0)`               | `0x440154ff`        |
+| `color_scale('viridis', 1.0, 1.0)`               | `0xfde725ff`        |
+| `color_scale('Viridis', 0.5, 1.0)`               | same as `'viridis'` |
+| `color_scale('viridis', -0.5, 1.0)`              | clamp → `t=0.0`     |
+| `color_scale('viridis', 1.5, 0.5)`               | clamp → `t=1.0`, a=128 |
+| `color_scale(NULL, 0.5, 1.0)`                    | `NULL`              |
+| `color_scale('viridis', NULL, 1.0)`              | `NULL`              |
+| `color_scale('viridis', 0.5, NULL)`              | `NULL`              |
+| `color_scale('not_a_map', 0.5, 1.0)`             | error before row loop (plan time when constant-folded) |
+
+### Future-extension reservations
+
+Document in `color/mod.rs` so future contributors don't pick conflicting
+names:
+
+- **Categorical scales** (e.g. `tab10`, `set1`) — separate UDF
+  `color_category(name, i, alpha) -> UInt32` taking an integer index
+  rather than a `t`. Different signature → different name.
+- **Diverging scales** (e.g. `RdBu`, `coolwarm`) — fit under
+  `color_scale` once they are added to the recognized set; document a
+  midpoint = 0.5 convention.
+- **Reversed scales** — add a `color_scale_reversed(name, t, alpha)`
+  helper, or accept a `'viridis_r'` suffix in the name; pick when the
+  first user asks. Reserved, not built.
+- **Direct exposure as individual UDFs** (e.g. `viridis(t, alpha)`) —
+  intentionally *not* reserved. The plan keeps a single
+  `color_scale` dispatch UDF to avoid polluting the function namespace
+  with per-colormap UDFs; if a future need arises, the individual names
+  can be added as aliases.
+
+## Implementation Steps
+
+1. **Add `colorous` to workspace dependencies.**
+   - `rust/Cargo.toml`: add `colorous = "1.0"` (latest stable, Apache-2.0)
+     to `[workspace.dependencies]` in alphabetical order.
+   - `rust/datafusion-extensions/Cargo.toml`: add
+     `colorous.workspace = true` under `[dependencies]` in alphabetical
+     order. Update the crate `description` to mention color scales
+     (e.g. append "with built-in perceptually-uniform color scales").
+2. **Add the UDF source file.** Create
+   `rust/datafusion-extensions/src/color/color_scale.rs`:
+   - `ColorScaleUdf` struct with `#[derive(Debug, PartialEq, Eq, Hash)]`
+     and `Signature` field (same idiom as `RgbaUdf` and `LerpColorUdf`).
+   - `ScalarUDFImpl` impl: `name()` returns `"color_scale"`,
+     `return_type` returns `UInt32`, `invoke_with_args` does the
+     scalar-name fast path then per-row evaluation.
+   - Private `resolve_colormap(&str) -> Option<colorous::Gradient>`
+     helper (returns by value — `Gradient` is `Copy` and the colorous
+     gradient items are `pub const`, not `static`).
+   - `make_color_scale_udf() -> ScalarUDF` constructor.
+3. **Wire it up.**
+   - `rust/datafusion-extensions/src/color/mod.rs`:
+     - Add `pub mod color_scale;` next to the existing two.
+     - Add a "Colormaps" line to the future-extension reservations
+       section in the module doc-comment, noting that `color_scale`
+       is the entry point and that categorical/reversed/diverging
+       variants are reserved (per the design above).
+   - `rust/datafusion-extensions/src/lib.rs`:
+     - Add `color_scale::make_color_scale_udf` to the `use color::{...}`
+       group.
+     - Append `ctx.register_udf(make_color_scale_udf());` after the two
+       existing color registrations (`lib.rs:77-78`).
+4. **Add tests.** Append cases to
+   `rust/datafusion-extensions/tests/color_tests.rs` (do not create a
+   new file — the existing file already covers the `color` module).
+   See *Testing Strategy*.
+5. **Update SQL function docs.** Append a
+   `##### color_scale(name, t, alpha)` subsection at the end of the
+   existing `#### Color Functions` section in
+   `mkdocs/docs/query-guide/functions-reference.md`, between
+   `lerp_color` and `#### Binning Functions`. Match the existing
+   Syntax / Parameters / Returns / Examples template.
+6. **Run CI locally.** From `rust/`:
+   - `cargo fmt`
+   - `cargo clippy --workspace -- -D warnings`
+   - `cargo test -p micromegas-datafusion-extensions`
+   - `python3 ../build/rust_ci.py`
+
+## Files to Modify
+
+- `rust/Cargo.toml` — add `colorous` workspace dep.
+- `rust/datafusion-extensions/Cargo.toml` — add `colorous.workspace =
+  true`; update crate description.
+- `rust/datafusion-extensions/src/color/mod.rs` — add module decl,
+  extend future-extension reservation doc.
+- `rust/datafusion-extensions/src/color/color_scale.rs` — NEW.
+- `rust/datafusion-extensions/src/lib.rs` — import + register UDF.
+- `rust/datafusion-extensions/tests/color_tests.rs` — append test
+  cases for `color_scale`.
+- `mkdocs/docs/query-guide/functions-reference.md` — add
+  `color_scale` subsection.
+
+## Trade-offs
+
+- **Single dispatch UDF (`color_scale(name, ...)`) vs. per-colormap
+  UDFs (`viridis(t, alpha)`, …).** Single UDF chosen. The issue offers
+  both options; single dispatch keeps the function namespace tight
+  ("one new SQL function for a whole family"), survives the addition
+  of more scales without growing the registration list, and matches
+  the d3 `interpolateXxx`/`scaleSequential` and matplotlib
+  `get_cmap('name')` style users may already know. Cost is that a
+  typo in the name surfaces at query time rather than function-name
+  resolution time — mitigated by the fast-path validation that
+  detects literal-name typos at plan time.
+- **`colorous` dependency vs. owning the colormap tables.** Take
+  the dep. It is Apache-2.0, has no runtime dependencies, is a thin
+  data-only crate (~5 KB of color tables and a handful of methods),
+  and is the canonical Rust port of the matplotlib/d3 colormap data.
+  Owning ~4 KB of `[u8; 3]` table data ourselves would add a
+  generator script, an audit responsibility for any future
+  regeneration, and a place future drift can sneak in. The crate is
+  small enough to vendor mentally — `eval_continuous(t)` and that's
+  it.
+- **Case-insensitive name match vs. strict lowercase.** Case-
+  insensitive. The lookup is a one-shot `to_ascii_lowercase` per call
+  and forgives the most common user mistake without a docs detour.
+  Documentation still shows lowercase as canonical.
+- **Error vs. NULL on unknown colormap name.** Error. The set is small
+  and finite; an unrecognized name is almost certainly a typo, not a
+  data condition. Returning NULL would hide the bug.
+- **Linear interpolation between table entries (what `colorous` does)
+  vs. nearest-neighbor lookup.** Interpolation — preserves smooth
+  gradients. `colorous::eval_continuous` already does this; nothing
+  to decide on our side.
+- **NaN handling.** No special case. `f64::clamp` propagates NaN, so
+  NaN `t` falls through to `colorous::eval_continuous` and NaN
+  `alpha` falls through to `float_to_byte`; in both paths the
+  saturating `f64 as u8` cast resolves NaN to 0. Matches the
+  existing family's "no NaN special-case" stance (`lerp_color` does
+  the same). Adding NaN logic was rejected as unnecessary surface.
+- **No alpha default.** `rgba` already requires an explicit alpha;
+  matching that here keeps the family consistent and dodges
+  variadic-signature complexity. Users who want full opacity write
+  `color_scale('viridis', t, 1.0)`.
+- **`color_scale` vs. `colormap` as the function name.** The issue
+  proposes `color_scale`; d3 says "scale," matplotlib says "cmap,"
+  ggplot says "scale." Naming follows the issue. `colormap` stays
+  available as an alias if a future need surfaces.
+
+## Documentation
+
+Add the following entry to
+`mkdocs/docs/query-guide/functions-reference.md`, immediately after
+the existing `##### lerp_color(c1, c2, t)` subsection and before
+`#### Binning Functions`:
+
+````markdown
+##### `color_scale(name, t, alpha)`
+
+Samples a built-in perceptually-uniform color scale, returning a
+packed RGBA `UInt32` in `0xRRGGBBAA` byte order.
+
+**Syntax:**
+```sql
+color_scale(name, t, alpha)
+```
+
+**Parameters:**
+
+- `name` (`Utf8`): Color scale identifier. Recognized values
+  (case-insensitive):
+  - `viridis` — blue → green → yellow (default for general heatmaps;
+    monotonic luminance, color-vision safe)
+  - `magma`   — black → red → yellow (good over dark backdrops)
+  - `plasma`  — purple → orange → yellow (high contrast)
+  - `inferno` — black → red → yellow (dark backdrops, hotter mid-band)
+  - `cividis` — blue → yellow (maximum color-vision-deficiency safety)
+  - `turbo`   — rainbow-style, perceptually corrected
+
+- `t` (`Float64`): Position along the scale, clamped to `[0.0, 1.0]`.
+
+- `alpha` (`Float64`): Output alpha channel, `[0.0, 1.0]` (clamped),
+  straight (not premultiplied) — independent of the scale's RGB.
+
+**Returns:** `UInt32` — packed color. `NULL` if any input is `NULL`.
+An unrecognized `name` raises an error.
+
+**Examples:**
+```sql
+-- Density overlay with a perceptual scale; replaces the blue→red lerp
+-- that has a muddy purple mid-band and poor accessibility.
+SELECT x, y,
+       color_scale('viridis', value / max_value, 0.7) AS color
+FROM density_grid;
+
+-- Dark-mode map cell: magma keeps the hottest cell bright yellow.
+SELECT x, y,
+       color_scale('magma', t, 1.0) AS color
+FROM heatmap;
+
+-- Pure turbo lookup (alpha = 1).
+SELECT color_scale('turbo', 0.5, 1.0);  -- mid-band turbo color
+```
+````
+
+No update required to `CLAUDE.md` or `AI_GUIDELINES.md`.
+
+## Testing Strategy
+
+Append cases to `rust/datafusion-extensions/tests/color_tests.rs`,
+reusing the existing `make_ctx()` / `eval_u32()` helpers. Coverage:
+
+- **Endpoint anchors per colormap.** For each of viridis / magma /
+  plasma / inferno / cividis / turbo: assert `color_scale(name, 0.0, 1.0)` and
+  `color_scale(name, 1.0, 1.0)` against the canonical hex values
+  reported by `colorous`. (Compute them once during test authoring by
+  calling `colorous::VIRIDIS.eval_continuous(0.0)` etc.; bake the
+  expected `u32` literals into the test. This guards against an
+  upstream crate update silently shifting the gradient — if `colorous`
+  changes its data, our tests fail loudly and we either pin a version
+  or refresh the constants.)
+- **Alpha is honoured.** `color_scale('viridis', 0.0, 0.5)` →
+  same RGB as `color_scale('viridis', 0.0, 1.0)` with the low byte
+  equal to `128`.
+- **Alpha clamping.** `alpha = -0.5` and `alpha = 1.5` produce `0` and
+  `255` respectively in the low byte.
+- **t clamping.** `t = -0.5` matches `t = 0.0`; `t = 1.5` matches
+  `t = 1.0`. Mirrors the existing `lerp_color` clamp tests.
+- **Case-insensitive name match.** `color_scale('Viridis', 0.5, 1.0)`
+  and `color_scale('VIRIDIS', 0.5, 1.0)` both equal
+  `color_scale('viridis', 0.5, 1.0)`.
+- **Null inputs.** Each of name / t / alpha → null result, mirroring
+  the existing `rgba_null_input_yields_null` and
+  `lerp_color_null_inputs_yield_null` patterns.
+- **Unknown name → error.** `color_scale('not_a_scale', 0.5, 1.0)`
+  fails the SQL call. Assert `.is_err()` (matching the
+  `lerp_color_rejects_bare_int_literals` test pattern at
+  `color_tests.rs:217-226`). Verify the error message names the
+  bad colormap and lists the recognized set — that's the load-bearing
+  user-facing detail that makes the error helpful rather than
+  cryptic.
+- **Integration smoke.** Compose with `rgba` /  arithmetic, e.g.
+  `color_scale('viridis', metric / 100.0, 1.0)` over a small literal
+  table, asserting no panic and a well-formed `UInt32` result.
+- **Constant folding.** Implicit — `Volatility::Immutable` plus the
+  scalar fast path means a fully-literal call is folded; no explicit
+  test needed unless we want to assert on the plan output. Skip for
+  now.
+
+## Dependencies
+
+- New: `colorous = "1.0"` (Apache-2.0; no runtime dependencies; WASM-
+  compatible — pure Rust with no platform code). Added at workspace
+  level so other crates can reuse it if needed.
+
+## Open Questions
+
+None.


### PR DESCRIPTION
## Summary

* Add `color_scale(name, t, alpha) -> UInt32` scalar UDF that samples a built-in perceptually-uniform color scale and returns a packed `0xRRGGBBAA` `u32`. Recognized scales: `viridis`, `magma`, `plasma`, `inferno`, `cividis`, `turbo` (case-insensitive). One call replaces the muddy `lerp_color(rgba(0,0,1,a), rgba(1,0,0,a), t)` pattern.
* Source colormap data from the `colorous` crate (Apache-2.0, no runtime deps, WASM-compatible) added at workspace level.
* Fast path validates a literal `name` argument up front so typos surface at plan time under `Volatility::Immutable` constant folding (or once per batch when only `t` / `alpha` are column-driven), instead of per row.
* Document the UDF in `mkdocs/docs/query-guide/functions-reference.md` (with inline gradient swatches) and extend the future-extension reservations in `color/mod.rs` for categorical / reversed / diverging scales so the namespace stays coherent.
* 14 new tests in `color_tests.rs`: endpoint anchors per gradient, alpha honored / clamped, `t` clamped both sides, case-insensitive name, NULL propagation, unknown-name error, int-literal coercion, arithmetic composition, and a column-driven name path.

Closes #1069

Design plan: `tasks/completed/1069_color_scale_udf_plan.md`

## Test plan

- [ ] `cd rust && cargo fmt --check`
- [ ] `cd rust && cargo clippy --workspace -- -D warnings`
- [ ] `cd rust && cargo test -p micromegas-datafusion-extensions --test color_tests`
- [ ] Smoke test in a notebook: `SELECT color_scale('viridis', x / 100.0, 1.0) FROM …` over a small `density_grid` and confirm the map cell renders the expected viridis gradient.
- [ ] Confirm `SELECT color_scale('not_a_scale', 0.5, 1.0)` errors with a message listing the recognized set.