### PR TITLE
Fix cargo doc --all-features hiding perfetto library modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This file documents the historical progress of the Micromegas project. For curre
   * Rework map cell keyboard controls onto a single camera-relative orthonormal basis (A/D strafe, W/S up/down, Q/E forward/back) so key pairs no longer collapse onto the same direction at high camera tilt; radial zoom stays on Ctrl+wheel
   * Fix table column-override memo keying on fresh-per-render objects, causing `evaluateTemplate` to re-run every render; key on a content hash of only template-referenced inputs instead (#1092)
   * Route Map detail-panel `$column` macros through the evaluator's raw row + column-types channel so bare references carry their Arrow `DataType`; timestamps format as RFC3339 and `format_value()` receives full-precision raw values instead of pre-stringified ones (#1091)
+* **Build:**
+  * Fix `cargo doc --workspace --all-features` hiding the `micromegas-perfetto` library modules by re-keying proto regeneration on the `MICROMEGAS_REGEN_PROTOS` env var instead of the `protogen` feature (#1079)
 * **Security:**
   * Bump qs to 6.15.2 and js-cookie to 3.0.7 to fix Dependabot alerts (#256, #257)
 * **Dependencies:**

--- a/rust/perfetto/build.rs
+++ b/rust/perfetto/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    // `regen_protos` empties the library modules so the `update-perfetto-protos`
+    // binary can build even when the committed `perfetto.protos.rs` does not
+    // compile. It is intentionally driven by an env var rather than a Cargo
+    // feature, so `--all-features` builds (e.g. `cargo doc`) keep the full API.
+    println!("cargo::rustc-check-cfg=cfg(regen_protos)");
+    println!("cargo::rerun-if-env-changed=MICROMEGAS_REGEN_PROTOS");
+    if std::env::var_os("MICROMEGAS_REGEN_PROTOS").is_some() {
+        println!("cargo::rustc-cfg=regen_protos");
+    }
+}

--- a/rust/perfetto/src/lib.rs
+++ b/rust/perfetto/src/lib.rs
@@ -1,6 +1,14 @@
 //! Library to write Perfetto traces, part of Micromegas.
 #![allow(missing_docs, clippy::missing_errors_doc)]
 
+// The library modules below are emptied out only while regenerating the
+// protobuf bindings (the `regen_protos` cfg, set by `build.rs` when the
+// `MICROMEGAS_REGEN_PROTOS` env var is present). This lets the
+// `update-perfetto-protos` binary build and run even when the committed
+// `perfetto.protos.rs` does not compile against the current `prost` runtime.
+// In every normal build — including `--all-features` and `cargo doc` — the
+// cfg is unset, so the full public API is always available.
+
 /// Protobufs (generated code)
 #[allow(
     clippy::doc_lazy_continuation,
@@ -8,23 +16,23 @@
     clippy::large_enum_variant,
     clippy::doc_overindented_list_items
 )]
-#[cfg(not(feature = "protogen"))]
+#[cfg(not(regen_protos))]
 pub mod protos {
     include!("perfetto.protos.rs");
 }
 
 /// Async writer trait
-#[cfg(not(feature = "protogen"))]
+#[cfg(not(regen_protos))]
 pub mod async_writer;
 
 /// Utility functions
-#[cfg(not(feature = "protogen"))]
+#[cfg(not(regen_protos))]
 pub mod utils;
 
 /// Streaming Trace Writer
-#[cfg(not(feature = "protogen"))]
+#[cfg(not(regen_protos))]
 pub mod streaming_writer;
 
 /// Chunk sender for streaming traces
-#[cfg(not(feature = "protogen"))]
+#[cfg(not(regen_protos))]
 pub mod chunk_sender;

--- a/rust/perfetto/src/update_perfetto_protos.rs
+++ b/rust/perfetto/src/update_perfetto_protos.rs
@@ -1,10 +1,18 @@
 ///
 /// to update the protos, run `cargo run --bin update-perfetto-protos --features=protogen`
 ///
+/// if the committed `perfetto.protos.rs` no longer compiles (e.g. after a
+/// `prost` upgrade), set `MICROMEGAS_REGEN_PROTOS=1` so the library modules are
+/// skipped while this binary builds:
+/// `MICROMEGAS_REGEN_PROTOS=1 cargo run --bin update-perfetto-protos --features=protogen`
+///
 use anyhow::{Context, Result};
 
 fn main() -> Result<()> {
-    std::env::set_var("OUT_DIR", "perfetto/src/");
+    // Safe: single-threaded, before any other env access or threads are spawned.
+    unsafe {
+        std::env::set_var("OUT_DIR", "perfetto/src/");
+    }
     let proto_include_paths = vec![
         std::env::var("PERFETTO_SRC_PATH")
             .with_context(|| "reading environment variable PERFETTO_SRC_PATH")?,


### PR DESCRIPTION
## Summary

* The `protogen` Cargo feature gated out the `micromegas-perfetto` library modules. Because `--all-features` enables `protogen` workspace-wide, `cargo doc --workspace --all-features` (and `micromegas-analytics`) broke — the public API was hidden behind the feature meant only for proto regeneration.
* Re-key the proto-regeneration escape hatch on a `MICROMEGAS_REGEN_PROTOS` env var (via a new `build.rs` cfg) instead of the `protogen` feature. The public API is now always present, while proto regeneration still works — even from a broken `perfetto.protos.rs`.
* Wrap `env::set_var` in `unsafe` so the regen binary compiles under edition 2024.

Fixes #1079

## Test plan

* `cargo doc --workspace --all-features --no-deps` — succeeds; all `micromegas-perfetto` modules appear in the generated docs.
* `cargo clippy -p micromegas-perfetto --all-features -- -D warnings` — clean.
* `cargo test -p micromegas-perfetto --all-features` — passes.
* `cargo fmt --check` — clean.
* Proto regeneration still works: `MICROMEGAS_REGEN_PROTOS=1 cargo build --bin update-perfetto-protos --features=protogen`.