### PR TITLE
Upgrade dompurify to 3.4.11 and @opentelemetry/core to 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ This file documents the historical progress of the Micromegas project. For curre
 * **Security:**
   * Bump react-router to 6.30.4 and @remix-run/router to 1.23.3 to fix open redirect CVE
   * Bump qs to 6.15.2 and js-cookie to 3.0.7 to fix Dependabot alerts (#256, #257)
+  * Upgrade `dompurify` to 3.4.11 (prototype pollution CVE) and `@opentelemetry/core` to 2.8.0
 * **Dependencies:**
   * Update DataFusion to 53.1 and rebuild the datafusion-wasm bindings (#1090)
 

--- a/doc/high-frequency-observability/package-lock.json
+++ b/doc/high-frequency-observability/package-lock.json
@@ -1640,9 +1640,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -2122,9 +2122,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/doc/high-frequency-observability/package.json
+++ b/doc/high-frequency-observability/package.json
@@ -20,6 +20,7 @@
     "vite": "^7.1.3"
   },
   "overrides": {
+    "dompurify": "^3.4.9",
     "esbuild": "0.28.1",
     "lodash-es": "^4.17.23",
     "postcss": "^8.5.10",

--- a/doc/intro-micromegas/package.json
+++ b/doc/intro-micromegas/package.json
@@ -20,9 +20,10 @@
     "reveal.js-mermaid-plugin": "11.6.0"
   },
   "devDependencies": {
-    "vite": "^7.1.3"
+    "vite": "^7.3.5"
   },
   "resolutions": {
+    "dompurify": "^3.4.9",
     "esbuild": "0.28.1",
     "lodash-es": "^4.17.23",
     "rollup": "^4.59.0",

--- a/doc/intro-micromegas/yarn.lock
+++ b/doc/intro-micromegas/yarn.lock
@@ -1184,15 +1184,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.3.1":
-  version: 3.4.2
-  resolution: "dompurify@npm:3.4.2"
+"dompurify@npm:^3.4.9":
+  version: 3.4.11
+  resolution: "dompurify@npm:3.4.11"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/23ab3ab079480a49e1426c4ee7279e393913fa7f2193c4142a5be54d4163dbdd969558675876c6b8bbcbf2ad5d1bc3e00bf902acf142fff12e50274a65ae95b3
+  checksum: 10c0/31439481c7e8fc3805d40c376936fd66936620fb1b1a31a2ec097f6165412c37f2d868e082c9ceba62bb37661c1ea132a5db4d5213434317e30df68d4aca9cc9
   languageName: node
   linkType: hard
 
@@ -1393,7 +1393,7 @@ __metadata:
     mermaid: "npm:11.15.0"
     reveal.js: "npm:^5.2.1"
     reveal.js-mermaid-plugin: "npm:11.6.0"
-    vite: "npm:^7.1.3"
+    vite: "npm:^7.3.5"
   languageName: unknown
   linkType: soft
 
@@ -1813,9 +1813,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^7.1.3":
-  version: 7.3.2
-  resolution: "vite@npm:7.3.2"
+"vite@npm:^7.3.5":
+  version: 7.3.5
+  resolution: "vite@npm:7.3.5"
   dependencies:
     esbuild: "npm:^0.27.0"
     fdir: "npm:^6.5.0"
@@ -1864,7 +1864,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/74be36907e208916f18bfec81c8eba18b869f0a170f1ece0a4dcb14874d0f0e7c022fb6c2ad896e3ee6c973fe88f53ac23b4078879ada340d8b263260868b8d4
+  checksum: 10c0/4ad700649ed2ebd1e726d32f3f6e41eecbec4e29bcb5977805f3d43a5659280518aa431b0fc61adc1879df4fe1978d7cfc7dbbe54cdf014022385052967721e8
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
     "lodash": "^4.18.0"
   },
   "resolutions": {
+    "@opentelemetry/core": "^2.8.0",
     "@protobufjs/utf8": "^1.1.1",
     "@remix-run/router": "^1.23.3",
     "diff": "^8.0.3",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.9",
     "eslint/ajv": "6.14.0",
     "fast-uri": "^3.1.2",
     "flatted": "^3.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1963,14 +1963,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/core@npm:2.0.1":
-  version: 2.0.1
-  resolution: "@opentelemetry/core@npm:2.0.1"
+"@opentelemetry/core@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "@opentelemetry/core@npm:2.8.0"
   dependencies:
     "@opentelemetry/semantic-conventions": "npm:^1.29.0"
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
-  checksum: 10c0/d587b1289559757d80da98039f9f57612f84f72ec608cd665dc467c7c6c5ce3a987dfcc2c63b521c7c86ce984a2552b3ead15a0dc458de1cf6bde5cdfe4ca9d8
+  checksum: 10c0/35b8a464b359a0699fcbcea8c11a883f0f634ee7638719b89fa0c0cbbaaa38c57db22e9ac19ffb15ce18014751dc7db11a26d7fb6ad6259f89a26bdc4d167e4b
   languageName: node
   linkType: hard
 
@@ -5190,15 +5190,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "dompurify@npm:3.4.0"
+"dompurify@npm:^3.4.9":
+  version: 3.4.11
+  resolution: "dompurify@npm:3.4.11"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/5593ac44ee20b9aa521c2120884effc98927fb9128c548183c75e79e0a04357c62ee913a049a267c8f396cb8c9d520ecf72562826c5524c46d4fe03c12063638
+  checksum: 10c0/31439481c7e8fc3805d40c376936fd66936620fb1b1a31a2ec097f6165412c37f2d868e082c9ceba62bb37661c1ea132a5db4d5213434317e30df68d4aca9cc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

* Upgrade `dompurify` from 3.2.4 to 3.4.11 to address a prototype pollution CVE — applied across root workspace, `doc/intro-micromegas`, and `doc/high-frequency-observability`
* Upgrade `@opentelemetry/core` to 2.8.0 in the root workspace (peer dep satisfied by installed `@opentelemetry/api@1.9.0`)
* Update all lock files (`yarn.lock` × 2, `package-lock.json` × 1) to match

## Test plan

- [ ] `yarn install --frozen-lockfile` passes at repo root and in `doc/intro-micromegas`
- [ ] `npm ci` passes in `doc/high-frequency-observability` (0 vulnerabilities)
- [ ] Grafana plugin builds cleanly: `cd grafana && yarn build`
- [ ] Analytics web app builds cleanly: `cd analytics-web-app && yarn build`