### PR TITLE
Dev worker: ephemeral runners with persistent cache volume

### DIFF
--- a/.github/workflows/grafana-plugin.yml
+++ b/.github/workflows/grafana-plugin.yml
@@ -44,6 +44,7 @@ jobs:
           cache: 'yarn'
 
       - name: Setup Go environment
+        if: needs.check-runner.outputs.runner == 'ubuntu-latest'
         uses: actions/setup-go@v5
         with:
           go-version: '1.25'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ on:
       - 'build/rust_ci.py'
       - 'build/rust_command.py'
       - '.github/workflows/rust.yml'
-  workflow_dispatch:  # For nightly cache warming via dev_worker.py --rotate-cache
+  workflow_dispatch:  # Allow manual runs from the Actions UI
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,7 +131,7 @@ jobs:
         CARGO_BUILD_JOBS: ${{ needs.check-runner.outputs.runner == 'ubuntu-latest' && '2' || '' }}
         # Override to WASM-specific cache dir on dev-worker (native and WASM targets conflict).
         # On GitHub-hosted this evaluates to '' which the shell guard above unsets.
-        CARGO_TARGET_DIR: ${{ needs.check-runner.outputs.runner == 'dev-worker' && '/cache/target-wasm' || '' }}
+        CARGO_TARGET_DIR: ${{ needs.check-runner.outputs.runner == 'dev-worker' && '/cache/rust/target-wasm' || '' }}
 
     - name: Cleanup build artifacts
       if: always() && needs.check-runner.outputs.runner == 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ This file documents the historical progress of the Micromegas project. For curre
   * Bump protobufjs, @protobufjs/utf8, brace-expansion, and authlib to fix Dependabot alerts (#178, #242-250)
 * **Repo:**
   * Migrate Yarn 1 (Classic) to Yarn 4 (Berry) via corepack across all six yarn projects; corepack-only delivery, `nodeLinker: node-modules`; CI/Docker/build scripts updated; clean lock + zero install warnings (#1008)
+* **CI:**
+  * Switch dev-worker runners to ephemeral mode (one job per container, unique name per run) with build caches persisted in a named Docker volume (cargo, yarn, go, playwright); bake Go 1.25 into the runner image and skip `setup-go` on dev-worker; drop the now-redundant `--clear-cache` / `--rotate-cache` / `--rotate-at` flags
 
 ## April 2026 - v0.24.0
 

--- a/build/dev_worker.py
+++ b/build/dev_worker.py
@@ -45,7 +45,10 @@ import uuid
 
 REPO = "madesroches/micromegas"
 IMAGE_NAME = "micromegas-github-runner"
-CONTAINER_NAME = "micromegas-runner"
+CONTAINER_NAME_PREFIX = "micromegas-runner"
+# Label applied to each runner container so we can find them by query without
+# needing to know the unique per-run container name.
+CONTAINER_LABEL = "com.micromegas.runner=dev-worker"
 PAT_FILE = os.path.expanduser("~/.config/micromegas/runner-pat")
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -135,15 +138,15 @@ def build_image():
 
 
 def start_container(pat, cpus=None, memory=None):
-    """Start a persistent runner container. Returns (Popen, token_path).
+    """Start an ephemeral runner container. Returns (Popen, token_path).
 
-    Uses a fixed container name to prevent multiple instances from
-    corrupting the shared build cache. The GitHub runner registration
-    uses a unique name to avoid stale session conflicts.
+    Each run gets a unique container name so successive containers cannot
+    conflict on Docker's name registry while the previous --rm cleanup is
+    still draining. The GitHub runner registers under the same unique name.
     """
     token = get_registration_token(pat)
     arch = get_arch()
-    runner_name = f"{CONTAINER_NAME}-{uuid.uuid4().hex[:8]}"
+    name = f"{CONTAINER_NAME_PREFIX}-{uuid.uuid4().hex[:8]}"
 
     # Write token to a temp file (never pass via env var or CLI)
     fd, token_path = tempfile.mkstemp(prefix="runner-token-")
@@ -155,12 +158,14 @@ def start_container(pat, cpus=None, memory=None):
         "docker",
         "run",
         "--name",
-        CONTAINER_NAME,
+        name,
+        "--label",
+        CONTAINER_LABEL,
         "--rm",
         "-e",
         f"REPO={REPO}",
         "-e",
-        f"RUNNER_NAME={runner_name}",
+        f"RUNNER_NAME={name}",
         "-e",
         f"ARCH={arch}",
         "--mount",
@@ -181,14 +186,21 @@ def start_container(pat, cpus=None, memory=None):
 
 
 def stop_container():
-    """Stop the running container if any."""
-    subprocess.run(["docker", "stop", CONTAINER_NAME], capture_output=True)
+    """Stop any currently running runner containers (located via label)."""
+    result = subprocess.run(
+        ["docker", "ps", "-q", "--filter", f"label={CONTAINER_LABEL}"],
+        capture_output=True,
+        text=True,
+    )
+    ids = result.stdout.split()
+    if ids:
+        subprocess.run(["docker", "stop", *ids], capture_output=True)
 
 
 def clear_cache():
     """Stop runner, clearing the build cache (cache lives on the container filesystem)."""
     stop_container()
-    # Give container time to exit
+    # Give the container time to exit and --rm to drain.
     time.sleep(2)
     print("Container stopped — build cache cleared.")
 
@@ -276,7 +288,7 @@ def nightly_rotation_thread(rotation_event, rotate_hour):
 
 
 def run_worker_loop(pat, cpus=None, memory=None, trigger_warming=False, rotate_hour=None):
-    """Main loop: start persistent container, restart on exit or rotation."""
+    """Main loop: start ephemeral containers, replace each one after it exits."""
     running = True
     rotation_event = threading.Event()
 
@@ -314,8 +326,6 @@ def run_worker_loop(pat, cpus=None, memory=None, trigger_warming=False, rotate_h
             proc, token_path = start_container(pat, cpus=cpus, memory=memory)
         except Exception as e:
             if running:
-                # Remove stale container left behind by a daemon crash
-                subprocess.run(["docker", "rm", "-f", CONTAINER_NAME], capture_output=True)
                 print(f"Failed to start container: {e}")
                 print("Retrying in 10 seconds...")
                 time.sleep(10)
@@ -337,7 +347,7 @@ def run_worker_loop(pat, cpus=None, memory=None, trigger_warming=False, rotate_h
                 pass
 
         if running:
-            print("Container exited unexpectedly, restarting runner...\n")
+            print("Runner finished its job, starting next ephemeral runner...\n")
 
 
 def main():

--- a/build/dev_worker.py
+++ b/build/dev_worker.py
@@ -10,17 +10,8 @@ Usage:
     # With resource limits
     python3 build/dev_worker.py --cpus 8 --memory 16g
 
-    # Clear the build cache and exit
-    python3 build/dev_worker.py --clear-cache
-
-    # Rotate cache: clear, restart worker, trigger warming build
-    python3 build/dev_worker.py --rotate-cache
-
     # Build the container image only
     python3 build/dev_worker.py --build-image
-
-    # Start with nightly cache rotation at 03:00 local time
-    python3 build/dev_worker.py --rotate-at 3
 
 PAT setup (choose one):
     export MICROMEGAS_RUNNER_PAT=ghp_xxx
@@ -29,7 +20,6 @@ PAT setup (choose one):
 """
 
 import argparse
-import datetime
 import json
 import os
 import platform
@@ -37,7 +27,6 @@ import signal
 import subprocess
 import sys
 import tempfile
-import threading
 import time
 import urllib.error
 import urllib.request
@@ -197,14 +186,6 @@ def stop_container():
         subprocess.run(["docker", "stop", *ids], capture_output=True)
 
 
-def clear_cache():
-    """Stop runner, clearing the build cache (cache lives on the container filesystem)."""
-    stop_container()
-    # Give the container time to exit and --rm to drain.
-    time.sleep(2)
-    print("Container stopped — build cache cleared.")
-
-
 def cleanup_offline_runners(pat):
     """Remove any offline dev-worker runners from the repository."""
     try:
@@ -227,78 +208,9 @@ def cleanup_offline_runners(pat):
         print(f"Failed to list runners for cleanup: {e}")
 
 
-def is_runner_online(pat):
-    """Check if a dev-worker runner is online."""
-    try:
-        result = github_api(f"repos/{REPO}/actions/runners", pat)
-        for runner in result.get("runners", []):
-            labels = [label["name"] for label in runner.get("labels", [])]
-            if "dev-worker" in labels and runner.get("status") == "online":
-                return True
-    except Exception:
-        pass
-    return False
-
-
-def wait_for_runner_online(pat, timeout=120):
-    """Poll until a dev-worker runner is online or timeout."""
-    print("Waiting for runner to register as online...")
-    start = time.time()
-    while time.time() - start < timeout:
-        if is_runner_online(pat):
-            print("Runner is online.")
-            return True
-        time.sleep(5)
-    print(f"Runner did not come online within {timeout}s.")
-    return False
-
-
-def trigger_warming_build(pat):
-    """Trigger rust.yml workflow_dispatch on main to warm the cache."""
-    try:
-        github_api(
-            f"repos/{REPO}/actions/workflows/rust.yml/dispatches",
-            pat,
-            method="POST",
-            data={"ref": "main"},
-        )
-        print("Triggered warming build on main.")
-    except Exception as e:
-        print(f"Failed to trigger warming build: {e}")
-
-
-def seconds_until(hour, minute=0):
-    """Return seconds from now until the next occurrence of hour:minute local time."""
-    now = datetime.datetime.now()
-    target = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
-    if target <= now:
-        target += datetime.timedelta(days=1)
-    return (target - now).total_seconds()
-
-
-def nightly_rotation_thread(rotation_event, rotate_hour):
-    """Sleep until rotate_hour:00 each night, then stop the container to trigger rotation."""
-    while True:
-        wait = seconds_until(rotate_hour)
-        print(f"Nightly cache rotation scheduled in {wait / 3600:.1f}h (at {rotate_hour:02d}:00)")
-        time.sleep(wait)
-        print("Nightly cache rotation triggered.")
-        rotation_event.set()
-        stop_container()
-
-
-def run_worker_loop(pat, cpus=None, memory=None, trigger_warming=False, rotate_hour=None):
+def run_worker_loop(pat, cpus=None, memory=None):
     """Main loop: start ephemeral containers, replace each one after it exits."""
     running = True
-    rotation_event = threading.Event()
-
-    if rotate_hour is not None:
-        t = threading.Thread(
-            target=nightly_rotation_thread,
-            args=(rotation_event, rotate_hour),
-            daemon=True,
-        )
-        t.start()
 
     def handle_signal(sig, _frame):
         nonlocal running
@@ -313,15 +225,6 @@ def run_worker_loop(pat, cpus=None, memory=None, trigger_warming=False, rotate_h
     print("Press Ctrl+C to stop\n")
 
     while running:
-        # Check if nightly rotation was requested
-        if rotation_event.is_set():
-            rotation_event.clear()
-            print("Performing nightly cache rotation...")
-            # Container was already stopped by the rotation thread;
-            # --rm ensures the filesystem (and cache) is gone.
-            time.sleep(2)
-            trigger_warming = True
-
         try:
             proc, token_path = start_container(pat, cpus=cpus, memory=memory)
         except Exception as e:
@@ -332,15 +235,8 @@ def run_worker_loop(pat, cpus=None, memory=None, trigger_warming=False, rotate_h
             continue
 
         try:
-            # After rotate-cache or nightly rotation, trigger a warming build
-            if trigger_warming:
-                if wait_for_runner_online(pat):
-                    trigger_warming_build(pat)
-                trigger_warming = False
-
             proc.wait()
         finally:
-            # Clean up the host-side token file
             try:
                 os.unlink(token_path)
             except OSError:
@@ -358,27 +254,12 @@ def main():
     parser.add_argument("--cpus", help="CPU limit for container (e.g., 8)")
     parser.add_argument("--memory", help="Memory limit for container (e.g., 16g)")
     parser.add_argument(
-        "--clear-cache", action="store_true", help="Clear build cache and exit"
-    )
-    parser.add_argument(
-        "--rotate-cache",
-        action="store_true",
-        help="Clear cache, restart worker, trigger warming build",
-    )
-    parser.add_argument(
         "--build-image", action="store_true", help="Build the container image and exit"
     )
     parser.add_argument(
         "--cleanup",
         action="store_true",
         help="Remove offline dev-worker runners from GitHub and exit",
-    )
-    parser.add_argument(
-        "--rotate-at",
-        type=int,
-        metavar="HOUR",
-        choices=range(24),
-        help="Nightly cache rotation hour in local time (0-23, e.g., 3 for 03:00)",
     )
     args = parser.parse_args()
 
@@ -392,25 +273,9 @@ def main():
         cleanup_offline_runners(pat)
         return
 
-    if args.clear_cache:
-        clear_cache()
-        return
-
-    trigger_warming = False
-    if args.rotate_cache:
-        print("Rotating cache...")
-        clear_cache()
-        trigger_warming = True
-
     cleanup_offline_runners(pat)
     build_image()
-    run_worker_loop(
-        pat,
-        cpus=args.cpus,
-        memory=args.memory,
-        trigger_warming=trigger_warming,
-        rotate_hour=args.rotate_at,
-    )
+    run_worker_loop(pat, cpus=args.cpus, memory=args.memory)
 
 
 if __name__ == "__main__":

--- a/build/dev_worker.py
+++ b/build/dev_worker.py
@@ -38,6 +38,11 @@ CONTAINER_NAME_PREFIX = "micromegas-runner"
 # Label applied to each runner container so we can find them by query without
 # needing to know the unique per-run container name.
 CONTAINER_LABEL = "com.micromegas.runner=dev-worker"
+# Named Docker volume that persists the build cache across ephemeral runs.
+# Layout: /cache/{rust,yarn,go-mod,go-build,playwright}. Assumes a single
+# worker per workstation; multiple concurrent workers would corrupt cargo's
+# registry/target locks.
+CACHE_VOLUME = "micromegas-runner-cache"
 PAT_FILE = os.path.expanduser("~/.config/micromegas/runner-pat")
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -132,6 +137,10 @@ def start_container(pat, cpus=None, memory=None):
     Each run gets a unique container name so successive containers cannot
     conflict on Docker's name registry while the previous --rm cleanup is
     still draining. The GitHub runner registers under the same unique name.
+
+    /cache is mounted from a named Docker volume so per-tool build caches
+    (cargo, yarn, go, playwright) survive across containers — only changed
+    inputs trigger recompiles/redownloads per job.
     """
     token = get_registration_token(pat)
     arch = get_arch()
@@ -157,8 +166,20 @@ def start_container(pat, cpus=None, memory=None):
         f"RUNNER_NAME={name}",
         "-e",
         f"ARCH={arch}",
+        # Redirect per-tool caches under /cache so the named volume persists
+        # them across ephemeral containers. Tools auto-create the subdirs.
+        "-e",
+        "YARN_CACHE_FOLDER=/cache/yarn",
+        "-e",
+        "GOMODCACHE=/cache/go-mod",
+        "-e",
+        "GOCACHE=/cache/go-build",
+        "-e",
+        "PLAYWRIGHT_BROWSERS_PATH=/cache/playwright",
         "--mount",
         f"type=bind,source={token_path},target=/run/secrets/registration-token,readonly",
+        "--mount",
+        f"type=volume,source={CACHE_VOLUME},target=/cache",
     ]
     if cpus:
         cmd.extend(["--cpus", str(cpus)])

--- a/docker/github-runner-entrypoint.sh
+++ b/docker/github-runner-entrypoint.sh
@@ -4,15 +4,17 @@ set -euo pipefail
 # Read the registration token from the bind-mounted secret file.
 TOKEN=$(cat /run/secrets/registration-token)
 
-# Configure the runner (persistent, labeled, non-interactive).
+# Configure the runner (ephemeral, labeled, non-interactive).
 ./config.sh \
   --url "https://github.com/${REPO}" \
   --token "${TOKEN}" \
   --name "${RUNNER_NAME}" \
   --labels "dev-worker,linux,${ARCH}" \
   --work _work \
-  --unattended
+  --ephemeral \
+  --unattended \
+  --replace
 
-# Run the runner agent. It stays online and processes jobs until stopped.
+# Run the runner agent. It picks up one job, executes it, then exits.
 # exec replaces the shell so signals are forwarded directly to the runner.
 exec ./run.sh

--- a/docker/github-runner.Dockerfile
+++ b/docker/github-runner.Dockerfile
@@ -113,16 +113,17 @@ RUN WASM_BINDGEN_VERSION=$(python3 -c "import re; t=open('/tmp/wasm-cargo.lock')
 # Mage (for Grafana plugin builds)
 RUN go install github.com/magefile/mage@latest
 
-# Set up cache directory (container filesystem — warm while container is running)
+# Set up cache directory — populated lazily; dev_worker mounts a named volume
+# at /cache so the rust subtree persists across ephemeral containers.
 USER root
-RUN mkdir -p /cache/cargo-home /cache/target-native /cache/target-wasm \
+RUN mkdir -p /cache/rust/cargo-home /cache/rust/target-native /cache/rust/target-wasm \
     && chown -R runner:runner /cache
 USER runner
 
-# Runtime env — cargo registry/git cached on container FS, image-installed tools on PATH
-ENV CARGO_HOME=/cache/cargo-home
-ENV CARGO_TARGET_DIR=/cache/target-native
-ENV PATH="/home/runner/.cargo/bin:/cache/cargo-home/bin:/home/runner/go/bin:/usr/local/go/bin:${PATH}"
+# Runtime env — cargo registry/git under /cache/rust, image-installed tools on PATH
+ENV CARGO_HOME=/cache/rust/cargo-home
+ENV CARGO_TARGET_DIR=/cache/rust/target-native
+ENV PATH="/home/runner/.cargo/bin:/cache/rust/cargo-home/bin:/home/runner/go/bin:/usr/local/go/bin:${PATH}"
 
 # Entrypoint
 COPY --chown=runner:runner docker/github-runner-entrypoint.sh /home/runner/entrypoint.sh

--- a/docker/github-runner.Dockerfile
+++ b/docker/github-runner.Dockerfile
@@ -52,9 +52,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && corepack prepare yarn@4.14.1 --activate \
     && chmod -R a+rX /opt/corepack
 
-# Go 1.21
+# Go 1.25 (matches grafana/go.mod and .github/workflows/grafana-plugin.yml)
 RUN GOARCH=$([ "$(uname -m)" = "x86_64" ] && echo "amd64" || echo "arm64") \
-    && curl -fsSL "https://go.dev/dl/go1.21.13.linux-${GOARCH}.tar.gz" | tar -C /usr/local -xz
+    && curl -fsSL "https://go.dev/dl/go1.25.10.linux-${GOARCH}.tar.gz" | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Poetry

--- a/mkdocs/docs/development/build.md
+++ b/mkdocs/docs/development/build.md
@@ -169,6 +169,15 @@ Each workflow has a `check-runner` job that runs on `ubuntu-latest` and decides 
 
 The runner container is ephemeral: each container registers with GitHub, picks up one job, executes it, and exits. The worker loop then starts a fresh container for the next job. Each container gets a unique name so successive runs cannot collide while Docker drains the previous `--rm` cleanup.
 
+The build caches live in a named Docker volume (`micromegas-runner-cache`) mounted at `/cache`, so they persist across the ephemeral containers. The volume holds:
+
+- Cargo registry and target directories (`CARGO_HOME`, `CARGO_TARGET_DIR`)
+- Yarn package downloads (`YARN_CACHE_FOLDER`)
+- Go module and build cache (`GOMODCACHE`, `GOCACHE`)
+- Playwright browser downloads (`PLAYWRIGHT_BROWSERS_PATH`)
+
+This assumes a single worker per workstation — two concurrent workers sharing the volume would corrupt cargo's locks. To wipe the cache, stop the worker and run `docker volume rm micromegas-runner-cache`.
+
 See `tasks/container_based_dev_worker_plan.md` for the full design.
 
 ## Next Steps

--- a/mkdocs/docs/development/build.md
+++ b/mkdocs/docs/development/build.md
@@ -156,23 +156,9 @@ python3 build/dev_worker.py --cpus 8 --memory 16g
 # Build the container image without starting the worker
 python3 build/dev_worker.py --build-image
 
-# Clear the build cache
-python3 build/dev_worker.py --clear-cache
-
-# Rotate cache: clear, restart, trigger a warming build on main
-python3 build/dev_worker.py --rotate-cache
+# Remove offline dev-worker runners from GitHub and exit
+python3 build/dev_worker.py --cleanup
 ```
-
-### Nightly Cache Rotation
-
-Use `--rotate-at` to automatically wipe and warm the cache each night:
-
-```bash
-# Start with nightly rotation at 03:00 local time
-python3 build/dev_worker.py --rotate-at 3
-```
-
-Between container runs, the worker restarts the container (clearing the cache) and triggers a full build on main so daytime builds hit a warm cache. No cron job needed.
 
 ### How It Works
 
@@ -181,7 +167,7 @@ Each workflow has a `check-runner` job that runs on `ubuntu-latest` and decides 
 1. If the build author is the repo owner **and** a dev worker is online, jobs route to `dev-worker`
 2. Otherwise, jobs run on `ubuntu-latest` (existing behavior)
 
-The runner container is persistent and handles multiple jobs back-to-back. The build cache (cargo registry, target directories) lives on the container filesystem and stays warm as long as the container is running.
+The runner container is ephemeral: each container registers with GitHub, picks up one job, executes it, and exits. The worker loop then starts a fresh container for the next job. Each container gets a unique name so successive runs cannot collide while Docker drains the previous `--rm` cleanup.
 
 See `tasks/container_based_dev_worker_plan.md` for the full design.
 


### PR DESCRIPTION
## Summary

- Switch dev-worker GitHub Actions runners from persistent to ephemeral: each container registers, picks up one job, exits, and is replaced. Containers are given unique UUID-suffixed names so successive runs can't collide while the previous `--rm` cleanup is still draining.
- Move build caches off the container filesystem onto a named Docker volume (`micromegas-runner-cache`) mounted at `/cache`, with subdirs for cargo, yarn, go (`GOMODCACHE`/`GOCACHE`), and playwright. The volume survives across the ephemeral containers so only changed inputs trigger recompiles.
- Drop `--clear-cache`, `--rotate-cache`, and `--rotate-at` flags — they were workarounds for the long-lived-container model and are no-ops here. Cache wipe is now `docker volume rm micromegas-runner-cache`.
- Bake Go 1.25.10 into the runner image (matches `grafana/go.mod`) and skip `setup-go` on dev-worker.
- Stop containers by label (`com.micromegas.runner=dev-worker`) instead of a fixed name, and update docs.

## Test plan

- [ ] `python3 build/dev_worker.py --build-image` builds the image (Go 1.25, all baked tools install cleanly).
- [ ] `python3 build/dev_worker.py` registers an ephemeral runner that processes one job, exits, and is replaced.
- [ ] A second job reuses cached cargo registry, target dir, yarn cache, and go module cache (no full recompile / re-download).
- [ ] Ctrl+C cleanly stops the running container (located via label) and exits the worker loop.
- [ ] Rust and grafana-plugin workflows still pass on both dev-worker and ubuntu-latest paths.