### PR TITLE
Bump react-router to 6.30.4 (CVE open redirect)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This file documents the historical progress of the Micromegas project. For curre
   * Split four high-complexity web-app files (PerformanceAnalysisPage, FlameGraphCell, MapViewer, XYChart) into pure-logic modules, THREE.js scene helpers, and thin React shells, with unit tests for the extracted logic; behavior unchanged (#1089)
   * Unify template and SQL macro value lookup behind a shared `resolveMacro` helper so both engines route every shape (`time`, `cellRow`, `selected`, `rowCol`, `varCol`, `var`) through one lookup; no behavior change (#1088)
 * **Security:**
+  * Bump react-router to 6.30.4 and @remix-run/router to 1.23.3 to fix open redirect CVE
   * Bump qs to 6.15.2 and js-cookie to 3.0.7 to fix Dependabot alerts (#256, #257)
 * **Dependencies:**
   * Update DataFusion to 53.1 and rebuild the datafusion-wasm bindings (#1090)

--- a/analytics-web-app/package.json
+++ b/analytics-web-app/package.json
@@ -38,7 +38,7 @@
     "react-day-picker": "^9.11.3",
     "react-dom": "^19.2.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^6.30.2",
+    "react-router-dom": "^6.30.4",
     "remark-gfm": "^4.0.1",
     "sql-formatter": "^15.7.2",
     "tailwind-merge": "^2.0.0",

--- a/analytics-web-app/yarn.lock
+++ b/analytics-web-app/yarn.lock
@@ -2974,10 +2974,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.23.2":
-  version: 1.23.2
-  resolution: "@remix-run/router@npm:1.23.2"
-  checksum: 10c0/7096b7f2086b2cd80c9e06873b71a8317e04858c01edc06a6fed187b660408a90f47c8e120e8af4c369cf1fa6b6a316a66b0917f42b6eb8a566e98b277c50449
+"@remix-run/router@npm:1.23.3":
+  version: 1.23.3
+  resolution: "@remix-run/router@npm:1.23.3"
+  checksum: 10c0/73622465dd9e9a2c5a7ced7d1151ea6e9195a8a979c99b4f70a67093eeff7f339daf03a7c6304709a9c27deb2081a8fff6737663aacb33529c1a12a0a0827a17
   languageName: node
   linkType: hard
 
@@ -4005,7 +4005,7 @@ __metadata:
     react-day-picker: "npm:^9.11.3"
     react-dom: "npm:^19.2.0"
     react-markdown: "npm:^10.1.0"
-    react-router-dom: "npm:^6.30.2"
+    react-router-dom: "npm:^6.30.4"
     remark-gfm: "npm:^4.0.1"
     sql-formatter: "npm:^15.7.2"
     tailwind-merge: "npm:^2.0.0"
@@ -8176,27 +8176,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^6.30.2":
-  version: 6.30.3
-  resolution: "react-router-dom@npm:6.30.3"
+"react-router-dom@npm:^6.30.4":
+  version: 6.30.4
+  resolution: "react-router-dom@npm:6.30.4"
   dependencies:
-    "@remix-run/router": "npm:1.23.2"
-    react-router: "npm:6.30.3"
+    "@remix-run/router": "npm:1.23.3"
+    react-router: "npm:6.30.4"
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: 10c0/e8a1e13c662ed6ee71a785bd3418ba04b700bcd8aff6ea7b32524371e8abb1c85568cd4fe9b9e9d555b8101fd415f6f1796531f593da60be179ce75b37038657
+  checksum: 10c0/1b25ab26a288da852f7b58eec5c14b3f37919e6773a557cd846d3a05d7a7d890c8d49bda93c0a7f497f240df1df8b0ad50635f990aafb55f2fc545ad8269a822
   languageName: node
   linkType: hard
 
-"react-router@npm:6.30.3":
-  version: 6.30.3
-  resolution: "react-router@npm:6.30.3"
+"react-router@npm:6.30.4":
+  version: 6.30.4
+  resolution: "react-router@npm:6.30.4"
   dependencies:
-    "@remix-run/router": "npm:1.23.2"
+    "@remix-run/router": "npm:1.23.3"
   peerDependencies:
     react: ">=16.8"
-  checksum: 10c0/a0a74bf5a933cf0abd47e0eac1d3a505cd66b866e3ee8f20d8016885d3b4361ba3ba72dee026248c6125e631b191ba6ad109184c892281cea6cb747c71bf5940
+  checksum: 10c0/fb6de7d1002bcab9ea12c4072d93792eca494f1e4f30cfec334ccb6523756d23ce3e093c7c1241399296cebed94789a3fb89f96ee76004e0e746458a8f6bab33
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "resolutions": {
     "@protobufjs/utf8": "^1.1.1",
-    "@remix-run/router": "^1.23.2",
+    "@remix-run/router": "^1.23.3",
     "diff": "^8.0.3",
     "dompurify": "^3.4.0",
     "eslint/ajv": "6.14.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "protobufjs": "^7.5.6",
     "protocol-buffers-schema": "^3.6.1",
     "qs": "^6.15.2",
-    "react-router": "^6.30.2",
+    "react-router": "^6.30.4",
     "serialize-javascript": "^7.0.5",
     "uuid": "^14.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9707,14 +9707,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:^6.30.2":
-  version: 6.30.3
-  resolution: "react-router@npm:6.30.3"
+"react-router@npm:^6.30.4":
+  version: 6.30.4
+  resolution: "react-router@npm:6.30.4"
   dependencies:
-    "@remix-run/router": "npm:1.23.2"
+    "@remix-run/router": "npm:1.23.3"
   peerDependencies:
     react: ">=16.8"
-  checksum: 10c0/a0a74bf5a933cf0abd47e0eac1d3a505cd66b866e3ee8f20d8016885d3b4361ba3ba72dee026248c6125e631b191ba6ad109184c892281cea6cb747c71bf5940
+  checksum: 10c0/fb6de7d1002bcab9ea12c4072d93792eca494f1e4f30cfec334ccb6523756d23ce3e093c7c1241399296cebed94789a3fb89f96ee76004e0e746458a8f6bab33
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2461,10 +2461,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:^1.23.2":
-  version: 1.23.2
-  resolution: "@remix-run/router@npm:1.23.2"
-  checksum: 10c0/7096b7f2086b2cd80c9e06873b71a8317e04858c01edc06a6fed187b660408a90f47c8e120e8af4c369cf1fa6b6a316a66b0917f42b6eb8a566e98b277c50449
+"@remix-run/router@npm:^1.23.3":
+  version: 1.23.3
+  resolution: "@remix-run/router@npm:1.23.3"
+  checksum: 10c0/73622465dd9e9a2c5a7ced7d1151ea6e9195a8a979c99b4f70a67093eeff7f339daf03a7c6304709a9c27deb2081a8fff6737663aacb33529c1a12a0a0827a17
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bump `react-router-dom` to 6.30.4 and `react-router` to 6.30.4 in both `analytics-web-app` and root workspaces to address an open redirect CVE in the routing layer
- Also bump the `@remix-run/router` resolution override in root `package.json` from `^1.23.2` to `^1.23.3` to ensure the fixed transitive dependency is installed monorepo-wide (the old resolution override was keeping 1.23.2 installed even after the react-router bump)

## Test plan

- `yarn install` resolves cleanly with `@remix-run/router@1.23.3` and no `1.23.2` entries remaining in any lock file
- `yarn lint` passes in `analytics-web-app`