### PR TITLE
Add span_fn tracing to delete pipeline functions

### DIFF
--- a/rust/analytics/src/delete.rs
+++ b/rust/analytics/src/delete.rs
@@ -9,6 +9,7 @@ use crate::lakehouse::write_partition::retire_expired_partitions;
 
 /// Deletes a batch of expired blocks from the data lake.
 /// Returns `true` if there are more blocks to delete, `false` otherwise.
+#[span_fn]
 pub async fn delete_expired_blocks_batch(
     lake: &DataLakeConnection,
     expiration: DateTime<Utc>,
@@ -44,6 +45,7 @@ pub async fn delete_expired_blocks_batch(
 }
 
 /// Deletes all expired blocks from the data lake.
+#[span_fn]
 pub async fn delete_expired_blocks(
     lake: &DataLakeConnection,
     expiration: DateTime<Utc>,
@@ -54,6 +56,7 @@ pub async fn delete_expired_blocks(
 
 /// Deletes a batch of empty streams from the data lake.
 /// Returns `true` if there are more streams to delete, `false` otherwise.
+#[span_fn]
 pub async fn delete_empty_streams_batch(
     lake: &DataLakeConnection,
     expiration: DateTime<Utc>,
@@ -94,6 +97,7 @@ pub async fn delete_empty_streams_batch(
 }
 
 /// Deletes all empty streams from the data lake.
+#[span_fn]
 pub async fn delete_empty_streams(
     lake: &DataLakeConnection,
     expiration: DateTime<Utc>,
@@ -104,6 +108,7 @@ pub async fn delete_empty_streams(
 
 /// Deletes a batch of empty processes from the data lake.
 /// Returns `true` if there are more processes to delete, `false` otherwise.
+#[span_fn]
 pub async fn delete_empty_processes_batch(
     lake: &DataLakeConnection,
     expiration: DateTime<Utc>,
@@ -140,6 +145,7 @@ pub async fn delete_empty_processes_batch(
 }
 
 /// Deletes all empty processes from the data lake.
+#[span_fn]
 pub async fn delete_empty_processes(
     lake: &DataLakeConnection,
     expiration: DateTime<Utc>,
@@ -149,6 +155,7 @@ pub async fn delete_empty_processes(
 }
 
 /// Deletes all data older than a specified number of days from the data lake.
+#[span_fn]
 pub async fn delete_old_data(lake: &DataLakeConnection, min_days_old: i32) -> Result<()> {
     let now = Utc::now();
     let expiration = now

--- a/rust/analytics/src/lakehouse/temp.rs
+++ b/rust/analytics/src/lakehouse/temp.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use super::partition_metadata::delete_partition_metadata_batch;
 
+#[span_fn]
 async fn delete_expired_temporary_files_batch(
     lake: &DataLakeConnection,
     now: DateTime<Utc>,
@@ -51,6 +52,7 @@ async fn delete_expired_temporary_files_batch(
     Ok(true)
 }
 
+#[span_fn]
 pub async fn delete_expired_temporary_files(lake: Arc<DataLakeConnection>) -> Result<()> {
     let now = Utc::now();
     while delete_expired_temporary_files_batch(&lake, now).await? {}


### PR DESCRIPTION
## Summary

- Add `#[span_fn]` to all public delete functions in `analytics/src/delete.rs`
- Add `#[span_fn]` to both functions in `analytics/src/lakehouse/temp.rs`

These functions drive the periodic data expiry pipeline (blocks, streams, processes, temporary files). Tracing them makes it possible to observe their execution time and call frequency in the analytics service.