### PR TITLE
Resilient Unreal telemetry sink: retry system, priority queues, idle-aware sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file documents the historical progress of the Micromegas project. For curre
 
 ## Unreleased
 
+* **Unreal:**
+  * Replace manual HTTP retry with `FHttpRetrySystem` (exponential backoff, per-priority retry budgets); add four priority queues (Metadata/Logs/Metrics/Traces) with configurable soft/hard byte-cap drop logic; gate concurrent uploads via `telemetry.max_in_flight_requests` CVar (#56, #43)
+  * Add idle-aware spike sampling: suppress spike recording after `telemetry.sampling.interaction_timeout` seconds of no user input; add periodic heartbeat captures every `telemetry.sampling.heartbeat_interval` seconds of active time
+  * Emit `TimeSinceLastInput` metric from `FSlateApplication` each frame, with a `BootTime` fallback so the value reads from boot instead of full uptime when no input has occurred yet
+  * Replace `volatile` members in `HttpEventSink` with `std::atomic`; remove `QueueSize` and `RequestShutdown` volatile fields (#43)
 * **Deployment:**
   * Add `micromegas-monolith` single-process binary that runs ingestion, FlightSQL, maintenance, and web in one Tokio runtime sharing a single data-lake connection; includes Docker image, docker-compose stack, `--monolith` start-script mode, per-role auth, and role selection via `--roles` / `MICROMEGAS_MONOLITH_ROLES` (#1139)
 * **Performance:**

--- a/unreal/MicromegasTelemetrySink/MicromegasTelemetrySink.Build.cs
+++ b/unreal/MicromegasTelemetrySink/MicromegasTelemetrySink.Build.cs
@@ -14,6 +14,7 @@ public class MicromegasTelemetrySink : ModuleRules
 			"HTTP",
 			"RenderCore",
 			"RHI",
+			"Slate",
 		]);
 
 		PrivateIncludePaths.Add( Path.Combine(ModuleDirectory, "ThirdParty/jsoncons-0.173.4") );

--- a/unreal/MicromegasTelemetrySink/Private/HttpEventSink.cpp
+++ b/unreal/MicromegasTelemetrySink/Private/HttpEventSink.cpp
@@ -5,6 +5,8 @@
 #include "HAL/RunnableThread.h"
 #include "HAL/ThreadManager.h"
 #include "HttpModule.h"
+#include "HttpRetrySystem.h"
+#include "Modules/ModuleManager.h"
 #include "InsertBlockRequest.h"
 #include "InsertProcessRequest.h"
 #include "InsertStreamRequest.h"
@@ -28,60 +30,31 @@ DEFINE_LOG_CATEGORY(LogMicromegasTelemetrySink);
 
 namespace
 {
-	void RetryRequest(FHttpRequestPtr OldRequest, int RemainingRetries);
+	// Retry counts and total retry-window budgets (seconds) indexed by EUploadPriority.
+	// The window is also the per-attempt socket timeout — see feature doc for rationale.
+	constexpr uint32 RetryCountByPriority[]         = { 10, 5, 2, 1 };
+	constexpr double RetryWindowSecondsByPriority[]  = { 300.0, 120.0, 30.0, 6.0 };
 
-	void OnProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, int RemainingRetries, uint64 StartTimestamp)
-	{
-		MICROMEGAS_IMETRIC("MicromegasTelemetrySink", MicromegasTracing::Verbosity::Min, TEXT("HttpRequestCompletionTime"), TEXT("ticks"), FPlatformTime::Cycles64() - StartTimestamp);
-		if (!HttpResponse.IsValid() && RemainingRetries > 0)
-		{
-			// the most common error we see is not from the server reporting an error, it's an internal client error failing to rewind a request
-			// in this case, we get a null HttpResponse
-			RetryRequest(HttpRequest, RemainingRetries - 1);
-			return;
-		}
-		int32 Code = HttpResponse ? HttpResponse->GetResponseCode() : 0;
-		if (!bSucceeded || Code != 200)
-		{
-			UE_LOG(LogMicromegasTelemetrySink, Warning, TEXT("Request completed with code=%d response=%s"), Code, HttpResponse ? *(HttpResponse->GetContentAsString()) : TEXT(""));
-		}
-	}
+	// Soft cap: above this Traces are dropped first.
+	TAutoConsoleVariable<int32> CVarMaxQueueBytes(
+		TEXT("telemetry.max_queue_bytes"),
+		128 * 1024 * 1024,
+		TEXT("Soft queue byte cap. Traces dropped above this threshold."));
 
-	void RetryRequest(FHttpRequestPtr OldRequest, int RemainingRetries)
-	{
-		UE_LOG(LogMicromegasTelemetrySink, Verbose, TEXT("Retrying telemetry http request, RemainingRetries=%d"), RemainingRetries);
-		// can't reuse the old request, need to clone it
-		TSharedRef<IHttpRequest, ESPMode::ThreadSafe> NewRequest = FHttpModule::Get().CreateRequest();
-		NewRequest->SetURL(OldRequest->GetURL());
-		NewRequest->SetVerb(OldRequest->GetVerb());
-		NewRequest->SetContent(OldRequest->GetContent());
-		for (FString HeaderPair : OldRequest->GetAllHeaders())
-		{
-			FString Name;
-			FString Value;
-			if (!HeaderPair.Split(TEXT(":"), &Name, &Value))
-			{
-				UE_LOG(LogMicromegasTelemetrySink, Warning, TEXT("Malformed header pair %s"), *HeaderPair);
-				return;
-			}
-			NewRequest->SetHeader(Name, Value);
-		}
-		TOptional<float> Timeout = OldRequest->GetTimeout();
-		if (Timeout.IsSet())
-		{
-			NewRequest->SetTimeout(Timeout.GetValue());
-		}
-		NewRequest->SetDelegateThreadPolicy(OldRequest->GetDelegateThreadPolicy());
-		uint64 StartTimestamp = FPlatformTime::Cycles64();
-		NewRequest->OnProcessRequestComplete().BindLambda([RemainingRetries, StartTimestamp](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded)
-			{
-				OnProcessRequestComplete(HttpRequest, HttpResponse, bSucceeded, RemainingRetries, StartTimestamp);
-			});
-		if (!NewRequest->ProcessRequest())
-		{
-			UE_LOG(LogMicromegasTelemetrySink, Warning, TEXT("Failed to retry telemetry http request"));
-		}
-	}
+	// Hard ceiling: above this Logs/Metrics are dropped too. Bounds memory for any outage.
+	TAutoConsoleVariable<int32> CVarHardQueueBytes(
+		TEXT("telemetry.hard_queue_bytes"),
+		256 * 1024 * 1024,
+		TEXT("Hard queue byte ceiling. Logs/Metrics dropped above this threshold. Must be >= telemetry.max_queue_bytes."));
+
+	// Max uploads handed to FHttpRetrySystem at once. The worker stops draining once this many are
+	// outstanding, keeping the outage backlog in our priority queues where the byte cap governs it.
+	TAutoConsoleVariable<int32> CVarMaxInFlightRequests(
+		TEXT("telemetry.max_in_flight_requests"),
+		3,
+		TEXT("Max concurrent telemetry uploads in flight. Worker pauses draining above this."));
+
+	constexpr float ShutdownFlushTimeoutSeconds = 5.0f;
 
 	uint64 GetTscFrequency()
 	{
@@ -98,7 +71,7 @@ namespace
 	{
 		FString ArgAsJsonArray;
 		TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> JsonWriter = TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&ArgAsJsonArray);
-		
+
 		JsonWriter->WriteArrayStart();
 		{
 			FString NextArg;
@@ -110,8 +83,46 @@ namespace
 		}
 		JsonWriter->WriteArrayEnd();
 		JsonWriter->Close();
-		
+
 		return ArgAsJsonArray;
+	}
+
+	void OnHttpRequestComplete(
+		FHttpRequestPtr Req,
+		FHttpResponsePtr Resp,
+		bool bSucceeded,
+		uint64 StartTimestamp,
+		TSharedPtr<FCompletionState, ESPMode::ThreadSafe> State)
+	{
+		// Fires once at terminal resolution (success or retries exhausted).
+		MICROMEGAS_IMETRIC("MicromegasTelemetrySink", MicromegasTracing::Verbosity::Min, TEXT("HttpRequestCompletionTime"), TEXT("ticks"), FPlatformTime::Cycles64() - StartTimestamp);
+		--State->HttpInFlightRequests;
+		MICROMEGAS_IMETRIC("MicromegasTelemetrySink", MicromegasTracing::Verbosity::Min, TEXT("HttpInFlightRequests"), TEXT("count"), static_cast<uint64>(State->HttpInFlightRequests.load()));
+		State->WakeupThread->Trigger(); // freed a gate slot — wake the worker to drain the next queued item
+
+		const int32 Code = Resp ? Resp->GetResponseCode() : 0;
+		if (Resp)
+		{
+			MICROMEGAS_IMETRIC("MicromegasTelemetrySink", MicromegasTracing::Verbosity::Min, TEXT("HttpResponseCode"), TEXT("code"), static_cast<uint64>(Code));
+		}
+
+		if (!bSucceeded || Code != 200)
+		{
+			FString Reason;
+			if (Resp)
+			{
+				Reason = LexToString(Resp->GetFailureReason());
+			}
+			else if (Req)
+			{
+				Reason = LexToString(Req->GetFailureReason());
+			}
+			UE_LOG(LogMicromegasTelemetrySink, Warning,
+				TEXT("Request completed with code=%d reason=%s response=%s"),
+				Code,
+				*Reason,
+				Resp ? *(Resp->GetContentAsString()) : TEXT(""));
+		}
 	}
 } // namespace
 
@@ -124,10 +135,12 @@ HttpEventSink::HttpEventSink(const FString& InBaseUrl,
 	, Process(ThisProcess)
 	, Auth(InAuth)
 	, Sampling(InSampling)
-	, QueueSize(0)
-	, RequestShutdown(false)
 	, Flusher(InFlusher)
 {
+	State = MakeShared<FCompletionState, ESPMode::ThreadSafe>();
+	RetryManager = MakeShared<FHttpRetrySystem::FManager>(
+		FHttpRetrySystem::FRetryLimitCountSetting(),
+		FHttpRetrySystem::FRetryTimeoutRelativeSecondsSetting());
 	Thread.Reset(FRunnableThread::Create(this, TEXT("MicromegasHttpTelemetrySink")));
 }
 
@@ -137,154 +150,120 @@ HttpEventSink::~HttpEventSink()
 
 void HttpEventSink::OnAuthUpdated()
 {
-	WakeupThread->Trigger();
+	State->WakeupThread->Trigger();
 }
 
 void HttpEventSink::OnStartup(const MicromegasTracing::ProcessInfoPtr& ProcessInfo)
 {
 	MicromegasTracing::Dispatch::InitCurrentThreadStream();
-	IncrementQueueSize();
-	Queue.Enqueue([this, ProcessInfo]()
+	EnqueueWithPriority(EUploadPriority::Metadata, 0, [this, ProcessInfo]()
 		{
 			const TArray<uint8> Body = FormatInsertProcessRequest(*ProcessInfo);
-			constexpr float TimeoutSeconds = 30.0f;
-			SendBinaryRequest(TEXT("insert_process"), Body, TimeoutSeconds);
+			SendBinaryRequest(TEXT("insert_process"), Body, EUploadPriority::Metadata);
 		});
-	WakeupThread->Trigger();
 }
 
 void HttpEventSink::OnShutdown()
 {
 	RequestShutdown = true;
-	WakeupThread->Trigger();
+	State->WakeupThread->Trigger();
 	Thread->WaitForCompletion();
+	if (RetryManager.IsValid() && FModuleManager::Get().IsModuleLoaded("HTTP"))
+	{
+		RetryManager->BlockUntilFlushed(ShutdownFlushTimeoutSeconds);
+	}
 }
 
 void HttpEventSink::OnInitLogStream(const MicromegasTracing::LogStreamPtr& Stream)
 {
-	IncrementQueueSize();
-	Queue.Enqueue([this, Stream]()
+	EnqueueStreamInit(EUploadPriority::Metadata, [this, Stream]() -> TArray<uint8>
 		{
-			const TArray<uint8> Body = FormatInsertLogStreamRequest(*Stream);
-			constexpr float TimeoutSeconds = 30.0f;
-			SendBinaryRequest(TEXT("insert_stream"), Body, TimeoutSeconds);
+			return FormatInsertLogStreamRequest(*Stream);
 		});
-	WakeupThread->Trigger();
 }
 
 void HttpEventSink::OnInitMetricStream(const MicromegasTracing::MetricStreamPtr& Stream)
 {
-	IncrementQueueSize();
-	Queue.Enqueue([this, Stream]()
+	EnqueueStreamInit(EUploadPriority::Metadata, [this, Stream]() -> TArray<uint8>
 		{
-			const TArray<uint8> Body = FormatInsertMetricStreamRequest(*Stream);
-			constexpr float TimeoutSeconds = 30.0f;
-			SendBinaryRequest(TEXT("insert_stream"), Body, TimeoutSeconds);
+			return FormatInsertMetricStreamRequest(*Stream);
 		});
-	WakeupThread->Trigger();
+}
+
+void HttpEventSink::OnInitNetStream(const MicromegasTracing::NetStreamPtr& Stream)
+{
+	EnqueueStreamInit(EUploadPriority::Metadata, [this, Stream]() -> TArray<uint8>
+		{
+			return FormatInsertNetStreamRequest(*Stream);
+		});
 }
 
 void HttpEventSink::OnInitThreadStream(MicromegasTracing::ThreadStream* Stream)
 {
 	const uint32 ThreadId = FPlatformTLS::GetCurrentThreadId();
-	const FString& ThreadName = FThreadManager::GetThreadName(ThreadId);
+	const FString* ThreadName = &FThreadManager::GetThreadName(ThreadId);
+	if (ThreadName->IsEmpty())
+	{
+		static const FString UnnamedThread{ TEXT("UnnamedThread") };
+		ThreadName = &UnnamedThread;
+	}
 
 	Stream->SetProperty(TEXT("thread-name"), *ThreadName);
-	Stream->SetProperty(TEXT("thread-id"), *FString::Format(TEXT("{0}"), { ThreadId }));
+	Stream->SetProperty(TEXT("thread-id"), FString::Format(TEXT("{0}"), { ThreadId }));
 
-	IncrementQueueSize();
-	Queue.Enqueue([this, Stream]()
+	EnqueueWithPriority(EUploadPriority::Metadata, 0, [this, Stream]()
 		{
 			const TArray<uint8> Body = FormatInsertThreadStreamRequest(*Stream);
-			constexpr float TimeoutSeconds = 30.0f;
-			SendBinaryRequest(TEXT("insert_stream"), Body, TimeoutSeconds);
+			SendBinaryRequest(TEXT("insert_stream"), Body, EUploadPriority::Metadata);
 		});
-	WakeupThread->Trigger();
 }
 
 void HttpEventSink::OnProcessLogBlock(const MicromegasTracing::LogBlockPtr& Block)
 {
-	MICROMEGAS_SPAN_FUNCTION("MicromegasTelemetrySink");
-	if (!Sampling->ShouldSampleBlock(Block))
-	{
-		return;
-	}
-	IncrementQueueSize();
-	Queue.Enqueue([this, Block]()
-		{
-			const TArray<uint8> Content = FormatBlockRequest(*Process, *Block);
-			constexpr float TimeoutSeconds = 10.0f;
-			SendBinaryRequest(TEXT("insert_block"), Content, TimeoutSeconds);
-		});
-	WakeupThread->Trigger();
+	EnqueueBlock(Block, EUploadPriority::Logs);
 }
 
 void HttpEventSink::OnProcessMetricBlock(const MicromegasTracing::MetricsBlockPtr& Block)
 {
-	MICROMEGAS_SPAN_FUNCTION("MicromegasTelemetrySink");
-	if (!Sampling->ShouldSampleBlock(Block))
-	{
-		return;
-	}
-	IncrementQueueSize();
-	Queue.Enqueue([this, Block]()
-		{
-			const TArray<uint8> Content = FormatBlockRequest(*Process, *Block);
-			constexpr float TimeoutSeconds = 10.0f;
-			SendBinaryRequest(TEXT("insert_block"), Content, TimeoutSeconds);
-		});
-	WakeupThread->Trigger();
+	EnqueueBlock(Block, EUploadPriority::Metrics);
 }
 
 void HttpEventSink::OnProcessThreadBlock(const MicromegasTracing::ThreadBlockPtr& Block)
 {
-	MICROMEGAS_SPAN_FUNCTION("MicromegasTelemetrySink");
-	if (!Sampling->ShouldSampleBlock(Block))
-	{
-		return;
-	}
-	IncrementQueueSize();
-	Queue.Enqueue([this, Block]()
-		{
-			const TArray<uint8> Content = FormatBlockRequest(*Process, *Block);
-			constexpr float TimeoutSeconds = 2.0f;
-			SendBinaryRequest(TEXT("insert_block"), Content, TimeoutSeconds);
-		});
-	WakeupThread->Trigger();
-}
-
-void HttpEventSink::OnInitNetStream(const MicromegasTracing::NetStreamPtr& Stream)
-{
-	IncrementQueueSize();
-	Queue.Enqueue([this, Stream]()
-		{
-			const TArray<uint8> Body = FormatInsertNetStreamRequest(*Stream);
-			constexpr float TimeoutSeconds = 30.0f;
-			SendBinaryRequest(TEXT("insert_stream"), Body, TimeoutSeconds);
-		});
-	WakeupThread->Trigger();
+	EnqueueBlock(Block, EUploadPriority::Traces);
 }
 
 void HttpEventSink::OnProcessNetBlock(const MicromegasTracing::NetBlockPtr& Block)
 {
-	MICROMEGAS_SPAN_FUNCTION("MicromegasTelemetrySink");
-	if (!Sampling->ShouldSampleBlock(Block))
-	{
-		return;
-	}
-	IncrementQueueSize();
-	Queue.Enqueue([this, Block]()
-		{
-			const TArray<uint8> Content = FormatBlockRequest(*Process, *Block);
-			constexpr float TimeoutSeconds = 2.0f;
-			SendBinaryRequest(TEXT("insert_block"), Content, TimeoutSeconds);
-		});
-	WakeupThread->Trigger();
+	EnqueueBlock(Block, EUploadPriority::Traces);
 }
 
 bool HttpEventSink::IsBusy()
 {
 	return QueueSize > 0;
+}
+
+bool HttpEventSink::DrainOneItem()
+{
+	if (State->HttpInFlightRequests.load() >= static_cast<int64>(CVarMaxInFlightRequests.GetValueOnAnyThread()))
+	{
+		return false; // gate closed — leave items queued, worker will sleep until a slot frees
+	}
+
+	WorkQueue* Queues[] = { &MetadataQueue, &LogQueue, &MetricQueue, &TraceQueue };
+	for (WorkQueue* Q : Queues)
+	{
+		FQueuedWork Item;
+		if (Q->Dequeue(Item))
+		{
+			DecrementQueueSize();
+			QueueSizeBytes -= Item.PayloadBytes;
+			MICROMEGAS_IMETRIC("MicromegasTelemetrySink", MicromegasTracing::Verbosity::Min, TEXT("QueueSizeBytes"), TEXT("bytes"), QueueSizeBytes.load());
+			Item.Work();
+			return true;
+		}
+	}
+	return false;
 }
 
 uint32 HttpEventSink::Run()
@@ -293,55 +272,174 @@ uint32 HttpEventSink::Run()
 	{
 		if (Auth->IsReady())
 		{
-			Callback c;
-			while (Queue.Dequeue(c))
+			while (DrainOneItem())
 			{
-				int32 newQueueSize = FPlatformAtomics::InterlockedDecrement(&QueueSize);
-				MICROMEGAS_IMETRIC("MicromegasTelemetrySink", MicromegasTracing::Verbosity::Min, TEXT("QueueSize"), TEXT("count"), newQueueSize);
-				c();
 			}
 		}
+		MICROMEGAS_IMETRIC("MicromegasTelemetrySink", MicromegasTracing::Verbosity::Min, TEXT("HttpInFlightRequests"), TEXT("count"), static_cast<uint64>(State->HttpInFlightRequests.load()));
 
 		if (RequestShutdown)
 		{
-			break;
+			// Final drain: bypass auth check, submit any remaining queued work before exit.
+			WorkQueue* Queues[] = { &MetadataQueue, &LogQueue, &MetricQueue, &TraceQueue };
+			for (WorkQueue* Q : Queues)
+			{
+				FQueuedWork Item;
+				while (Q->Dequeue(Item))
+				{
+					DecrementQueueSize();
+					QueueSizeBytes -= Item.PayloadBytes;
+					Item.Work();
+				}
+			}
+			return 0;
 		}
-		const uint32 TimeoutMs = static_cast<uint32>(Flusher->Tick(this) * 1000.0);
-		WakeupThread->Wait(TimeoutMs);
+
+		const double WaitSeconds = Flusher->Tick(this);
+		State->WakeupThread->Wait(static_cast<uint32>(FMath::Max(0.0, WaitSeconds) * 1000.0));
 	}
-	return 0;
 }
 
 void HttpEventSink::IncrementQueueSize()
 {
-	int32 IncrementedQueueSize = FPlatformAtomics::InterlockedIncrement(&QueueSize);
+	int32 IncrementedQueueSize = ++QueueSize;
 	MICROMEGAS_IMETRIC("MicromegasTelemetrySink", MicromegasTracing::Verbosity::Min, TEXT("QueueSize"), TEXT("count"), IncrementedQueueSize);
 }
 
-void HttpEventSink::SendBinaryRequest(const TCHAR* command, const TArray<uint8>& content, float TimeoutSeconds)
+void HttpEventSink::DecrementQueueSize()
+{
+	int32 NewQueueSize = --QueueSize;
+	MICROMEGAS_IMETRIC("MicromegasTelemetrySink", MicromegasTracing::Verbosity::Min, TEXT("QueueSize"), TEXT("count"), NewQueueSize);
+}
+
+auto HttpEventSink::QueueForPriority(EUploadPriority UploadPriority) -> WorkQueue&
+{
+	switch (UploadPriority)
+	{
+	case EUploadPriority::Metadata: return MetadataQueue;
+	case EUploadPriority::Logs:     return LogQueue;
+	case EUploadPriority::Metrics:  return MetricQueue;
+	default:                        return TraceQueue;
+	}
+}
+
+void HttpEventSink::EnqueueWithPriority(EUploadPriority Priority, int32 PayloadBytes, Callback Work)
+{
+	const int64 SoftCap = static_cast<int64>(CVarMaxQueueBytes.GetValueOnAnyThread());
+	const int64 HardCap = FMath::Max(static_cast<int64>(CVarHardQueueBytes.GetValueOnAnyThread()), SoftCap);
+
+	if (Priority == EUploadPriority::Traces && QueueSizeBytes.load() >= SoftCap)
+	{
+		int64 Dropped = ++DroppedUploads;
+		MICROMEGAS_IMETRIC("MicromegasTelemetrySink", MicromegasTracing::Verbosity::Min, TEXT("DroppedUploads"), TEXT("count"), static_cast<uint64>(Dropped));
+		return;
+	}
+
+	if (Priority != EUploadPriority::Metadata && QueueSizeBytes.load() >= HardCap)
+	{
+		int64 Dropped = ++DroppedUploads;
+		MICROMEGAS_IMETRIC("MicromegasTelemetrySink", MicromegasTracing::Verbosity::Min, TEXT("DroppedUploads"), TEXT("count"), static_cast<uint64>(Dropped));
+		return;
+	}
+
+	// Charge count and bytes before Enqueue: the worker may dequeue and de-charge
+	// immediately, driving both counters transiently negative otherwise.
+	IncrementQueueSize();
+	QueueSizeBytes += PayloadBytes;
+	MICROMEGAS_IMETRIC("MicromegasTelemetrySink", MicromegasTracing::Verbosity::Min, TEXT("QueueSizeBytes"), TEXT("bytes"), QueueSizeBytes.load());
+	QueueForPriority(Priority).Enqueue(FQueuedWork(MoveTemp(Work), PayloadBytes));
+	State->WakeupThread->Trigger();
+}
+
+void HttpEventSink::EnqueueStreamInit(EUploadPriority Priority, TFunction<TArray<uint8>()> FormatFn)
+{
+	EnqueueWithPriority(Priority, 0, [this, FormatFn = MoveTemp(FormatFn), Priority]()
+		{
+			const TArray<uint8> Body = FormatFn();
+			SendBinaryRequest(TEXT("insert_stream"), Body, Priority);
+		});
+}
+
+template <typename BlockPtrT>
+void HttpEventSink::EnqueueBlock(const BlockPtrT& Block, EUploadPriority Priority)
 {
 	MICROMEGAS_SPAN_FUNCTION("MicromegasTelemetrySink");
-	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> HttpRequest = FHttpModule::Get().CreateRequest();
-	HttpRequest->SetURL(BaseUrl + command);
-	HttpRequest->SetVerb(TEXT("POST"));
-	HttpRequest->SetContent(content);
-	HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/octet-stream"));
-	HttpRequest->SetTimeout(TimeoutSeconds);
-	HttpRequest->SetDelegateThreadPolicy(EHttpRequestDelegateThreadPolicy::CompleteOnHttpThread);
-	uint64 StartTimestamp = FPlatformTime::Cycles64();
-	HttpRequest->OnProcessRequestComplete().BindLambda([StartTimestamp](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded)
+	if (!Sampling->ShouldSampleBlock(Block))
+	{
+		return;
+	}
+	const int32 PayloadBytes = static_cast<int32>(Block->GetEvents().GetSizeBytes());
+	EnqueueWithPriority(Priority, PayloadBytes, [this, Block, Priority]()
 		{
-			const int RetryCount = 1;
-			OnProcessRequestComplete(HttpRequest, HttpResponse, bSucceeded, RetryCount, StartTimestamp);
+			const TArray<uint8> Content = FormatBlockRequest(*Process, *Block);
+			SendBinaryRequest(TEXT("insert_block"), Content, Priority);
 		});
+}
+
+void HttpEventSink::SendBinaryRequest(const TCHAR* Command, const TArray<uint8>& Content, EUploadPriority Priority)
+{
+	MICROMEGAS_SPAN_FUNCTION("MicromegasTelemetrySink");
+
+	if (!FModuleManager::Get().IsModuleLoaded("HTTP"))
+	{
+		return;
+	}
+
+	const uint8 PriorityIndex = static_cast<uint8>(Priority);
+	const uint32 RetryLimit   = RetryCountByPriority[PriorityIndex];
+	const double RetryWindow  = RetryWindowSecondsByPriority[PriorityIndex];
+
+	// 429=rate-limited, 500=internal, 502/503=gateway/unavailable, 504=gateway-timeout
+	static const FHttpRetrySystem::FRetryResponseCodes RetryCodes({ 429, 500, 502, 503, 504 });
+	static const FHttpRetrySystem::FRetryVerbs RetryVerbs({ FName(TEXT("POST")) });
+	FHttpRetrySystem::FExponentialBackoffCurve Backoff;
+
+	TSharedRef<FHttpRetrySystem::FRequest, ESPMode::ThreadSafe> HttpRequest =
+		RetryManager->CreateRequest(
+			FHttpRetrySystem::FRetryLimitCountSetting(RetryLimit),
+			FHttpRetrySystem::FRetryTimeoutRelativeSecondsSetting(RetryWindow),
+			RetryCodes,
+			RetryVerbs,
+			FHttpRetrySystem::FRetryDomainsPtr(),
+			FHttpRetrySystem::FRetryLimitCountSetting(),
+			Backoff);
+
+	HttpRequest->SetURL(BaseUrl + Command);
+	HttpRequest->SetVerb(TEXT("POST"));
+	HttpRequest->SetContent(Content);
+	HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/octet-stream"));
+	HttpRequest->SetDelegateThreadPolicy(EHttpRequestDelegateThreadPolicy::CompleteOnHttpThread);
+
+	const uint64 StartTimestamp = FPlatformTime::Cycles64();
+	TSharedPtr<FCompletionState, ESPMode::ThreadSafe> StateCopy = State;
+
+	HttpRequest->OnProcessRequestComplete().BindLambda(
+		[StartTimestamp, StateCopy](FHttpRequestPtr Req, FHttpResponsePtr Resp, bool bSucceeded)
+		{
+			OnHttpRequestComplete(Req, Resp, bSucceeded, StartTimestamp, StateCopy);
+		});
+
+	HttpRequest->OnRequestWillRetry().BindLambda(
+		[](FHttpRequestPtr Req, FHttpResponsePtr Resp, float SecondsToRetry)
+		{
+			const int32 Code = Resp ? Resp->GetResponseCode() : 0;
+			MICROMEGAS_IMETRIC("MicromegasTelemetrySink", MicromegasTracing::Verbosity::Min, TEXT("HttpRetryResponseCode"), TEXT("code"), static_cast<uint64>(Code));
+			MICROMEGAS_FMETRIC("MicromegasTelemetrySink", MicromegasTracing::Verbosity::Min, TEXT("HttpRetryAttemptElapsed"), TEXT("seconds"), Req->GetElapsedTime());
+		});
+
 	if (!Auth->Sign(*HttpRequest))
 	{
 		UE_LOG(LogMicromegasTelemetrySink, Warning, TEXT("Failed to sign telemetry http request"));
 		return;
 	}
 
+	// Charge the gate before ProcessRequest: completion fires on the HTTP thread and
+	// could otherwise decrement before this increment, driving the counter negative.
+	++State->HttpInFlightRequests;
+	MICROMEGAS_IMETRIC("MicromegasTelemetrySink", MicromegasTracing::Verbosity::Min, TEXT("HttpInFlightRequests"), TEXT("count"), static_cast<uint64>(State->HttpInFlightRequests.load()));
 	if (!HttpRequest->ProcessRequest())
 	{
+		--State->HttpInFlightRequests; // no completion delegate will fire
 		UE_LOG(LogMicromegasTelemetrySink, Warning, TEXT("Failed to initialize telemetry http request"));
 	}
 }
@@ -392,7 +490,7 @@ TSharedPtr<MicromegasTracing::EventSink> InitHttpEventSink(
 	Process->CpuBrand = *FPlatformMisc::GetCPUBrand();
 	Process->TscFrequency = GetTscFrequency();
 	Process->StartTime = StartTime;
-	
+
 	// Currently this data duplicates some of the data in the process info, but the goal is to move it here
 	// and leave the process info with only the minimum necessary
 	Process->Properties.Add(TEXT("platform-name"), FPlatformProperties::IniPlatformName());
@@ -419,9 +517,9 @@ TSharedPtr<MicromegasTracing::EventSink> InitHttpEventSink(
     // this is not a typo, _ was chosen to delimit the unit
 	Process->Properties.Add(TEXT("ram_mb"), FString::FromInt(static_cast<int32>(FPlatformMemory::GetStats().TotalPhysical / (1024 * 1024))));
 
-	for (const TPair<FString,FString>& P : AdditionalProcessProperties)
+	for (const TPair<FString,FString>& Pair : AdditionalProcessProperties)
 	{
-		Process->Properties.Add(P.Key, P.Value);
+		Process->Properties.Add(Pair.Key, Pair.Value);
 	}
 
 	TSharedPtr<EventSink> Sink = MakeShared<HttpEventSink>(BaseUrl, Process, Auth, Sampling, Flusher);

--- a/unreal/MicromegasTelemetrySink/Private/MetricPublisher.cpp
+++ b/unreal/MicromegasTelemetrySink/Private/MetricPublisher.cpp
@@ -4,6 +4,7 @@
 #include "MicromegasTelemetrySink/MetricPublisher.h"
 
 #include "Engine/World.h"
+#include "Framework/Application/SlateApplication.h"
 #include "HAL/PlatformTime.h"
 #include "MicromegasTracing/DefaultContext.h"
 #include "MicromegasTracing/Macros.h"
@@ -15,6 +16,7 @@
 #include "UnrealClient.h"
 
 MetricPublisher::MetricPublisher()
+	: BootTime(FPlatformTime::Seconds()) // shares Slate's GetCurrentTime() epoch; the "active on boot" baseline for TimeSinceLastInput
 {
 	FWorldDelegates::OnPreWorldInitialization.AddRaw(this, &MetricPublisher::OnWorldInit);
 	FWorldDelegates::OnWorldBeginTearDown.AddRaw(this, &MetricPublisher::OnWorldTornDown);
@@ -131,6 +133,17 @@ void MetricPublisher::Tick()
 		MICROMEGAS_FMETRIC("Frame", MicromegasTracing::Verbosity::Med, TEXT("GPUTime"), TEXT("seconds"), FPlatformTime::ToSeconds(RHIGetGPUFrameCycles(0)));
 		MICROMEGAS_IMETRIC("Frame", MicromegasTracing::Verbosity::Med, TEXT("DrawCalls"), TEXT("count"), GNumDrawCallsRHI[0]);
 		MICROMEGAS_IMETRIC("Frame", MicromegasTracing::Verbosity::Med, TEXT("PrimitivesDrawn"), TEXT("count"), GNumPrimitivesDrawnRHI[0]);
+
+		// Slate tracks the last keyboard/mouse/touch/controller interaction below the gameplay layer,
+		// so this works in any game and in the editor
+		if (FSlateApplication::IsInitialized())
+		{
+			const FSlateApplication& SlateApp = FSlateApplication::Get();
+			// LastUserInteractionTime is 0 until the first input; fall back to BootTime so the metric reads from boot rather than full uptime.
+			const double LastUserInteractionTime = FMath::Max(SlateApp.GetLastUserInteractionTime(), BootTime);
+			const double TimeSinceLastInput = SlateApp.GetCurrentTime() - LastUserInteractionTime;
+			MICROMEGAS_FMETRIC("Frame", MicromegasTracing::Verbosity::Med, TEXT("TimeSinceLastInput"), TEXT("seconds"), TimeSinceLastInput);
+		}
 	}
 
 	const FPlatformMemoryStats MemStats = FPlatformMemory::GetStats();

--- a/unreal/MicromegasTelemetrySink/Private/SamplingController.cpp
+++ b/unreal/MicromegasTelemetrySink/Private/SamplingController.cpp
@@ -4,6 +4,7 @@
 #include "MicromegasTracing/EventBlock.h"
 #include "MicromegasTracing/Macros.h"
 #include "MicromegasTracing/NetTraceWriter.h"
+#include "Framework/Application/SlateApplication.h"
 #include "Misc/App.h"
 #include "Misc/CoreDelegates.h"
 #include "Misc/Parse.h"
@@ -36,6 +37,7 @@ FSamplingController::FSamplingController(const SharedFlushMonitor& InFlushMonito
 	: FlushMonitor(InFlushMonitor)
 	, FrameTimeRunningAvg(RUNNING_AVERAGE_WINDOW_SIZE, RUNNING_AVERAGE_INITIAL_VALUE) // init with a large value to avoid triggering on the first frames, but not so large to get into numerical instability
 	, LastFrameDateTime(FDateTime::UtcNow())
+	, LastCaptureDateTime(FDateTime::UtcNow())
 	, SpikeFactor(INITIAL_SPIKE_FACTOR)
 	, CVarLogEnable(new TAutoConsoleVariable<bool>(
 		  TEXT("telemetry.log.enable"),
@@ -57,6 +59,14 @@ FSamplingController::FSamplingController(const SharedFlushMonitor& InFlushMonito
 		  TEXT("telemetry.net.verbosity"),
 		  2,
 		  TEXT("Net trace verbosity: 0=off, 1=packets, 2=+root objects, 3=+all objects, 4=+properties/RPCs")))
+	, CVarInteractionTimeout(new TAutoConsoleVariable<float>(
+		  TEXT("telemetry.sampling.interaction_timeout"),
+		  2.0f,
+		  TEXT("Seconds since last user input before spike recording is suppressed; 0 disables the gate")))
+	, CVarHeartbeatInterval(new TAutoConsoleVariable<float>(
+		  TEXT("telemetry.sampling.heartbeat_interval"),
+		  120.0f,
+		  TEXT("Seconds of active user time between heartbeat captures; 0 disables")))
 {
 	// Command-line override for net verbosity
 	int32 NetVerbosityOverride = -1;
@@ -81,6 +91,18 @@ FSamplingController::~FSamplingController()
 	FCoreDelegates::OnBeginFrame.RemoveAll(this);
 }
 
+void FSamplingController::RecordSampledRange(const TimeRange& NewRange)
+{
+	FDateTime SampleExpiration = NewRange.Get<1>() - FTimespan(static_cast<int64>(FlushMonitor->GetFlushPeriodSeconds() * ETimespan::TicksPerSecond));
+	UE::TUniqueLock<UE::FMutex> Lock(SampledTimeRangesMutex);
+	SampledTimeRanges.Add(NewRange);
+	// check for out of date samples only when adding a new one to avoid acquiring the lock every frame
+	while (!SampledTimeRanges.IsEmpty() && SampledTimeRanges[0].Get<1>() < SampleExpiration)
+	{
+		SampledTimeRanges.PopFront();
+	}
+}
+
 void FSamplingController::Tick()
 {
 	MICROMEGAS_SPAN_FUNCTION("MicromegasTelemetrySink");
@@ -94,21 +116,39 @@ void FSamplingController::Tick()
 	double LastFrameDeltaTime = FApp::GetDeltaTime(); // we could compute it, but I prefer to rely on the same number that is fed as a metric
 	FrameTimeRunningAvg.Add(LastFrameDeltaTime);
 
+	const float InteractionTimeout = CVarInteractionTimeout->GetValueOnGameThread();
+	if (InteractionTimeout > 0.f && FSlateApplication::IsInitialized())
+	{
+		const FSlateApplication& SlateApp = FSlateApplication::Get();
+		const double TimeSinceLastInput = SlateApp.GetCurrentTime() - SlateApp.GetLastUserInteractionTime();
+		if (TimeSinceLastInput > static_cast<double>(InteractionTimeout))
+		{
+			LastFrameDateTime = Now;
+			return;
+		}
+	}
+
 	double RunningAvg = FrameTimeRunningAvg.Get();
 	if (LastFrameDeltaTime >= RunningAvg * SpikeFactor)
 	{
-		FDateTime SampleExpiration = Now - FTimespan(static_cast<int64>(FlushMonitor->GetFlushPeriodSeconds() * ETimespan::TicksPerSecond));
 		TimeRange NewRange(LastFrameDateTime, Now);
 		UE_LOG(LogMicromegasTelemetrySink, Verbose, TEXT("Spike detected: range=%s factor=%f delta=%f RunningAvg=%f"), *FormatTimeRange(NewRange), SpikeFactor, LastFrameDeltaTime, RunningAvg);
-
-		UE::TUniqueLock<UE::FMutex> Lock(SampledTimeRangesMutex);
-		SampledTimeRanges.Add(NewRange);
-		// check for out of date samples only when adding a new one to avoid acquiring the lock every frame
-		while (!SampledTimeRanges.IsEmpty() && SampledTimeRanges[0].Get<1>() < SampleExpiration)
-		{
-			SampledTimeRanges.PopFront();
-		}
+		RecordSampledRange(NewRange);
+		LastCaptureDateTime = Now;
 		SpikeFactor *= SPIKE_FACTOR_INFLATION; // making the spike detector less sensitive as we collect spikes
+	}
+
+	const float HeartbeatInterval = CVarHeartbeatInterval->GetValueOnGameThread();
+	if (HeartbeatInterval > 0.f)
+	{
+		const double SecondsSinceLastCapture = (Now - LastCaptureDateTime).GetTotalSeconds();
+		if (SecondsSinceLastCapture >= static_cast<double>(HeartbeatInterval))
+		{
+			TimeRange NewRange(LastFrameDateTime, Now);
+			UE_LOG(LogMicromegasTelemetrySink, Verbose, TEXT("Heartbeat capture: range=%s"), *FormatTimeRange(NewRange));
+			RecordSampledRange(NewRange);
+			LastCaptureDateTime = Now;
+		}
 	}
 
 	LastFrameDateTime = Now;

--- a/unreal/MicromegasTelemetrySink/Private/SamplingController.h
+++ b/unreal/MicromegasTelemetrySink/Private/SamplingController.h
@@ -30,19 +30,24 @@ public:
 private:
 	void OnNetVerbosityChanged(IConsoleVariable* Var);
 
+	void RecordSampledRange(const TimeRange& NewRange);
+
 	SharedFlushMonitor FlushMonitor;
 	FRunningAverage FrameTimeRunningAvg;
 	FDateTime LastFrameDateTime;
+	FDateTime LastCaptureDateTime;
 	double SpikeFactor;
-	
+
 	mutable UE::FMutex SampledTimeRangesMutex;
 	TRingBuffer<TimeRange> SampledTimeRanges;
-	
+
 	TUniquePtr<TAutoConsoleVariable<bool>> CVarLogEnable;
 	TUniquePtr<TAutoConsoleVariable<bool>> CVarMetricsEnable;
 	TUniquePtr<TAutoConsoleVariable<bool>> CVarSpansEnable;
 	TUniquePtr<TAutoConsoleVariable<bool>> CVarSpansAll;
 	TUniquePtr<TAutoConsoleVariable<int32>> CVarNetVerbosity;
+	TUniquePtr<TAutoConsoleVariable<float>> CVarInteractionTimeout;
+	TUniquePtr<TAutoConsoleVariable<float>> CVarHeartbeatInterval;
 };
 
 typedef TSharedPtr<FSamplingController, ESPMode::ThreadSafe> SharedSamplingController;

--- a/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/HttpEventSink.h
+++ b/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/HttpEventSink.h
@@ -13,9 +13,42 @@
 #include "MicromegasTracing/Fwd.h"
 #include "SamplingController.h"
 #include "Templates/SharedPointer.h"
+#include <atomic>
 #include <functional>
 
 class FlushMonitor;
+
+// HTTP private dependency — full definition in HttpEventSink.cpp
+namespace FHttpRetrySystem
+{
+	class FManager;
+}
+
+enum class EUploadPriority : uint8
+{
+	Metadata = 0,
+	Logs     = 1,
+	Metrics  = 2,
+	Traces   = 3,
+};
+
+struct FCompletionState
+{
+	std::atomic<int64> HttpInFlightRequests{ 0 };
+	FEventRef          WakeupThread;
+};
+
+struct FQueuedWork
+{
+	std::function<void()> Work;
+	int32                 PayloadBytes = 0;
+
+	FQueuedWork() = default;
+	FQueuedWork(std::function<void()> InWork, int32 InPayloadBytes)
+		: Work(MoveTemp(InWork))
+		, PayloadBytes(InPayloadBytes)
+	{}
+};
 
 class HttpEventSink : public MicromegasTracing::EventSink, public FRunnable
 {
@@ -49,21 +82,43 @@ public:
 	virtual uint32 Run() override;
 
 private:
-	void IncrementQueueSize();
-	void SendBinaryRequest(const TCHAR* Command, const TArray<uint8>& Content, float TimeoutSeconds);
-
 	typedef std::function<void()> Callback;
-	typedef TQueue<Callback, EQueueMode::Mpsc> WorkQueue;
+	typedef TQueue<FQueuedWork, EQueueMode::Mpsc> WorkQueue;
+
+	void IncrementQueueSize();
+	void DecrementQueueSize();
+	bool DrainOneItem();
+	void EnqueueWithPriority(EUploadPriority Priority, int32 PayloadBytes, Callback Work);
+	WorkQueue& QueueForPriority(EUploadPriority UploadPriority);
+	void SendBinaryRequest(const TCHAR* Command, const TArray<uint8>& Content, EUploadPriority Priority);
+
+	template <typename BlockPtrT>
+	void EnqueueBlock(const BlockPtrT& Block, EUploadPriority Priority);
+
+	void EnqueueStreamInit(
+		EUploadPriority Priority,
+		TFunction<TArray<uint8>()> FormatFn);
+
 	FString BaseUrl;
 	MicromegasTracing::ProcessInfoPtr Process;
 	SharedTelemetryAuthenticator Auth;
 	SharedSamplingController Sampling;
-	WorkQueue Queue;
-	volatile int32 QueueSize;
-	volatile bool RequestShutdown;
-	FEventRef WakeupThread;
+
+	WorkQueue MetadataQueue;
+	WorkQueue LogQueue;
+	WorkQueue MetricQueue;
+	WorkQueue TraceQueue;
+
+	std::atomic<int32> QueueSize{ 0 };
+	std::atomic<int64> QueueSizeBytes{ 0 };
+	std::atomic<int64> DroppedUploads{ 0 };
+
+	std::atomic<bool> RequestShutdown{ false };
 	TUniquePtr<FRunnableThread> Thread;
 	SharedFlushMonitor Flusher;
+
+	TSharedPtr<FCompletionState, ESPMode::ThreadSafe> State;
+	TSharedPtr<FHttpRetrySystem::FManager> RetryManager;
 };
 
 MICROMEGASTELEMETRYSINK_API TSharedPtr<MicromegasTracing::EventSink> InitHttpEventSink(

--- a/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/MetricPublisher.h
+++ b/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/MetricPublisher.h
@@ -27,6 +27,8 @@ private:
 	static void EmitVSyncStatus(IConsoleVariable* CVar);
 
 	FName CurrentWorldName;
+	// Slate's last-interaction time is 0 until the first input; fall back to this so idle time reads from boot, not full uptime.
+	double BootTime;
 };
 
 typedef TSharedPtr<MetricPublisher, ESPMode::ThreadSafe> SharedMetricPublisher;


### PR DESCRIPTION
## Summary

- Replace manual HTTP retry logic with `FHttpRetrySystem` (exponential backoff per priority level; 10/5/2/1 retries with 300/120/30/6 s windows)
- Four priority queues (Metadata → Logs → Metrics → Traces) drained in order; soft byte cap drops Traces first, hard cap drops Logs/Metrics too — bounds memory during outages
- `telemetry.max_in_flight_requests` CVar gates concurrent uploads; worker wakes when a slot frees
- Idle-aware sampling: `telemetry.sampling.interaction_timeout` suppresses spike recording when no user input detected via `FSlateApplication`
- Periodic heartbeat captures every `telemetry.sampling.heartbeat_interval` seconds of active time
- `TimeSinceLastInput` metric emitted each frame from `FSlateApplication::GetLastUserInteractionTime()`, with `BootTime` fallback
- Replace all `volatile` members in `HttpEventSink` with `std::atomic`
- Flush `RetryManager` on shutdown; guard `SendBinaryRequest` against unloaded HTTP module

Closes #56
Closes #43

## Test plan

- Build and run a game with the plugin; confirm telemetry still flows to the ingestion server
- Disconnect the ingestion server and reconnect — verify requests retry and are eventually delivered
- Set `telemetry.max_queue_bytes` to a low value and flood the queue — confirm Traces are dropped first, then Logs/Metrics, and `DroppedUploads` metric increments
- Leave the game idle past `telemetry.sampling.interaction_timeout` — verify no new spike captures appear in the analytics data
- Query `TimeSinceLastInput` metric in the analytics UI and confirm it reads near-zero after mouse movement and grows during idle