### PR TITLE
Update README roadmap and fix stale docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ To get started with Micromegas, please refer to the [Getting Started](https://mi
 
 ## Current Status & Roadmap
 
+### Unreleased
+* `micromegas-monolith`: single-process deployment running all roles (`ingestion`, `analytics`, `web`, `admin`) in one binary — simplifies self-hosted and single-machine deployments
+* Graceful shutdown for all services
+* Deep `/ready` readiness probe for all services
+* OTLP/JSON content-type support alongside existing protobuf ingestion
+* jemalloc global allocator for production services
+* Chart threshold indicators: reference lines, per-row colors, series color assignment
+* Map cell: orthographic camera mode, camera-relative keyboard controls, hover tooltip preview for markers
+* Swimlane cell: optional color column, label text on bars
+* Log cell: resizable columns, one-click copy for log rows
+* `make_histogram` accepts runtime scalar bounds
+* `format_value()` template function for adaptive unit formatting in detail templates
+* Batched expiry pipeline: bounded memory and transaction sizes for partition retirement, block deletion, and temporary-file cleanup
+* DataFusion 53.1; react-router 6.30.4 (CVE), esbuild 0.28.1 (security)
+
 ### v0.25.0 (May 2026)
 * Native OTLP/HTTP ingestion for logs, metrics, and traces with `otel_spans` JIT view
 * Map notebook cell: GLB models, native UE coordinates, primitive overlays with column-bound visual channels, admin Maps management UI
@@ -124,11 +139,6 @@ To get started with Micromegas, please refer to the [Getting Started](https://mi
 * Drag-to-zoom on charts, config diff modal, per-cell data sources
 * Client-side Perfetto trace generation with gzip compression
 * Parquet content cache and parallelized query planning
-
-### v0.19.0 (January 2026)
-* User-defined screens — JSON-configured notebooks, tables, and dashboards
-* Analytics web app with syntax-highlighted SQL editors
-* `expand_histogram` table function
 
 For the full history, see [CHANGELOG.md](./CHANGELOG.md).
 

--- a/mkdocs/docs/query-guide/functions-reference.md
+++ b/mkdocs/docs/query-guide/functions-reference.md
@@ -908,9 +908,9 @@ make_histogram(start, end, bins, values)
 
 **Parameters:**
 
-- `start` (`Float64`): Histogram minimum value
+- `start` (`Float64`): Histogram minimum value — accepts a literal or any runtime scalar expression (e.g. `MIN(value)`)
 
-- `end` (`Float64`): Histogram maximum value
+- `end` (`Float64`): Histogram maximum value — accepts a literal or any runtime scalar expression (e.g. `MAX(value)`)
 
 - `bins` (`Int64`): Number of histogram bins
 

--- a/mkdocs/docs/web-app/notebooks/cell-types.md
+++ b/mkdocs/docs/web-app/notebooks/cell-types.md
@@ -222,7 +222,7 @@ The renderer auto-classifies columns by name:
 - `target` — logger target/module
 - `msg` — log message
 
-Additional columns render as fixed-width monospace and truncate at 200px — hover to see the full value in a tooltip.
+Additional columns are sized to their content (up to the page width) — hover to see the full value in a tooltip. Columns are resizable by dragging the column header dividers. Each row has a one-click copy icon to copy the full row as JSON.
 
 - Results registered in the [local WASM query engine](execution.md#local-wasm-query-engine) under the cell name for downstream queries
 


### PR DESCRIPTION
## Summary

- Add **Unreleased** section to README covering features merged since v0.25.0 (monolith, graceful shutdown, readiness probes, chart thresholds, map/swimlane/log cell improvements, jemalloc, batched expiry pipeline, etc.)
- Drop v0.19.0 (January 2026) from the README — older than 4 months
- Fix stale log cell docs: columns now sized to content, resizable, with one-click row copy
- Document that `make_histogram` `start`/`end` accept runtime scalar expressions (e.g. `MIN(value)`), not just literals

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Run `python serve.py` in `mkdocs/` and confirm log cell and `make_histogram` pages look correct