### PR TITLE
Docs: fact-check and reorganize notebook cell-types reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ This file documents the historical progress of the Micromegas project. For curre
   * Document `rgba` and `lerp_color` color functions in the SQL functions reference (#1062)
   * Document `color_scale` perceptual colormap function in the SQL functions reference (#1069)
   * Document `bin_center` binning function in the SQL functions reference (#1068)
+  * Rework notebook cell-types reference: alphabetize sections, expand Map cell with channel mapping and color encodings, fact-check defaults/levels/bindings against the implementation, and move admin/maps content to the Admin → Web App page
 * **Security:**
   * Bump rustls-webpki, rand, and uuid to fix Dependabot alerts (#210-213)
   * Bump postcss and uuid to fix Dependabot alerts (#214-221)

--- a/mkdocs/docs/admin/web-app.md
+++ b/mkdocs/docs/admin/web-app.md
@@ -64,7 +64,22 @@ Map cells render GLB assets fetched from a server-side object store. Set `MICROM
 
 **IAM / credentials.** The process credentials need the equivalent of `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, and `s3:ListBucket` (or GCS / local-fs equivalents) scoped to the configured prefix. Read-only credentials are sufficient only if you keep populating maps out-of-band (`aws s3 cp ...`) and don't expose the admin page.
 
-**Upload cap.** `MICROMEGAS_MAPS_MAX_UPLOAD_BYTES` bounds the per-request body for uploads (default 256 MiB). The cap is enforced before the body is buffered. The handler gzips on upload and the read path serves bytes verbatim with `Content-Encoding: gzip`.
+**Upload cap.** `MICROMEGAS_MAPS_MAX_UPLOAD_BYTES` bounds the per-request body for uploads (default 256 MiB). The cap is enforced before the body is buffered. The handler gzips on upload and the read path serves bytes verbatim with `Content-Encoding: gzip`. Bare uploads (no metadata) are served uncompressed.
+
+**Catalog discovery.** The catalog is derived at request time by listing every `*.glb` object directly under the configured prefix — there is no `maps.json` to keep in sync. Display names are derived client-side: the `.glb` extension is stripped (`Arena_North.glb` → `Arena_North`).
+
+**Out-of-band uploads.** Ops can drop `.glb` files directly into the configured prefix (no UI required), but the upload must set `Content-Type: model/gltf-binary` and `Content-Encoding: gzip` if pre-compressed. The Admin → Maps page is the recommended path because it handles the compression and metadata in one shot.
+
+**GLB authoring contract.** The renderer expects each GLB to satisfy these invariants — there is no fallback path:
+
+- **Z-up** — the only hard axis constraint; the renderer pins `scene.up = (0, 0, 1)` and has no axis-conversion step. Handedness and units must simply match between the GLB and the event data (no specific units required, no auto-centering, no scaling).
+- **Exactly one perspective camera** referenced from `scenes[0]`, used to seed the initial camera (position, orientation, fov, near, far). Camera roll is dropped when seeding the orbit controller.
+- **`KHR_lights_punctual`** — directional lights live inside the scene tree and render automatically.
+- **`MM_ambient_light`** vendor extension — `{ color: [r, g, b], intensity: number }` at the root extensions; the renderer reads it directly from `gltf.parser.json.extensions`.
+
+GLBs missing the camera log a console error and fall back to the default seed framing (likely mis-framed); GLBs missing `MM_ambient_light` log a console error and render without ambient illumination. These are visible failure modes that signal a non-conforming GLB.
+
+> Because the contract uses Z-up, the GLBs are technically out of spec for glTF 2.0 (which mandates Y-up). External viewers — Blender, online glTF validators, Windows 3D Viewer — will render them rotated. The micromegas web-app is the only intended consumer.
 
 **URI grammar.** Same shape as `MICROMEGAS_OBJECT_STORE_URI` (passed through `object_store::parse_url_opts`):
 

--- a/mkdocs/docs/assets/stylesheets/extra.css
+++ b/mkdocs/docs/assets/stylesheets/extra.css
@@ -281,8 +281,10 @@
 .md-nav--secondary a[href="#log"]::before,
 .md-nav--secondary a[href="#property-timeline"]::before,
 .md-nav--secondary a[href="#swimlane"]::before,
+.md-nav--secondary a[href="#flame-graph"]::before,
 .md-nav--secondary a[href="#perfetto-export"]::before,
 .md-nav--secondary a[href="#reference-table"]::before,
+.md-nav--secondary a[href="#map"]::before,
 .md-nav--secondary a[href="#horizontal-group-hg"]::before {
     content: "";
     display: inline-block;
@@ -302,8 +304,10 @@
 .md-nav--secondary a[href="#log"]::before { background-image: url("../images/cell-icons/scroll-text.svg"); }
 .md-nav--secondary a[href="#property-timeline"]::before { background-image: url("../images/cell-icons/gantt-chart.svg"); }
 .md-nav--secondary a[href="#swimlane"]::before { background-image: url("../images/cell-icons/align-center.svg"); }
+.md-nav--secondary a[href="#flame-graph"]::before { background-image: url("../images/cell-icons/flame.svg"); }
 .md-nav--secondary a[href="#perfetto-export"]::before { background-image: url("../images/cell-icons/download.svg"); }
 .md-nav--secondary a[href="#reference-table"]::before { background-image: url("../images/cell-icons/book-open.svg"); }
+.md-nav--secondary a[href="#map"]::before { background-image: url("../images/cell-icons/map.svg"); }
 .md-nav--secondary a[href="#horizontal-group-hg"]::before { background-image: url("../images/cell-icons/group.svg"); }
 
 /* Sidebar navigation active item */

--- a/mkdocs/docs/web-app/index.md
+++ b/mkdocs/docs/web-app/index.md
@@ -74,7 +74,7 @@ Data sources are managed from the **Admin** page.
 
 ## Maps
 
-Map cells render 3D scenes from GLB assets stored in a server-side object store. Admins upload and remove maps from **Admin → Maps**; the server gzips on upload so the read path serves the bytes verbatim with `Content-Encoding: gzip`. See [Map cells](notebooks/cell-types.md#-map) for the authoring contract.
+Map cells render 3D scenes from GLB assets stored in a server-side object store. Admins upload and remove maps from **Admin → Maps**; the server gzips on upload so the read path serves the bytes verbatim with `Content-Encoding: gzip`. See [Map cells](notebooks/cell-types.md#map) for the authoring contract.
 
 ## Further Reading
 

--- a/mkdocs/docs/web-app/notebooks/cell-types.md
+++ b/mkdocs/docs/web-app/notebooks/cell-types.md
@@ -15,8 +15,8 @@ Multi-query time-series charts supporting line and bar chart types.
 | Field | Type | Description |
 |-------|------|-------------|
 | `queries` | array | One or more query definitions |
-| `options.scale_mode` | `'p99'` \| `'max'` | Y-axis scaling mode |
-| `options.chart_type` | `'line'` \| `'bar'` | Chart type |
+| `options.scale_mode` | `'p99'` \| `'max'` | Y-axis scaling mode (default `'p99'`) |
+| `options.chart_type` | `'line'` \| `'bar'` | Chart type (default `'line'`) |
 
 **Query definition:**
 
@@ -39,7 +39,7 @@ Multi-query time-series charts supporting line and bar chart types.
 - Color-coded series with a rotating palette
 - Drag-to-zoom: drag horizontally on the chart to select a time range and zoom in
 - Chart type and scale mode toggleable via controls
-- Each query's results are registered in the WASM engine as `cellName.queryName`
+- Each query's results are registered in the WASM engine as `cellName.queryName` — or just `cellName` if the query has no `name` (single-query charts can omit it; multi-query charts should set distinct names to avoid collision)
 
 **Example:**
 
@@ -93,11 +93,24 @@ Interactive span visualization rendered with WebGL. Spans are grouped into lanes
 
 - WebGL-rendered spans with Canvas2D label and time-axis overlay — handles millions of rows
 - Color-coded by span name using a brand-derived rust/blue/gold palette
-- Drag horizontally to zoom into a time range; WASD keys pan and zoom (cursor-anchored)
-- Mouse wheel scrolls vertically across lanes
-- Hover tooltip shows span name, duration, id, depth, and parent name
+- Mouse wheel scrolls vertically across lanes (no zoom modifier — keeps the surrounding page reachable)
+- Hover tooltip shows span name, duration, id, depth, and parent name (plus any of `target`, `filename`, `line`, `kind`, `bit_size`, etc. when those columns are present in the result)
 - The lane literally named `async` is laid out by greedy packing to avoid overlap; all other lanes use the raw `depth` column
+- Auto-detects the x-axis mode from the `begin`/`end` column types: timestamp columns drive time mode; numeric columns drive "bits" mode (used for memory snapshots). In bits mode, `initialFrom` / `initialTo` are ignored.
 - Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
+
+**Interactions:**
+
+| Input | Action |
+|-------|--------|
+| Horizontal drag | Zoom into the dragged time range (local zoom) |
+| `Alt` + horizontal drag | In time mode, broadcasts the dragged range to downstream cells via the cell's selection |
+| Double-click | Reset zoom to the full data extent |
+| Mouse wheel | Scroll vertically across lanes |
+| `W` / `S` | Zoom in / out, anchored at the cursor |
+| `A` / `D` | Pan left / right |
+
+Keyboard input requires the flame graph to have keyboard focus (click it first).
 
 **Example SQL:**
 
@@ -125,10 +138,10 @@ A container cell that arranges its children side by side in a horizontal layout.
 
 **Features:**
 
-- Children render side by side with equal width
-- Drag children horizontally to reorder within the group
-- Drag a child vertically (out of the group area) to extract it to the main cell list
-- Add new children via the group editor
+- Children render side by side with equal width via flex layout
+- Reorder via a drag handle (appears on hover over a child)
+- Drag a child vertically more than ~30px outside the group bounds to extract it back to the main cell list
+- Add new children via the group editor; remove a child via the "Remove from group" context-menu entry
 - Each child has independent execution, state, and data source settings
 - Aggregate stats (row count, byte size) displayed in the group header
 
@@ -161,18 +174,18 @@ SQL query results formatted as log entries with level-based coloring.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `pageSize` | number | Entries per page (default: 50) |
+| `pageSize` | number | Entries per page (default: 100; selectable from 50 / 100 / 250 / 500 / 1000) |
 
 **Expected columns:**
 
 The renderer auto-classifies columns by name:
 
 - `time` — event timestamp
-- `level` — log level (`ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`)
+- `level` — log level (`FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`)
 - `target` — logger target/module
 - `msg` — log message
 
-Additional columns are rendered as fixed-width monospace text.
+Additional columns render as fixed-width monospace and truncate at 200px — hover to see the full value in a tooltip.
 
 - Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
 
@@ -180,10 +193,12 @@ Additional columns are rendered as fixed-width monospace text.
 
 | Level | Color |
 |-------|-------|
+| FATAL | Bright red |
 | ERROR | Red |
 | WARN | Yellow |
-| INFO | Gray |
-| DEBUG/TRACE | Muted |
+| INFO | Blue (link color) |
+| DEBUG | Secondary text |
+| TRACE | Muted |
 
 **Example SQL:**
 
@@ -213,9 +228,9 @@ LIMIT 500
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `x` | number | X coordinate (Unreal Engine world units) |
-| `y` | number | Y coordinate (Unreal Engine world units) |
-| `z` | number | Z coordinate (Unreal Engine world units) |
+| `x` | number | X coordinate |
+| `y` | number | Y coordinate |
+| `z` | number | Z coordinate |
 
 Any additional columns the query returns are addressable as `$column` in the detail template (see below).
 
@@ -351,7 +366,7 @@ Static text and documentation using GitHub Flavored Markdown.
 **Features:**
 
 - Full GitHub Flavored Markdown: headings, tables, lists, code blocks, strikethrough
-- Supports [variable substitution](variables.md#sql-macro-substitution): `$variable`, `$variable.column`, `$begin`, `$end`
+- Supports [variable substitution](variables.md#sql-macro-substitution): `$variable`, `$variable.column`, `$from`, `$to`
 - Validates macro references during editing — warns about undefined variables
 - Does not execute queries or block downstream cells
 - Rendered output appears only after the cell's turn in sequential execution — the body stays blank until upstream variables and cell results are resolved, so macros never display stale or broken values on first paint
@@ -361,7 +376,7 @@ Static text and documentation using GitHub Flavored Markdown.
 ```markdown
 # Dashboard for $process_id
 
-Showing data from **$begin** to **$end**.
+Showing data from **$from** to **$to**.
 ```
 
 ---
@@ -381,9 +396,10 @@ Exports trace data to [Perfetto UI](https://ui.perfetto.dev) for visualization, 
 **Features:**
 
 - Split button: **Open in Perfetto** (primary) or **Download** (secondary)
+- Download saves a Perfetto protobuf trace as `trace-{processId}.pb`
 - Shows a warning if the referenced variable is empty or undefined
 - Caches the generated trace buffer — cleared when process ID, span type, time range, or data source changes
-- Progress indicator during trace generation
+- Progress indicator during trace generation (shows running MB received as chunks stream in)
 - No automatic execution — triggered by user button click
 
 ---
@@ -435,13 +451,15 @@ Embeds inline CSV data that is registered as a queryable table in the [local WAS
 
 **Options:**
 
-Same as Table — `sortColumn`, `sortDirection`, `pageSize`, `hiddenColumns`.
+The editor only exposes the CSV body. The renderer honors `sortColumn`, `sortDirection`, `pageSize`, and `hiddenColumns` in the raw config if present, but there is no UI to set them.
 
 **Features:**
 
-- CSV is parsed into an Arrow table with automatic type inference (numeric, boolean, string)
+- CSV parsed with [d3-dsv](https://d3js.org/d3-dsv) (RFC 4180 quoting/escaping)
+- Type inference is per-column: a column becomes `Float64` if every non-empty cell parses as a finite number; otherwise `Utf8` (string). Empty cells become `NaN` (numeric) or `''` (string)
+- Empty or header-only input is rejected with an error
 - Registered in the WASM engine under the cell name — queryable by downstream cells
-- Displays as a sortable, paginated table (same UI as the Table cell)
+- Displays as a sortable, paginated table (same UI as the Table cell). Row selection is not supported.
 - Useful for lookup tables, configuration data, or reference values
 
 **Example:**
@@ -492,7 +510,7 @@ Multiple rows with the same `id` create multiple segments in one lane. Lanes are
 
 - Fixed label column on the left with lane names
 - Horizontal time bars in the center
-- Drag-to-zoom time selection
+- Horizontal drag selects a time range; broadcasts the selection to downstream cells (`$cellname.selected.begin`, `$cellname.selected.end`)
 - Time axis with formatted tick marks
 - Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
 
@@ -535,9 +553,10 @@ SQL query results displayed in a sortable, paginated table.
 |-------|------|-------------|
 | `sortColumn` | string | Currently sorted column |
 | `sortDirection` | `'asc'` \| `'desc'` | Sort direction |
-| `pageSize` | number | Rows per page (default: 50) |
+| `pageSize` | number | Rows per page (default: 100; selectable from 50 / 100 / 250 / 500 / 1000) |
 | `hiddenColumns` | string[] | Columns to hide |
-| `overrides` | array | Column format overrides |
+| `overrides` | array | Column format overrides — each entry `{ column, format }` |
+| `selectionMode` | `'none'` \| `'single'` | Whether clicking a row publishes a selection to downstream cells (default `'none'`) |
 
 **Features:**
 
@@ -546,6 +565,7 @@ SQL query results displayed in a sortable, paginated table.
 - Client-side pagination with configurable page size
 - Sort column available as `$order_by` macro in SQL for server-side sorting
 - Column format overrides with markdown and row macros (`$row.columnName`)
+- With `selectionMode: 'single'`, the selected row is exposed to downstream cells as `$cellname.selected.column`
 - Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
 
 **Column format overrides:**
@@ -577,15 +597,14 @@ SQL results with rows and columns swapped. The original column names become the 
 
 **Configuration:**
 
-Same as Table — `sql`, `dataSource`, and options for hidden rows, page size, and format overrides.
+Same as Table — `sql`, `dataSource`. The transposed view has no pagination (all rows scroll inside the cell).
 
 **Options:**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `pageSize` | number | Page size for scrolling |
 | `hiddenRows` | string[] | Hidden row names (original column names) |
-| `overrides` | array | Row rendering overrides |
+| `overrides` | array | Row rendering overrides — each entry `{ column, format }`, where `column` is the original column name (now a row label) |
 
 **Features:**
 
@@ -616,11 +635,12 @@ There are four variable subtypes, controlled by the `variableType` field.
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `name` | string | Variable identifier — referenced downstream as `$name` (or `$name.column` for multi-column combobox values) |
 | `variableType` | `'text'` \| `'combobox'` \| `'expression'` \| `'datasource'` | Variable subtype |
 | `defaultValue` | string or object | Default value used when no URL override is present |
 | `dataSource` | string | Data source for SQL queries (combobox only) |
 
-See [Variables](variables.md) for full documentation of the variable system including scope, expressions, and URL sync.
+Variable cells block downstream cells until their value is resolved. See [Variables](variables.md) for full documentation of the variable system including scope, expressions, and URL sync.
 
 ### Text
 
@@ -660,9 +680,9 @@ Computed value from a JavaScript expression. Evaluated automatically — not use
 |-------|------|-------------|
 | `expression` | string | JavaScript expression to evaluate |
 
-Available bindings: `$begin`, `$end`, `$duration_ms`, `$innerWidth`, `$devicePixelRatio`, and upstream variables as `$variableName`.
+Available bindings: `$from`, `$to`, `$duration_ms`, `$innerWidth`, `$devicePixelRatio`, and upstream variables as `$variableName`.
 
-Available functions: `snap_interval()`, `Math.*`.
+Allowed operations: arithmetic (`+`, `-`, `*`, `/`, `%`), `Math.*`, `new Date(...)`, and `snap_interval(ms)`. Browser globals (`window`, `document`, `eval`, `fetch`, …) are blocked.
 
 ```javascript
 // Compute a time bin interval based on viewport width

--- a/mkdocs/docs/web-app/notebooks/cell-types.md
+++ b/mkdocs/docs/web-app/notebooks/cell-types.md
@@ -290,7 +290,9 @@ standard notebook macros work too:
 The default template is:
 
 ```markdown
-### Event
+### Event Details
+
+---
 
 **Location:** ($x, $y, $z)
 ```

--- a/mkdocs/docs/web-app/notebooks/cell-types.md
+++ b/mkdocs/docs/web-app/notebooks/cell-types.md
@@ -6,6 +6,338 @@ Data cells (table, chart, log, etc.) execute SQL queries and register their resu
 
 ---
 
+## ![Chart](../../assets/images/cell-icons/bar-chart-3.svg){ .cell-icon } Chart
+
+Multi-query time-series charts supporting line and bar chart types.
+
+**Configuration:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `queries` | array | One or more query definitions |
+| `options.scale_mode` | `'p99'` \| `'max'` | Y-axis scaling mode |
+| `options.chart_type` | `'line'` \| `'bar'` | Chart type |
+
+**Query definition:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sql` | string | SQL query returning `time` + value columns |
+| `name` | string | Query name (used for WASM table registration) |
+| `unit` | string | Y-axis unit label |
+| `label` | string | Series label override |
+| `dataSource` | string | Per-query data source |
+
+**Scale modes:**
+
+- **p99** (default) — scales Y-axis to the 99th percentile, handling outliers gracefully
+- **max** — scales Y-axis from 0 to the maximum value
+
+**Features:**
+
+- Multiple queries per chart, each with its own data source and unit
+- Color-coded series with a rotating palette
+- Drag-to-zoom: drag horizontally on the chart to select a time range and zoom in
+- Chart type and scale mode toggleable via controls
+- Each query's results are registered in the WASM engine as `cellName.queryName`
+
+**Example:**
+
+```sql
+SELECT time, value
+FROM measures
+WHERE name = '$metric'
+ORDER BY time
+```
+
+![Chart cell with frame time data and drag-to-zoom](../../assets/images/notebooks/chart_zoom.png){ .screenshot }
+
+---
+
+## ![Flame Graph](../../assets/images/cell-icons/flame.svg){ .cell-icon } Flame Graph
+
+Interactive span visualization rendered with WebGL. Spans are grouped into lanes (one per thread or async scope) and stacked by call depth, with drag-to-zoom and WASD navigation.
+
+**Configuration:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sql` | string | SQL query returning span data |
+| `dataSource` | string | Data source override |
+
+**Options:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `initialFrom` | string | Initial zoomed-in start time (accepts `$variable`, relative like `now-1h`, or absolute) |
+| `initialTo` | string | Initial zoomed-in end time |
+
+**Required columns:**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | bigint | Unique span identifier |
+| `parent` | bigint | Parent span id (0 or null for roots) |
+| `name` | string | Span name (used for label and color hash) |
+| `begin` | timestamp | Span start time |
+| `end` | timestamp | Span end time |
+| `depth` | int | Call depth within the lane (UInt32 in `process_spans`) |
+
+**Optional columns:**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `lane` | string | Lane name — one lane per distinct value (e.g., thread name, `async`). If omitted, all spans render in a single lane named `default`. The lane literally named `async` gets greedy-packed layout (see Features). |
+
+**Features:**
+
+- WebGL-rendered spans with Canvas2D label and time-axis overlay — handles millions of rows
+- Color-coded by span name using a brand-derived rust/blue/gold palette
+- Drag horizontally to zoom into a time range; WASD keys pan and zoom (cursor-anchored)
+- Mouse wheel scrolls vertically across lanes
+- Hover tooltip shows span name, duration, id, depth, and parent name
+- The lane literally named `async` is laid out by greedy packing to avoid overlap; all other lanes use the raw `depth` column
+- Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
+
+**Example SQL:**
+
+```sql
+SELECT id, parent, name, begin, "end", depth, thread_name AS lane
+FROM process_spans('$process_id', 'both')
+ORDER BY lane, begin
+```
+
+The `process_spans(process_id, types)` table function returns thread spans, async spans, or `'both'`.
+
+![Flame graph showing nested async spans with a hover tooltip](../../assets/images/notebooks/flame_graph.png){ .screenshot }
+
+---
+
+## ![Horizontal Group](../../assets/images/cell-icons/group.svg){ .cell-icon } Horizontal Group (HG)
+
+A container cell that arranges its children side by side in a horizontal layout.
+
+**Configuration:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `children` | array | Child cell configurations (any type except HG) |
+
+**Features:**
+
+- Children render side by side with equal width
+- Drag children horizontally to reorder within the group
+- Drag a child vertically (out of the group area) to extract it to the main cell list
+- Add new children via the group editor
+- Each child has independent execution, state, and data source settings
+- Aggregate stats (row count, byte size) displayed in the group header
+
+**Constraints:**
+
+- HG cells cannot be nested — no HG inside another HG
+- During execution, children are flattened into the main sequence and execute left to right
+- Variables defined in child cells are visible to cells below the group
+
+**Example use case:**
+
+Place two related charts side by side — one showing CPU usage and another showing memory usage — for a compact comparison view.
+
+![Horizontal group with table, chart, and log cells side by side](../../assets/images/notebooks/horizontal_group.png){ .screenshot }
+
+---
+
+## ![Log](../../assets/images/cell-icons/scroll-text.svg){ .cell-icon } Log
+
+SQL query results formatted as log entries with level-based coloring.
+
+**Configuration:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sql` | string | SQL query returning log data |
+| `dataSource` | string | Data source override |
+
+**Options:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pageSize` | number | Entries per page (default: 50) |
+
+**Expected columns:**
+
+The renderer auto-classifies columns by name:
+
+- `time` — event timestamp
+- `level` — log level (`ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`)
+- `target` — logger target/module
+- `msg` — log message
+
+Additional columns are rendered as fixed-width monospace text.
+
+- Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
+
+**Level coloring:**
+
+| Level | Color |
+|-------|-------|
+| ERROR | Red |
+| WARN | Yellow |
+| INFO | Gray |
+| DEBUG/TRACE | Muted |
+
+**Example SQL:**
+
+```sql
+SELECT time, level, target, msg
+FROM log_entries
+ORDER BY time DESC
+LIMIT 500
+```
+
+![Log cell with level-based coloring and full-text search](../../assets/images/notebooks/log_cell.png){ .screenshot }
+
+---
+
+## ![Map](../../assets/images/cell-icons/map.svg){ .cell-icon } Map
+
+3D map visualization that plots spatial events on a GLB model. Events are rendered as instanced sphere markers at their native `(x, y, z)` coordinates.
+
+**Configuration:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sql` | string | SQL query returning spatial data |
+| `dataSource` | string | Data source override |
+
+**Required columns:**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `x` | number | X coordinate (Unreal Engine world units) |
+| `y` | number | Y coordinate (Unreal Engine world units) |
+| `z` | number | Z coordinate (Unreal Engine world units) |
+
+Any additional columns the query returns are addressable as `$column` in the detail template (see below).
+
+**Options:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mapUrl` | string | none | Bare GLB filename from the catalog (e.g. `Arena_North.glb`) — despite the name, not a URL; the renderer composes the blob URL at load time. |
+| `shape` | `'sphere'` \| `'box'` | `'sphere'` | Marker primitive |
+| `mapping` | object | per-shape defaults | Per-channel column-or-scalar bindings (see below) |
+| `detailTemplate` | string | see below | Markdown template rendered in the event detail panel when a marker is clicked |
+
+**Channel mapping:**
+
+Marker appearance is driven by a `mapping` object whose channels depend on the selected shape:
+
+| Channel | Shapes | Default scalar | Description |
+|---------|--------|----------------|-------------|
+| `x`, `y`, `z` | both | `'x'`, `'y'`, `'z'` | Position. Each entry is `{ column: name }` to read per-row values, or `{ scalar: name }` to remap to a differently-named column. Must resolve to numeric columns. |
+| `size` | sphere | `10` | Uniform radius. |
+| `scaleX`, `scaleY`, `scaleZ` | box | `100` each | Per-axis extents. |
+| `color` | both | `0xbf360cff` (Rust orange) | Marker color. Scalar is an RGBA u32 (also accepts `#rrggbb` / `#rrggbbaa` strings in the editor). Column bindings accept three column kinds — see below. |
+
+Each non-position channel is `{ scalar: value }` (applies to every row) or `{ column: name }` (reads from that column). String scalars may contain notebook macros (`$mySize`, `$cell.selected.radius`) — they are re-resolved at render time, so editor scrubbing stays cheap without rebuilding the per-instance buffers.
+
+**Color column encodings:**
+
+When `color` is column-bound, the renderer accepts three column types. **UInt32 is the idiomatic form** — the built-in color UDFs all return UInt32 in `0xRRGGBBAA` byte order:
+
+| UDF | Signature | Description |
+|-----|-----------|-------------|
+| `rgba(r, g, b, a)` | `(f64, f64, f64, f64) → UInt32` | Pack four `[0.0, 1.0]` channels (out-of-range values clamp at the byte boundary). |
+| `lerp_color(c1, c2, t)` | `(UInt32, UInt32, f64) → UInt32` | Linear interpolation between two packed colors in straight-alpha sRGB. |
+| `color_scale(name, t, alpha)` | `(string, f64, f64) → UInt32` | Perceptually-uniform colormap sample (`'viridis'`, `'magma'`, etc). |
+
+The full set of accepted column types:
+
+| Column type | Encoding |
+|-------------|----------|
+| UInt32 (or any integer) | Packed RGBA in `0xRRGGBBAA` order — the form emitted by `rgba()`, `lerp_color()`, and `color_scale()`. |
+| String | Hex literal — `'#rrggbb'` (alpha = `0xff`) or `'#rrggbbaa'`. |
+| Binary (4 bytes) | `R, G, B, A` byte order — DataFusion produces this for raw `0xrrggbbaa` hex literals in SQL. |
+
+Non-finite numeric values (NaN, null) in any column-bound numeric channel fail the build with a row-level error — filter them in SQL.
+
+**Detail template:**
+
+When a marker is selected, the cell renders a Markdown template with macro
+substitution. The selected row's columns are exposed as `$column`, and the
+standard notebook macros work too:
+
+- `$column` — column from the selected row (wins name collisions against variables)
+- `$from`, `$to` — current time range
+- `$variable`, `$variable.column` — notebook variables and their columns
+- `$cell[N].column`, `$cell.selected.column` — cross-cell references
+
+The default template is:
+
+```markdown
+### Event
+
+**Location:** ($x, $y, $z)
+```
+
+Authors extend it to surface query-specific columns. For example, to link to
+the process page using a `process_id` column:
+
+```markdown
+### Event
+
+**Location:** ($x, $y, $z)
+
+[View process logs](/process?process_id=$process_id)
+```
+
+Internal links (starting with `/`) route through the app's base-path-aware
+router; external links open in a new tab. Raw HTML in the template is
+rendered as text (not parsed), matching the Markdown cell's behavior.
+
+**Coordinate frame:**
+
+Events are placed at their raw `x`, `y`, `z` values without any runtime transform. The renderer assumes **Z-up**; handedness and units must match between the GLB and the event data (no specific units are required). See [Admin → Maps](../../admin/web-app.md#maps) for the full GLB authoring contract and catalog configuration.
+
+**Features:**
+
+- Instanced rendering — handles hundreds of thousands of markers efficiently
+- Interactive markers — click to select, hover to highlight
+- Event detail panel rendered from a Markdown template with macro substitution
+- Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
+
+**Camera controls:**
+
+| Input | Action |
+|-------|--------|
+| Left-drag | Pan (top-down XY translation) |
+| Right-drag | Orbit around the look-at point. Pitch is clamped to keep the camera above the horizon. |
+| Ctrl/Cmd + wheel | Zoom, anchored to the point under the cursor. Plain wheel scrolls the surrounding page. |
+| `W` / `S` | Pan forward / back (top-down — does not change elevation) |
+| `A` / `D` | Strafe left / right |
+| `Q` / `E` | Zoom in / out |
+| `Z` | Reset view to the initial framing |
+
+Keyboard controls (WASD/QE/Z) require the pointer to be over the map — keeps multiple Map cells on the same page from moving together and ignores keystrokes typed into form inputs.
+
+**Example SQL (spatial events from a JSONB-encoded payload):**
+
+```sql
+SELECT
+  time,
+  process_id,
+  jsonb_as_f64(jsonb_path_query_first(msg_jsonb, '$.position[0]')) as x,
+  jsonb_as_f64(jsonb_path_query_first(msg_jsonb, '$.position[1]')) as y,
+  jsonb_as_f64(jsonb_path_query_first(msg_jsonb, '$.position[2]')) as z,
+  jsonb_as_string(jsonb_path_query_first(msg_jsonb, '$.actor_id')) as actor_id,
+  jsonb_as_string(jsonb_path_query_first(msg_jsonb, '$.event_type')) as event_type
+FROM events
+WHERE name = 'spatial_event'
+LIMIT 10000
+```
+
+---
+
 ## ![Markdown](../../assets/images/cell-icons/file-text.svg){ .cell-icon } Markdown
 
 Static text and documentation using GitHub Flavored Markdown.
@@ -34,79 +366,155 @@ Showing data from **$begin** to **$end**.
 
 ---
 
-## ![Variable](../../assets/images/cell-icons/variable.svg){ .cell-icon } Variable
+## ![Perfetto Export](../../assets/images/cell-icons/download.svg){ .cell-icon } Perfetto Export
 
-User-configurable inputs that populate `$variable` references in downstream cells. Variable cells render in the cell title bar rather than taking up vertical space.
+Exports trace data to [Perfetto UI](https://ui.perfetto.dev) for visualization, or downloads it as a file.
 
-There are four variable subtypes, controlled by the `variableType` field.
-
-**Common configuration:**
+**Configuration:**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `variableType` | `'text'` \| `'combobox'` \| `'expression'` \| `'datasource'` | Variable subtype |
-| `defaultValue` | string or object | Default value used when no URL override is present |
-| `dataSource` | string | Data source for SQL queries (combobox only) |
+| `processIdVar` | string | Variable name containing the process ID (default: `$process_id`) |
+| `spanType` | `'thread'` \| `'async'` \| `'both'` | Which span types to include (default: `both`) |
+| `dataSource` | string | Data source override |
 
-See [Variables](variables.md) for full documentation of the variable system including scope, expressions, and URL sync.
+**Features:**
 
-### Text
+- Split button: **Open in Perfetto** (primary) or **Download** (secondary)
+- Shows a warning if the referenced variable is empty or undefined
+- Caches the generated trace buffer — cleared when process ID, span type, time range, or data source changes
+- Progress indicator during trace generation
+- No automatic execution — triggered by user button click
 
-Free-form text input. The user types a value directly. No SQL execution.
+---
 
-```
-variableType: 'text'
-defaultValue: 'cpu_usage'
-```
+## ![Property Timeline](../../assets/images/cell-icons/gantt-chart.svg){ .cell-icon } Property Timeline
 
-### Combobox
+Visualizes how JSON properties change over time as horizontal timeline segments.
 
-Dropdown populated by a SQL query. Single-column queries produce simple string options. Multi-column queries produce options with named fields accessible via `$variable.column` syntax.
+**Configuration:**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `sql` | string | SQL query returning option values |
-| `dataSource` | string | Data source for the query |
+| `sql` | string | SQL query returning `time` and `properties` (JSON) columns |
+| `dataSource` | string | Data source override |
+
+**Options:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `selectedKeys` | string[] | Property keys to display as timeline tracks |
+
+**Features:**
+
+- Parses JSON properties from each row and detects value changes
+- Each selected property key displays as a horizontal timeline track
+- Interactive key selection — add or remove property keys from the display
+- Time range zoom via drag selection
+- Fills time gaps with "no value" state
+- Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
+
+**Expected columns:**
+
+- `time` — timestamp
+- `properties` — JSON object string (e.g., `{"cpu": 45, "state": "running"}`)
+
+![Property timeline showing map property changes over time](../../assets/images/notebooks/property_timeline.png){ .screenshot }
+
+---
+
+## ![Reference Table](../../assets/images/cell-icons/book-open.svg){ .cell-icon } Reference Table
+
+Embeds inline CSV data that is registered as a queryable table in the [local WASM query engine](execution.md#local-wasm-query-engine). Downstream cells can query it by the cell's name.
+
+**Configuration:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `csv` | string | CSV data with headers in the first row |
+
+**Options:**
+
+Same as Table — `sortColumn`, `sortDirection`, `pageSize`, `hiddenColumns`.
+
+**Features:**
+
+- CSV is parsed into an Arrow table with automatic type inference (numeric, boolean, string)
+- Registered in the WASM engine under the cell name — queryable by downstream cells
+- Displays as a sortable, paginated table (same UI as the Table cell)
+- Useful for lookup tables, configuration data, or reference values
+
+**Example:**
+
+A cell named `thresholds` with this CSV:
+
+```csv
+metric,warn_threshold,error_threshold
+cpu_usage,80,95
+memory_usage,70,90
+disk_usage,85,95
+```
+
+Can be queried by a downstream table cell:
 
 ```sql
--- Single column: options are strings
-SELECT DISTINCT name FROM measures
-
--- Multi-column: options are objects with .name and .unit fields
-SELECT DISTINCT name, unit FROM measures
+SELECT m.name, m.value, t.warn_threshold, t.error_threshold
+FROM raw_metrics m
+JOIN thresholds t ON m.name = t.metric
+WHERE m.value > t.warn_threshold
 ```
 
-After execution, the current value is validated against available options. If invalid, the default value or first option is auto-selected.
+---
 
-![Combobox variable with dropdown open showing metric options](../../assets/images/notebooks/variables.png){ .screenshot }
+## ![Swimlane](../../assets/images/cell-icons/align-center.svg){ .cell-icon } Swimlane
 
-### Expression
+Horizontal lane visualization for thread or async activity over time. Each lane shows one or more time segments as horizontal bars.
 
-Computed value from a JavaScript expression. Evaluated automatically — not user-editable at runtime.
+**Configuration:**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `expression` | string | JavaScript expression to evaluate |
+| `sql` | string | SQL query returning lane data |
+| `dataSource` | string | Data source override |
 
-Available bindings: `$begin`, `$end`, `$duration_ms`, `$innerWidth`, `$devicePixelRatio`, and upstream variables as `$variableName`.
+**Required columns:**
 
-Available functions: `snap_interval()`, `Math.*`.
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | string | Unique lane identifier |
+| `name` | string | Lane display name |
+| `begin` | timestamp | Segment start time |
+| `end` | timestamp | Segment end time |
 
-```javascript
-// Compute a time bin interval based on viewport width
-snap_interval($duration_ms / $innerWidth)
+Multiple rows with the same `id` create multiple segments in one lane. Lanes are ordered by first occurrence in the query results.
+
+**Features:**
+
+- Fixed label column on the left with lane names
+- Horizontal time bars in the center
+- Drag-to-zoom time selection
+- Time axis with formatted tick marks
+- Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
+
+**Example SQL:**
+
+```sql
+SELECT
+  arrow_cast(stream_id, 'Utf8') as id,
+  concat(
+    arrow_cast(property_get("streams.properties", 'thread-name'), 'Utf8'),
+    '-',
+    arrow_cast(property_get("streams.properties", 'thread-id'), 'Utf8')
+  ) as name,
+  begin_time as begin,
+  end_time as end
+FROM blocks
+WHERE process_id = '$process_id'
+  AND array_has("streams.tags", 'cpu')
+ORDER BY name, begin
 ```
 
-See [Expression Evaluation](variables.md#expression-evaluation) for details.
-
-### Datasource
-
-Dropdown populated with available data sources from the API. Use with `$variableName` in a query cell's data source field to route queries to user-selected backends.
-
-```
-variableType: 'datasource'
-defaultValue: 'production'
-```
+![Swimlane showing thread activity across a task pool](../../assets/images/notebooks/swimlane.png){ .screenshot }
 
 ---
 
@@ -198,484 +606,76 @@ A query returning `process_id, exe, username, computer` for a single row display
 
 ---
 
-## ![Chart](../../assets/images/cell-icons/bar-chart-3.svg){ .cell-icon } Chart
+## ![Variable](../../assets/images/cell-icons/variable.svg){ .cell-icon } Variable
 
-Multi-query time-series charts supporting line and bar chart types.
+User-configurable inputs that populate `$variable` references in downstream cells. Variable cells render in the cell title bar rather than taking up vertical space.
 
-**Configuration:**
+There are four variable subtypes, controlled by the `variableType` field.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `queries` | array | One or more query definitions |
-| `options.scale_mode` | `'p99'` \| `'max'` | Y-axis scaling mode |
-| `options.chart_type` | `'line'` \| `'bar'` | Chart type |
-
-**Query definition:**
+**Common configuration:**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `sql` | string | SQL query returning `time` + value columns |
-| `name` | string | Query name (used for WASM table registration) |
-| `unit` | string | Y-axis unit label |
-| `label` | string | Series label override |
-| `dataSource` | string | Per-query data source |
+| `variableType` | `'text'` \| `'combobox'` \| `'expression'` \| `'datasource'` | Variable subtype |
+| `defaultValue` | string or object | Default value used when no URL override is present |
+| `dataSource` | string | Data source for SQL queries (combobox only) |
 
-**Scale modes:**
+See [Variables](variables.md) for full documentation of the variable system including scope, expressions, and URL sync.
 
-- **p99** (default) — scales Y-axis to the 99th percentile, handling outliers gracefully
-- **max** — scales Y-axis from 0 to the maximum value
+### Text
 
-**Features:**
+Free-form text input. The user types a value directly. No SQL execution.
 
-- Multiple queries per chart, each with its own data source and unit
-- Color-coded series with a rotating palette
-- Drag-to-zoom: drag horizontally on the chart to select a time range and zoom in
-- Chart type and scale mode toggleable via controls
-- Each query's results are registered in the WASM engine as `cellName.queryName`
+```
+variableType: 'text'
+defaultValue: 'cpu_usage'
+```
 
-**Example:**
+### Combobox
+
+Dropdown populated by a SQL query. Single-column queries produce simple string options. Multi-column queries produce options with named fields accessible via `$variable.column` syntax.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sql` | string | SQL query returning option values |
+| `dataSource` | string | Data source for the query |
 
 ```sql
-SELECT time, value
-FROM measures
-WHERE name = '$metric'
-ORDER BY time
+-- Single column: options are strings
+SELECT DISTINCT name FROM measures
+
+-- Multi-column: options are objects with .name and .unit fields
+SELECT DISTINCT name, unit FROM measures
 ```
 
-![Chart cell with frame time data and drag-to-zoom](../../assets/images/notebooks/chart_zoom.png){ .screenshot }
+After execution, the current value is validated against available options. If invalid, the default value or first option is auto-selected.
 
----
+![Combobox variable with dropdown open showing metric options](../../assets/images/notebooks/variables.png){ .screenshot }
 
-## ![Log](../../assets/images/cell-icons/scroll-text.svg){ .cell-icon } Log
+### Expression
 
-SQL query results formatted as log entries with level-based coloring.
-
-**Configuration:**
+Computed value from a JavaScript expression. Evaluated automatically — not user-editable at runtime.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `sql` | string | SQL query returning log data |
-| `dataSource` | string | Data source override |
+| `expression` | string | JavaScript expression to evaluate |
 
-**Options:**
+Available bindings: `$begin`, `$end`, `$duration_ms`, `$innerWidth`, `$devicePixelRatio`, and upstream variables as `$variableName`.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `pageSize` | number | Entries per page (default: 50) |
+Available functions: `snap_interval()`, `Math.*`.
 
-**Expected columns:**
-
-The renderer auto-classifies columns by name:
-
-- `time` — event timestamp
-- `level` — log level (`ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`)
-- `target` — logger target/module
-- `msg` — log message
-
-Additional columns are rendered as fixed-width monospace text.
-
-- Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
-
-**Level coloring:**
-
-| Level | Color |
-|-------|-------|
-| ERROR | Red |
-| WARN | Yellow |
-| INFO | Gray |
-| DEBUG/TRACE | Muted |
-
-**Example SQL:**
-
-```sql
-SELECT time, level, target, msg
-FROM log_entries
-ORDER BY time DESC
-LIMIT 500
+```javascript
+// Compute a time bin interval based on viewport width
+snap_interval($duration_ms / $innerWidth)
 ```
 
-![Log cell with level-based coloring and full-text search](../../assets/images/notebooks/log_cell.png){ .screenshot }
+See [Expression Evaluation](variables.md#expression-evaluation) for details.
 
----
+### Datasource
 
-## ![Property Timeline](../../assets/images/cell-icons/gantt-chart.svg){ .cell-icon } Property Timeline
+Dropdown populated with available data sources from the API. Use with `$variableName` in a query cell's data source field to route queries to user-selected backends.
 
-Visualizes how JSON properties change over time as horizontal timeline segments.
-
-**Configuration:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `sql` | string | SQL query returning `time` and `properties` (JSON) columns |
-| `dataSource` | string | Data source override |
-
-**Options:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `selectedKeys` | string[] | Property keys to display as timeline tracks |
-
-**Features:**
-
-- Parses JSON properties from each row and detects value changes
-- Each selected property key displays as a horizontal timeline track
-- Interactive key selection — add or remove property keys from the display
-- Time range zoom via drag selection
-- Fills time gaps with "no value" state
-- Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
-
-**Expected columns:**
-
-- `time` — timestamp
-- `properties` — JSON object string (e.g., `{"cpu": 45, "state": "running"}`)
-
-![Property timeline showing map property changes over time](../../assets/images/notebooks/property_timeline.png){ .screenshot }
-
----
-
-## ![Swimlane](../../assets/images/cell-icons/align-center.svg){ .cell-icon } Swimlane
-
-Horizontal lane visualization for thread or async activity over time. Each lane shows one or more time segments as horizontal bars.
-
-**Configuration:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `sql` | string | SQL query returning lane data |
-| `dataSource` | string | Data source override |
-
-**Required columns:**
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | string | Unique lane identifier |
-| `name` | string | Lane display name |
-| `begin` | timestamp | Segment start time |
-| `end` | timestamp | Segment end time |
-
-Multiple rows with the same `id` create multiple segments in one lane. Lanes are ordered by first occurrence in the query results.
-
-**Features:**
-
-- Fixed label column on the left with lane names
-- Horizontal time bars in the center
-- Drag-to-zoom time selection
-- Time axis with formatted tick marks
-- Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
-
-**Example SQL:**
-
-```sql
-SELECT
-  arrow_cast(stream_id, 'Utf8') as id,
-  concat(
-    arrow_cast(property_get("streams.properties", 'thread-name'), 'Utf8'),
-    '-',
-    arrow_cast(property_get("streams.properties", 'thread-id'), 'Utf8')
-  ) as name,
-  begin_time as begin,
-  end_time as end
-FROM blocks
-WHERE process_id = '$process_id'
-  AND array_has("streams.tags", 'cpu')
-ORDER BY name, begin
 ```
-
-![Swimlane showing thread activity across a task pool](../../assets/images/notebooks/swimlane.png){ .screenshot }
-
----
-
-## ![Flame Graph](../../assets/images/cell-icons/flame.svg){ .cell-icon } Flame Graph
-
-Interactive span visualization rendered with WebGL. Spans are grouped into lanes (one per thread or async scope) and stacked by call depth, with drag-to-zoom and WASD navigation.
-
-**Configuration:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `sql` | string | SQL query returning span data |
-| `dataSource` | string | Data source override |
-
-**Options:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `initialFrom` | string | Initial zoomed-in start time (accepts `$variable`, relative like `now-1h`, or absolute) |
-| `initialTo` | string | Initial zoomed-in end time |
-
-**Required columns:**
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `id` | bigint | Unique span identifier |
-| `parent` | bigint | Parent span id (0 or null for roots) |
-| `name` | string | Span name (used for label and color hash) |
-| `begin` | timestamp | Span start time |
-| `end` | timestamp | Span end time |
-| `depth` | int | Call depth within the lane (UInt32 in `process_spans`) |
-
-**Optional columns:**
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `lane` | string | Lane name — one lane per distinct value (e.g., thread name, `async`). If omitted, all spans render in a single lane named `default`. The lane literally named `async` gets greedy-packed layout (see Features). |
-
-**Features:**
-
-- WebGL-rendered spans with Canvas2D label and time-axis overlay — handles millions of rows
-- Color-coded by span name using a brand-derived rust/blue/gold palette
-- Drag horizontally to zoom into a time range; WASD keys pan and zoom (cursor-anchored)
-- Mouse wheel scrolls vertically across lanes
-- Hover tooltip shows span name, duration, id, depth, and parent name
-- The lane literally named `async` is laid out by greedy packing to avoid overlap; all other lanes use the raw `depth` column
-- Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
-
-**Example SQL:**
-
-```sql
-SELECT id, parent, name, begin, "end", depth, thread_name AS lane
-FROM process_spans('$process_id', 'both')
-ORDER BY lane, begin
+variableType: 'datasource'
+defaultValue: 'production'
 ```
-
-The `process_spans(process_id, types)` table function returns thread spans, async spans, or `'both'`.
-
-![Flame graph showing nested async spans with a hover tooltip](../../assets/images/notebooks/flame_graph.png){ .screenshot }
-
----
-
-## ![Perfetto Export](../../assets/images/cell-icons/download.svg){ .cell-icon } Perfetto Export
-
-Exports trace data to [Perfetto UI](https://ui.perfetto.dev) for visualization, or downloads it as a file.
-
-**Configuration:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `processIdVar` | string | Variable name containing the process ID (default: `$process_id`) |
-| `spanType` | `'thread'` \| `'async'` \| `'both'` | Which span types to include (default: `both`) |
-| `dataSource` | string | Data source override |
-
-**Features:**
-
-- Split button: **Open in Perfetto** (primary) or **Download** (secondary)
-- Shows a warning if the referenced variable is empty or undefined
-- Caches the generated trace buffer — cleared when process ID, span type, time range, or data source changes
-- Progress indicator during trace generation
-- No automatic execution — triggered by user button click
-
----
-
-## ![Reference Table](../../assets/images/cell-icons/book-open.svg){ .cell-icon } Reference Table
-
-Embeds inline CSV data that is registered as a queryable table in the [local WASM query engine](execution.md#local-wasm-query-engine). Downstream cells can query it by the cell's name.
-
-**Configuration:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `csv` | string | CSV data with headers in the first row |
-
-**Options:**
-
-Same as Table — `sortColumn`, `sortDirection`, `pageSize`, `hiddenColumns`.
-
-**Features:**
-
-- CSV is parsed into an Arrow table with automatic type inference (numeric, boolean, string)
-- Registered in the WASM engine under the cell name — queryable by downstream cells
-- Displays as a sortable, paginated table (same UI as the Table cell)
-- Useful for lookup tables, configuration data, or reference values
-
-**Example:**
-
-A cell named `thresholds` with this CSV:
-
-```csv
-metric,warn_threshold,error_threshold
-cpu_usage,80,95
-memory_usage,70,90
-disk_usage,85,95
-```
-
-Can be queried by a downstream table cell:
-
-```sql
-SELECT m.name, m.value, t.warn_threshold, t.error_threshold
-FROM raw_metrics m
-JOIN thresholds t ON m.name = t.metric
-WHERE m.value > t.warn_threshold
-```
-
----
-
-## ![Map](../../assets/images/cell-icons/map.svg){ .cell-icon } Map
-
-3D map visualization that plots spatial events on a GLB model. Events are rendered as instanced sphere markers at their native `(x, y, z)` coordinates.
-
-**Configuration:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `sql` | string | SQL query returning spatial data |
-| `dataSource` | string | Data source override |
-
-**Required columns:**
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `x` | number | X coordinate (Unreal Engine world units) |
-| `y` | number | Y coordinate (Unreal Engine world units) |
-| `z` | number | Z coordinate (Unreal Engine world units) |
-
-**Optional columns:**
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `time` | timestamp | Event timestamp — addressable as `$time` in the detail template |
-| `process_id` | string | Process identifier — addressable as `$process_id` in the detail template |
-| *(any other)* | any | Every column the query produces is addressable as `$column` in the detail template |
-
-**Options:**
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `mapUrl` | string | none | GLB filename selected from the catalog (bare filename — the renderer composes the blob URL) |
-| `markerColor` | string | `#bf360c` | Marker color (hex) |
-| `markerSize` | number | `10` | Marker size — scaled proportionally to the map extent |
-| `detailTemplate` | string | see below | Markdown template rendered in the event detail panel when a marker is clicked |
-
-**Detail template:**
-
-When a marker is selected, the cell renders a Markdown template with macro
-substitution. The selected row's columns are exposed as `$column`, and the
-standard notebook macros work too:
-
-- `$column` — column from the selected row (wins name collisions against variables)
-- `$from`, `$to` — current time range
-- `$variable`, `$variable.column` — notebook variables and their columns
-- `$cell[N].column`, `$cell.selected.column` — cross-cell references
-
-The default template is:
-
-```markdown
-### Event
-
-**Location:** ($x, $y, $z)
-```
-
-Authors extend it to surface query-specific columns. For example, to link to
-the process page using a `process_id` column:
-
-```markdown
-### Event
-
-**Location:** ($x, $y, $z)
-
-[View process logs](/process?process_id=$process_id)
-```
-
-Internal links (starting with `/`) route through the app's base-path-aware
-router; external links open in a new tab. Raw HTML in the template is
-rendered as text (not parsed), matching the Markdown cell's behavior.
-
-**Map catalog:**
-
-Maps are stored in a server-side object store and served through the analytics web tier. The catalog is derived at request time by listing every `*.glb` object directly under the configured prefix — there is no `maps.json` to keep in sync.
-
-Configure the prefix via `MICROMEGAS_MAPS_OBJECT_STORE_URI`. The URL grammar matches the rest of the platform (passed through `object_store::parse_url_opts`):
-
-| Environment | Example URI |
-|---|---|
-| Local dev | `file:///home/you/lake/maps/` (sibling of `lake/blobs/`) |
-| AWS prod | `s3://my-bucket/maps/` |
-
-Admins upload `.glb` files through the **Admin → Maps** page. The server gzips on upload and stores the object with `Content-Type: model/gltf-binary` + `Content-Encoding: gzip` so the existing read path serves it verbatim and the browser decodes transparently. Display names are derived client-side: the `.glb` extension is stripped (`Arena_North.glb` → `Arena_North`).
-
-Ops can still drop `.glb` files directly into the configured prefix (no UI required), but the upload must set the same `Content-Type` + `Content-Encoding` attributes — the Admin → Maps page is the recommended path because it handles the compression and metadata in one shot.
-
-If `MICROMEGAS_MAPS_OBJECT_STORE_URI` is unset, `/api/maps/catalog` returns 503 and the dropdown is empty. The local-dev start script (`start_analytics_web.py`) defaults this to `<MICROMEGAS_OBJECT_STORE_URI>/maps/` — i.e. a `maps/` sibling of the telemetry lake — so a single lake root supplies both telemetry blobs and map assets.
-
-**Upload size:**
-
-Uploads through the Admin → Maps page are capped per request at 256 MiB by default; override with `MICROMEGAS_MAPS_MAX_UPLOAD_BYTES` (raw byte count).
-
-**Storage compression:**
-
-GLBs may be stored gzipped: set `Content-Encoding: gzip` and `Content-Type: model/gltf-binary` on the object. The endpoint passes both headers through verbatim and never re-encodes — the server burns no CPU compressing on the fly, `Content-Length` reflects the wire size, and the browser auto-decodes before handing bytes to three.js. Bare uploads (no metadata) are served uncompressed.
-
-**Coordinate frame:**
-
-Events are placed at their raw `x`, `y`, `z` values without any runtime transform. The GLB is expected to be authored in the same frame and units the events are emitted in — see the GLB authoring contract below.
-
-**GLB authoring contract:**
-
-The renderer expects each GLB to satisfy these invariants — there is no fallback path:
-
-- **Z-up, left-handed, centimeters** — matches the Unreal Engine world frame; no auto-centering. Events flow through unmodified.
-- **Exactly one perspective camera** referenced from `scenes[0]`, used to seed the initial camera (position, orientation, fov, near, far). Camera roll is dropped when seeding the orbit controller.
-- **`KHR_lights_punctual`** — directional lights live inside the scene tree and render automatically.
-- **`MM_ambient_light`** vendor extension — `{ color: [r, g, b], intensity: number }` at the root extensions; the renderer reads it directly from `gltf.parser.json.extensions`.
-
-GLBs missing the camera log a console error and fall back to the default seed framing (likely mis-framed); GLBs missing `MM_ambient_light` log a console error and render without ambient illumination. These are visible failure modes that signal a non-conforming GLB.
-
-> Because the contract uses Z-up / left-handed / centimeters, the GLBs are technically out of spec for glTF 2.0 (which mandates Y-up RH meters). External viewers — Blender, online glTF validators, Windows 3D Viewer — will render them rotated or flag warnings. The micromegas web-app is the only intended consumer.
-
-**Features:**
-
-- Instanced rendering — handles thousands of markers efficiently
-- Interactive markers — click to select, hover to highlight
-- Camera controls — left-drag to pan, right-drag to orbit, scroll to zoom, WASD to fly
-- Reset view with the Z key
-- Event detail panel rendered from a Markdown template with macro substitution
-- Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
-
-**Example SQL (spatial events from a JSONB-encoded payload):**
-
-```sql
-SELECT
-  time,
-  process_id,
-  jsonb_as_f64(jsonb_path_query_first(msg_jsonb, '$.position[0]')) as x,
-  jsonb_as_f64(jsonb_path_query_first(msg_jsonb, '$.position[1]')) as y,
-  jsonb_as_f64(jsonb_path_query_first(msg_jsonb, '$.position[2]')) as z,
-  jsonb_as_string(jsonb_path_query_first(msg_jsonb, '$.actor_id')) as actor_id,
-  jsonb_as_string(jsonb_path_query_first(msg_jsonb, '$.event_type')) as event_type
-FROM events
-WHERE name = 'spatial_event'
-ORDER BY time DESC
-LIMIT 10000
-```
-
----
-
-## ![Horizontal Group](../../assets/images/cell-icons/group.svg){ .cell-icon } Horizontal Group (HG)
-
-A container cell that arranges its children side by side in a horizontal layout.
-
-**Configuration:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `children` | array | Child cell configurations (any type except HG) |
-
-**Features:**
-
-- Children render side by side with equal width
-- Drag children horizontally to reorder within the group
-- Drag a child vertically (out of the group area) to extract it to the main cell list
-- Add new children via the group editor
-- Each child has independent execution, state, and data source settings
-- Aggregate stats (row count, byte size) displayed in the group header
-
-**Constraints:**
-
-- HG cells cannot be nested — no HG inside another HG
-- During execution, children are flattened into the main sequence and execute left to right
-- Variables defined in child cells are visible to cells below the group
-
-**Example use case:**
-
-Place two related charts side by side — one showing CPU usage and another showing memory usage — for a compact comparison view.
-
-![Horizontal group with table, chart, and log cells side by side](../../assets/images/notebooks/horizontal_group.png){ .screenshot }

--- a/mkdocs/docs/web-app/notebooks/variables.md
+++ b/mkdocs/docs/web-app/notebooks/variables.md
@@ -46,8 +46,8 @@ SQL queries, markdown content, and chart unit labels all support macro substitut
 | `$cellName.selected.column` | Replaced with a value from the selected row in an upstream table cell |
 | `$variableName` | Replaced with the variable's value |
 | `$variableName.column` | Replaced with a specific column from a multi-column variable |
-| `$begin` | Start of the current time range (ISO 8601 timestamp) |
-| `$end` | End of the current time range (ISO 8601 timestamp) |
+| `$from` | Start of the current time range (ISO 8601 timestamp) |
+| `$to` | End of the current time range (ISO 8601 timestamp) |
 | `$order_by` | Current sort column (table cells only) |
 
 ### Matching Rules
@@ -104,10 +104,10 @@ Table cells support interactive row selection. When enabled (via the **Row Selec
 Table and transposed table cells support column format overrides using markdown with row macros:
 
 ```markdown
-[$row.exe](/process/$row.process_id?from=$begin&to=$end)
+[$row.exe](/process/$row.process_id?from=$from&to=$to)
 ```
 
-Row macros use `$row.columnName` or `$row["column-name"]` syntax to reference values from the current row. Standard variable macros (`$begin`, `$end`, `$variableName`) are also available in format strings.
+Row macros use `$row.columnName` or `$row["column-name"]` syntax to reference values from the current row. Standard variable macros (`$from`, `$to`, `$variableName`) are also available in format strings.
 
 ## Expression Evaluation
 
@@ -117,8 +117,8 @@ Expression variables evaluate JavaScript expressions in a sandboxed environment 
 
 | Binding | Type | Description |
 |---------|------|-------------|
-| `$begin` | string | Time range start (ISO 8601) |
-| `$end` | string | Time range end (ISO 8601) |
+| `$from` | string | Time range start (ISO 8601) |
+| `$to` | string | Time range end (ISO 8601) |
 | `$duration_ms` | number | Time range duration in milliseconds |
 | `$innerWidth` | number | Browser viewport width in CSS pixels |
 | `$devicePixelRatio` | number | Device pixel ratio (e.g., 2 for Retina displays) |
@@ -176,7 +176,7 @@ A cell can only reference variables and cell results from cells that appear **ab
 - Variables inside a horizontal group (HG) are visible to cells below the group.
 - A variable cell cannot reference other variable cells at the same level.
 
-The editor panel shows an **Available Variables** panel listing all variables accessible to the currently selected cell, including `$begin`, `$end`, upstream user-defined variables with their current values, and upstream cell results with their column schemas. Multi-column variables show both the full object and individual `.column` accessors. Cell results show `$cellName[0].column` entries for each column in the result schema.
+The editor panel shows an **Available Variables** panel listing all variables accessible to the currently selected cell, including `$from`, `$to`, upstream user-defined variables with their current values, and upstream cell results with their column schemas. Multi-column variables show both the full object and individual `.column` accessors. Cell results show `$cellName[0].column` entries for each column in the result schema.
 
 ## URL Parameter Sync
 

--- a/rust/datafusion-extensions/src/jsonb/keys.rs
+++ b/rust/datafusion-extensions/src/jsonb/keys.rs
@@ -14,8 +14,8 @@ use std::sync::Arc;
 
 /// A scalar UDF that extracts the keys from a JSONB object.
 ///
-/// Accepts both Binary and Dictionary<Int32, Binary> inputs.
-/// Returns Dictionary<Int32, List<Utf8>> containing the object keys, or null if input is not an object.
+/// Accepts both `Binary` and `Dictionary<Int32, Binary>` inputs.
+/// Returns `Dictionary<Int32, List<Utf8>>` containing the object keys, or null if input is not an object.
 /// Dictionary encoding is used because JSONB values (especially properties) are often repeated.
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct JsonbObjectKeys {


### PR DESCRIPTION
## Summary

- Alphabetize cell sections in `cell-types.md` so authors can find a cell type by name.
- Expand the Map cell entry with the full channel-mapping table, color column encodings (UInt32 / String / Binary), color UDF signatures (`rgba`, `lerp_color`, `color_scale`), shape defaults, and the camera/keyboard interaction details.
- Move maps admin content (catalog discovery, out-of-band upload contract, GLB authoring contract) out of the cell reference and into Admin → Web App where it belongs.
- Fact-check all cell entries against the implementation — fix wrong page-size defaults (50 → 100), missing `FATAL` log level, outdated color scheme, `\$begin`/`\$end` → `\$from`/`\$to` macro names in expression and table-override docs, `Available Variables` panel listing, and the `DEFAULT_MAP_DETAIL_TEMPLATE` body.
- Add `flame.svg` and `map.svg` to the sidebar TOC icon CSS so Flame Graph and Map sections get their cell icons in the right nav.
- Fix a broken anchor link (`cell-types.md#-map` → `#map`) from `web-app/index.md` introduced by the heading reformat.

## Test plan

- [x] `mkdocs build --strict` is clean (no broken links / missing anchors)
- [x] Verified every cell-type claim against the analytics-web-app source (defaults, options, color encodings, interactions, UDF signatures, default detail template)