### PR TITLE
Add label text to swimlane bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file documents the historical progress of the Micromegas project. For curre
 ## Unreleased
 
 * **Web App:**
+  * Add optional `label` column to swimlane cells; labels render as truncated text inside each bar and appear in a hover tooltip alongside the lane name and time range
   * Route `formatDuration` through `formatTimeValue` so flamegraph tooltips show minutes, hours, and days for long spans instead of capping at seconds
   * Add per-row colors, user-selectable series colors, and reference line threshold indicators to XYChart; reference lines support named labels, units, dashed/solid style, and per-line color (#1043)
   * Add a per-Map-cell **Camera** setting with `perspective` (default) and `orthographic` modes; orthographic fits the camera to the projected map silhouette and maps Q/E to zoom (#1065)

--- a/analytics-web-app/src/lib/screen-renderers/cells/SwimlaneCell.tsx
+++ b/analytics-web-app/src/lib/screen-renderers/cells/SwimlaneCell.tsx
@@ -33,6 +33,7 @@ const TIME_AXIS_FORMAT = new Intl.DateTimeFormat(undefined, {
 interface Segment {
   begin: number
   end: number
+  label?: string
 }
 
 interface Lane {
@@ -63,7 +64,7 @@ function extractLanesFromTable(table: Table): ExtractResult {
     const available = table.schema.fields.map((f) => f.name).join(', ') || 'none'
     return {
       lanes: [],
-      error: `Missing required columns: ${missingColumns.join(', ')}. Query must return: id, name, begin, end. Available: ${available}`,
+      error: `Missing required columns: ${missingColumns.join(', ')}. Query must return: id, name, begin, end (label is optional). Available: ${available}`,
     }
   }
 
@@ -71,6 +72,7 @@ function extractLanesFromTable(table: Table): ExtractResult {
   const nameCol = table.getChild('name')!
   const beginCol = table.getChild('begin')!
   const endCol = table.getChild('end')!
+  const labelCol = table.getChild('label') ?? null
 
   const beginField = table.schema.fields.find((f) => f.name === 'begin')
   const endField = table.schema.fields.find((f) => f.name === 'end')
@@ -95,7 +97,9 @@ function extractLanesFromTable(table: Table): ExtractResult {
       laneOrder.push(id)
     }
 
-    laneMap.get(id)!.segments.push({ begin, end })
+    const labelRaw = labelCol?.get(i)
+    const label = labelRaw != null ? String(labelRaw) : undefined
+    laneMap.get(id)!.segments.push({ begin, end, label })
   }
 
   // Return lanes in first-occurrence order
@@ -149,10 +153,25 @@ interface SwimlaneProps {
   onTimeRangeSelect?: (from: Date, to: Date) => void
 }
 
+const TIME_FORMAT = new Intl.DateTimeFormat(undefined, {
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+})
+
 function Swimlane({ lanes, timeRange, onTimeRangeSelect }: SwimlaneProps) {
   const duration = timeRange.to - timeRange.from
   const [selection, setSelection] = useState<{ startX: number; currentX: number } | null>(null)
   const [isDragging, setIsDragging] = useState(false)
+  const [tooltip, setTooltip] = useState<{
+    x: number
+    y: number
+    laneName: string
+    label: string
+    begin: number
+    end: number
+  } | null>(null)
 
   // Calculate position as percentage
   const toPercent = (time: number) => {
@@ -305,12 +324,36 @@ function Swimlane({ lanes, timeRange, onTimeRangeSelect }: SwimlaneProps) {
                   return (
                     <div
                       key={idx}
-                      className="absolute top-1 bottom-1 bg-chart-line rounded-sm pointer-events-none"
+                      className="absolute top-1 bottom-1 bg-chart-line rounded-sm flex items-center overflow-hidden transition-opacity hover:opacity-85 hover:ring-1 hover:ring-brand-gold"
                       style={{
                         left: `${startPercent}%`,
-                        width: `${Math.max(widthPercent, 0.5)}%`, // Min width for visibility
+                        width: `${Math.max(widthPercent, 0.5)}%`,
                       }}
-                    />
+                      onMouseEnter={(e) => {
+                        if (segment.label != null) {
+                          setTooltip({
+                            x: e.clientX,
+                            y: e.clientY,
+                            laneName: lane.name,
+                            label: segment.label,
+                            begin: segment.begin,
+                            end: segment.end,
+                          })
+                        }
+                      }}
+                      onMouseMove={(e) => {
+                        if (segment.label != null) {
+                          setTooltip((prev) => prev ? { ...prev, x: e.clientX, y: e.clientY } : null)
+                        }
+                      }}
+                      onMouseLeave={() => setTooltip(null)}
+                    >
+                      {segment.label != null && (
+                        <span className="truncate px-1 text-[10px] font-medium text-white pointer-events-none">
+                          {segment.label}
+                        </span>
+                      )}
+                    </div>
                   )
                 })}
               </div>
@@ -326,6 +369,20 @@ function Swimlane({ lanes, timeRange, onTimeRangeSelect }: SwimlaneProps) {
           <TimeAxis from={timeRange.from} to={timeRange.to} />
         </div>
       </div>
+
+      {/* Tooltip */}
+      {tooltip && (
+        <div
+          className="fixed bg-app-bg border border-theme-border rounded-md px-3 py-2 text-xs pointer-events-none z-50 shadow-lg"
+          style={{ left: tooltip.x + 15, top: tooltip.y - 10 }}
+        >
+          <div className="text-theme-text-muted text-[10px] mb-1">{tooltip.laneName}</div>
+          <div className="text-theme-text-primary font-medium">{tooltip.label}</div>
+          <div className="text-theme-text-secondary text-[10px] mt-1">
+            {TIME_FORMAT.format(tooltip.begin)} → {TIME_FORMAT.format(tooltip.end)}
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -416,7 +473,7 @@ function SwimlaneCellEditor({ config, onChange, variables, timeRange, onRun, cel
           value={slConfig.sql}
           onChange={(sql) => onChange({ ...slConfig, sql })}
           language="sql"
-          placeholder="SELECT id, name, begin, end FROM ..."
+          placeholder="SELECT id, name, begin, end [, label] FROM ..."
           minHeight="240px"
           onRunShortcut={onRun}
         />

--- a/analytics-web-app/src/lib/screen-renderers/cells/SwimlaneCell.tsx
+++ b/analytics-web-app/src/lib/screen-renderers/cells/SwimlaneCell.tsx
@@ -330,7 +330,7 @@ function Swimlane({ lanes, timeRange, onTimeRangeSelect }: SwimlaneProps) {
                         width: `${Math.max(widthPercent, 0.5)}%`,
                       }}
                       onMouseEnter={(e) => {
-                        if (segment.label != null) {
+                        if (segment.label != null && !isDragging) {
                           setTooltip({
                             x: e.clientX,
                             y: e.clientY,
@@ -342,7 +342,7 @@ function Swimlane({ lanes, timeRange, onTimeRangeSelect }: SwimlaneProps) {
                         }
                       }}
                       onMouseMove={(e) => {
-                        if (segment.label != null) {
+                        if (segment.label != null && !isDragging) {
                           setTooltip((prev) => prev ? { ...prev, x: e.clientX, y: e.clientY } : null)
                         }
                       }}
@@ -374,7 +374,10 @@ function Swimlane({ lanes, timeRange, onTimeRangeSelect }: SwimlaneProps) {
       {tooltip && (
         <div
           className="fixed bg-app-bg border border-theme-border rounded-md px-3 py-2 text-xs pointer-events-none z-50 shadow-lg"
-          style={{ left: tooltip.x + 15, top: tooltip.y - 10 }}
+          style={{
+            left: Math.min(tooltip.x + 15, window.innerWidth - 196),
+            top: Math.min(tooltip.y - 10, window.innerHeight - 76),
+          }}
         >
           <div className="text-theme-text-muted text-[10px] mb-1">{tooltip.laneName}</div>
           <div className="text-theme-text-primary font-medium">{tooltip.label}</div>

--- a/mkdocs/docs/web-app/notebooks/cell-types.md
+++ b/mkdocs/docs/web-app/notebooks/cell-types.md
@@ -556,6 +556,12 @@ Horizontal lane visualization for thread or async activity over time. Each lane 
 | `begin` | timestamp | Segment start time |
 | `end` | timestamp | Segment end time |
 
+**Optional columns:**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `label` | string | Text displayed inside each segment bar; shown in a tooltip on hover alongside the lane name and time range |
+
 Multiple rows with the same `id` create multiple segments in one lane. Lanes are ordered by first occurrence in the query results.
 
 **Features:**


### PR DESCRIPTION
## Summary

- Add optional `label` column to the swimlane cell type; when present, labels render as truncated text inside each segment bar (matching the PropertyTimeline style)
- Hover over a labeled bar shows a tooltip with the lane name, label value, and begin → end time range
- Tooltip is suppressed during drag-to-select and clamped to the viewport edges
- Docs updated in `cell-types.md` with the new optional column

## Test plan

- Add `label` to a swimlane query (e.g. `some_state as label`) and confirm text appears inside bars
- Hover a labeled bar → tooltip shows lane name, label, and time range
- Drag across labeled bars to select a time range → tooltip does not appear during the drag
- Position the browser window so bars are near the right/bottom edge → tooltip stays inside the viewport
- Omit the `label` column entirely → swimlane renders exactly as before