### PR TITLE
Map detail popup: clear close button from first line (#1067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This file documents the historical progress of the Micromegas project. For curre
   * Remove admin-oriented `MICROMEGAS_MAPS_OBJECT_STORE_URI` / `.glb` drop hint from the map cell editor (admins use the Maps management UI)
   * Resolve `$var` macros in map cell primitive scalar bindings (size, scaleX/Y/Z, color); editor swaps the legacy number/color inputs for a text field with local-draft commit (Enter/blur commits, Escape cancels)
   * Require Ctrl/Cmd modifier for map cell wheel zoom so plain wheel scrolls the surrounding notebook page
+  * Fix map cell event detail popup close button overlapping the first line of the markdown template (#1067)
 * **Python:**
   * Switch `bulk_ingest` to accept `pyarrow.Table` directly for native pass-through of struct/list/binary columns
   * Resolve CLI connection settings from `~/.micromegas/config.json` with env-var override (#1033)

--- a/analytics-web-app/src/components/map/EventDetailPanel.tsx
+++ b/analytics-web-app/src/components/map/EventDetailPanel.tsx
@@ -68,7 +68,7 @@ export function EventDetailPanel({
       >
         <X className="w-4 h-4 text-theme-text-muted" />
       </button>
-      <div className="prose prose-invert prose-sm max-w-none px-4 py-3 prose-headings:text-theme-text-primary prose-headings:mt-0 prose-p:text-theme-text-secondary prose-a:text-accent-link prose-strong:text-theme-text-primary prose-code:text-accent-highlight prose-code:bg-app-card prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:before:content-none prose-code:after:content-none prose-pre:bg-app-card prose-li:text-theme-text-secondary prose-hr:border-theme-border prose-hr:my-3">
+      <div className="prose prose-invert prose-sm max-w-none pl-4 pr-10 py-3 prose-headings:text-theme-text-primary prose-headings:mt-0 prose-p:text-theme-text-secondary prose-a:text-accent-link prose-strong:text-theme-text-primary prose-code:text-accent-highlight prose-code:bg-app-card prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:before:content-none prose-code:after:content-none prose-pre:bg-app-card prose-li:text-theme-text-secondary prose-hr:border-theme-border prose-hr:my-3">
         <Markdown remarkPlugins={[remarkGfm]} components={{ a: MarkdownLink }}>
           {rendered}
         </Markdown>


### PR DESCRIPTION
## Summary
- Reserve right padding on the map cell's event detail popup so the markdown content no longer flows under the absolute-positioned close (×) button.
- Swap `px-4` → `pl-4 pr-10` on the markdown wrapper in `EventDetailPanel`. The button (~32px from the right edge) is now cleared by the 40px right gutter.

Fixes #1067

## Test plan
- [ ] Open a notebook with a `map` cell using `selectionMode: "single"` and a `detailTemplate` whose first line is non-empty (e.g. `**Cell:** ($x, $y)`).
- [ ] Click a map cell; verify the × button no longer overlaps the first line of the rendered markdown.
- [ ] Confirm `yarn lint`, `yarn type-check`, and `yarn test` pass in `analytics-web-app/`.