### PR TITLE
Replace Perforce junction links with one-way copy script

### DIFF
--- a/build/copy_unreal_from_workspace.py
+++ b/build/copy_unreal_from_workspace.py
@@ -13,8 +13,14 @@ into the git repo, then review the diff and commit.
 import os
 import pathlib
 import shutil
+import stat
 import subprocess
 import tempfile
+
+
+def _force_remove(func, path, _exc_info):
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
 
 
 def has_untracked_files(directory: pathlib.Path) -> bool:
@@ -41,6 +47,21 @@ def has_dirty_files(directory: pathlib.Path) -> bool:
     return bool(result.stdout.strip())
 
 
+TEXT_SUFFIXES = {
+    ".h", ".cpp", ".cs", ".inl", ".hpp", ".c", ".txt", ".md", ".json", ".xml",
+    ".ini", ".uplugin", ".uproject", ".natvis",
+}
+
+
+def normalize_line_endings(directory: pathlib.Path) -> None:
+    for path in directory.rglob("*"):
+        if path.is_file() and path.suffix.lower() in TEXT_SUFFIXES:
+            data = path.read_bytes()
+            if b"\r\n" in data:
+                path.chmod(stat.S_IWRITE | stat.S_IREAD)
+                path.write_bytes(data.replace(b"\r\n", b"\n"))
+
+
 def copy_tree(src: pathlib.Path, dst: pathlib.Path) -> None:
     if not src.exists():
         raise FileNotFoundError(f"source not found: {src}")
@@ -55,16 +76,17 @@ def copy_tree(src: pathlib.Path, dst: pathlib.Path) -> None:
             )
     tmp = dst.parent / (dst.name + ".tmp")
     if tmp.exists():
-        shutil.rmtree(tmp)
+        shutil.rmtree(tmp, onexc=_force_remove)
     try:
         shutil.copytree(src, tmp, ignore=shutil.ignore_patterns("*.~*", "*~"))
     except Exception:
         shutil.rmtree(tmp, ignore_errors=True)
         raise
+    normalize_line_endings(tmp)
     if dst.exists():
-        shutil.rmtree(dst)
+        shutil.rmtree(dst, onexc=_force_remove)
     tmp.rename(dst)
-    print(f"copied {src}\n     → {dst}")
+    print(f"copied {src}\n    -> {dst}")
 
 
 unreal_root_dir = os.environ.get("MICROMEGAS_UNREAL_ROOT_DIR")

--- a/build/copy_unreal_from_workspace.py
+++ b/build/copy_unreal_from_workspace.py
@@ -14,6 +14,7 @@ import os
 import pathlib
 import shutil
 import subprocess
+import tempfile
 
 
 def has_untracked_files(directory: pathlib.Path) -> bool:
@@ -21,6 +22,7 @@ def has_untracked_files(directory: pathlib.Path) -> bool:
         ["git", "ls-files", "--others", "--exclude-standard", str(directory)],
         capture_output=True,
         text=True,
+        check=True,
     )
     return bool(result.stdout.strip())
 
@@ -33,8 +35,17 @@ def copy_tree(src: pathlib.Path, dst: pathlib.Path) -> None:
             raise RuntimeError(
                 f"untracked files found in {dst} — commit or remove them before copying"
             )
+    tmp = dst.parent / (dst.name + ".tmp")
+    if tmp.exists():
+        shutil.rmtree(tmp)
+    try:
+        shutil.copytree(src, tmp, ignore=shutil.ignore_patterns("*.~*", "*~"))
+    except Exception:
+        shutil.rmtree(tmp, ignore_errors=True)
+        raise
+    if dst.exists():
         shutil.rmtree(dst)
-    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("*.~*", "*~"))
+    tmp.rename(dst)
     print(f"copied {src}\n     → {dst}")
 
 

--- a/build/copy_unreal_from_workspace.py
+++ b/build/copy_unreal_from_workspace.py
@@ -1,0 +1,53 @@
+"""
+Copy Unreal Engine modules from a local Perforce workspace into this git repo.
+
+Environment variables:
+  MICROMEGAS_UNREAL_ROOT_DIR             - root of the Unreal Engine source tree
+  MICROMEGAS_UNREAL_TELEMETRY_MODULE_DIR - directory that contains MicromegasTelemetrySink
+                                           (may be inside a plugin folder)
+
+Run this script whenever the Perforce workspace has changes you want to bring
+into the git repo, then review the diff and commit.
+"""
+
+import os
+import pathlib
+import shutil
+
+
+def copy_tree(src: pathlib.Path, dst: pathlib.Path) -> None:
+    if not src.exists():
+        raise FileNotFoundError(f"source not found: {src}")
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns("*.~*", "*~"))
+    print(f"copied {src}\n     → {dst}")
+
+
+unreal_root_dir = os.environ.get("MICROMEGAS_UNREAL_ROOT_DIR")
+telemetry_module_dir = os.environ.get("MICROMEGAS_UNREAL_TELEMETRY_MODULE_DIR")
+
+if not unreal_root_dir:
+    raise EnvironmentError("MICROMEGAS_UNREAL_ROOT_DIR is not set")
+if not telemetry_module_dir:
+    raise EnvironmentError("MICROMEGAS_UNREAL_TELEMETRY_MODULE_DIR is not set")
+
+core_dir = pathlib.Path(unreal_root_dir) / "Engine" / "Source" / "Runtime" / "Core"
+repo_unreal = pathlib.Path(__file__).parent.parent / "unreal"
+
+copy_tree(
+    core_dir / "Public" / "MicromegasTracing",
+    repo_unreal / "MicromegasTracing" / "Public" / "MicromegasTracing",
+)
+
+copy_tree(
+    core_dir / "Private" / "MicromegasTracing",
+    repo_unreal / "MicromegasTracing" / "Private",
+)
+
+copy_tree(
+    pathlib.Path(telemetry_module_dir) / "MicromegasTelemetrySink",
+    repo_unreal / "MicromegasTelemetrySink",
+)
+
+print("\nDone. Review `git diff unreal/` and commit.")

--- a/build/copy_unreal_from_workspace.py
+++ b/build/copy_unreal_from_workspace.py
@@ -18,11 +18,25 @@ import tempfile
 
 
 def has_untracked_files(directory: pathlib.Path) -> bool:
+    repo_root = pathlib.Path(__file__).parent.parent
     result = subprocess.run(
         ["git", "ls-files", "--others", "--exclude-standard", str(directory)],
         capture_output=True,
         text=True,
         check=True,
+        cwd=repo_root,
+    )
+    return bool(result.stdout.strip())
+
+
+def has_dirty_files(directory: pathlib.Path) -> bool:
+    repo_root = pathlib.Path(__file__).parent.parent
+    result = subprocess.run(
+        ["git", "status", "--porcelain", str(directory)],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=repo_root,
     )
     return bool(result.stdout.strip())
 
@@ -34,6 +48,10 @@ def copy_tree(src: pathlib.Path, dst: pathlib.Path) -> None:
         if has_untracked_files(dst):
             raise RuntimeError(
                 f"untracked files found in {dst} — commit or remove them before copying"
+            )
+        if has_dirty_files(dst):
+            raise RuntimeError(
+                f"locally modified files found in {dst} — commit or stash them before copying"
             )
     tmp = dst.parent / (dst.name + ".tmp")
     if tmp.exists():

--- a/build/copy_unreal_from_workspace.py
+++ b/build/copy_unreal_from_workspace.py
@@ -13,12 +13,26 @@ into the git repo, then review the diff and commit.
 import os
 import pathlib
 import shutil
+import subprocess
+
+
+def has_untracked_files(directory: pathlib.Path) -> bool:
+    result = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard", str(directory)],
+        capture_output=True,
+        text=True,
+    )
+    return bool(result.stdout.strip())
 
 
 def copy_tree(src: pathlib.Path, dst: pathlib.Path) -> None:
     if not src.exists():
         raise FileNotFoundError(f"source not found: {src}")
     if dst.exists():
+        if has_untracked_files(dst):
+            raise RuntimeError(
+                f"untracked files found in {dst} — commit or remove them before copying"
+            )
         shutil.rmtree(dst)
     shutil.copytree(src, dst, ignore=shutil.ignore_patterns("*.~*", "*~"))
     print(f"copied {src}\n     → {dst}")
@@ -28,9 +42,9 @@ unreal_root_dir = os.environ.get("MICROMEGAS_UNREAL_ROOT_DIR")
 telemetry_module_dir = os.environ.get("MICROMEGAS_UNREAL_TELEMETRY_MODULE_DIR")
 
 if not unreal_root_dir:
-    raise EnvironmentError("MICROMEGAS_UNREAL_ROOT_DIR is not set")
+    raise ValueError("MICROMEGAS_UNREAL_ROOT_DIR is not set")
 if not telemetry_module_dir:
-    raise EnvironmentError("MICROMEGAS_UNREAL_TELEMETRY_MODULE_DIR is not set")
+    raise ValueError("MICROMEGAS_UNREAL_TELEMETRY_MODULE_DIR is not set")
 
 core_dir = pathlib.Path(unreal_root_dir) / "Engine" / "Source" / "Runtime" / "Core"
 repo_unreal = pathlib.Path(__file__).parent.parent / "unreal"

--- a/build/unreal_hard_link_windows.py
+++ b/build/unreal_hard_link_windows.py
@@ -1,3 +1,6 @@
+# DEPRECATED - use copy_unreal_from_workspace.py instead.
+# This script created junction links from a Perforce workspace into the git repo.
+# The copy script is the replacement: it copies files one-way (Perforce → git).
 import os
 import pathlib
 import subprocess


### PR DESCRIPTION
## Summary
- Replaces Perforce junction-based Unreal Engine integration with a one-way copy script (`build/copy_unreal_from_workspace.py`)
- Adds guards in the sync script for dirty tracked files and fixes `git cwd` handling in `has_untracked_files`
- Guards `rmtree` against untracked files and fixes `EnvironmentError` type handling

## Test plan
- [ ] Run `build/copy_unreal_from_workspace.py` against a local workspace and verify files are copied correctly
- [ ] Verify the sync script handles dirty tracked files without data loss
- [ ] Verify `has_untracked_files` correctly detects untracked files in the working directory