### PR TITLE
Add image stream support to Unreal telemetry sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file documents the historical progress of the Micromegas project. For curre
 * **Tracing:**
   * Add image streams: instrumented applications can send screenshots or other images as telemetry via `send_image()`; images are queryable via the `images` SQL table with a `data Binary` column holding raw bytes
 * **Unreal:**
+  * Add image stream support to the Unreal telemetry sink: wire `ImageStream`/`ImageBlock` into `Dispatch`, `EventSink`, and `HttpEventSink`; add `telemetry.screenshot` console command that captures the game viewport (or editor viewport via `WITH_EDITOR`) as a PNG and sends it as a telemetry image; gate capture with `telemetry.images.enable` CVar
   * Replace manual HTTP retry with `FHttpRetrySystem` (exponential backoff, per-priority retry budgets); add four priority queues (Metadata/Logs/Metrics/Traces) with configurable soft/hard byte-cap drop logic; gate concurrent uploads via `telemetry.max_in_flight_requests` CVar (#56, #43)
   * Add idle-aware spike sampling: suppress spike recording after `telemetry.sampling.interaction_timeout` seconds of no user input; add periodic heartbeat captures every `telemetry.sampling.heartbeat_interval` seconds of active time
   * Emit `TimeSinceLastInput` metric from `FSlateApplication` each frame, with a `BootTime` fallback so the value reads from boot instead of full uptime when no input has occurred yet

--- a/unreal/MicromegasTelemetrySink/MicromegasTelemetrySink.Build.cs
+++ b/unreal/MicromegasTelemetrySink/MicromegasTelemetrySink.Build.cs
@@ -9,13 +9,18 @@ public class MicromegasTelemetrySink : ModuleRules
 			"BuildSettings",
 			"Core",
 			"CoreUObject",
-			"Engine", 
+			"Engine",
 			"Json",
 			"HTTP",
 			"RenderCore",
 			"RHI",
 			"Slate",
 		]);
+
+		if (Target.bBuildEditor)
+		{
+			PrivateDependencyModuleNames.Add("UnrealEd");
+		}
 
 		PrivateIncludePaths.Add( Path.Combine(ModuleDirectory, "ThirdParty/jsoncons-0.173.4") );
 		PrivateIncludePaths.Add( Path.Combine(ModuleDirectory, "ThirdParty") );

--- a/unreal/MicromegasTelemetrySink/Private/FlushMonitor.cpp
+++ b/unreal/MicromegasTelemetrySink/Private/FlushMonitor.cpp
@@ -47,6 +47,7 @@ void FlushMonitor::Flush()
 	MicromegasTracing::Dispatch::FlushLogStream();
 	MicromegasTracing::Dispatch::FlushMetricStream();
 	MicromegasTracing::Dispatch::FlushNetStream();
+	MicromegasTracing::Dispatch::FlushImageStream();
 	MicromegasTracing::Dispatch::ForEachThreadStream(&MarkStreamFull);
 	MicromegasTracing::Dispatch::FlushCurrentThreadStream();
 	LastFlush = FPlatformTime::Seconds();

--- a/unreal/MicromegasTelemetrySink/Private/HttpEventSink.cpp
+++ b/unreal/MicromegasTelemetrySink/Private/HttpEventSink.cpp
@@ -198,6 +198,14 @@ void HttpEventSink::OnInitNetStream(const MicromegasTracing::NetStreamPtr& Strea
 		});
 }
 
+void HttpEventSink::OnInitImageStream(const MicromegasTracing::ImageStreamPtr& Stream)
+{
+	EnqueueStreamInit(EUploadPriority::Metadata, [this, Stream]() -> TArray<uint8>
+		{
+			return FormatInsertImageStreamRequest(*Stream);
+		});
+}
+
 void HttpEventSink::OnInitThreadStream(MicromegasTracing::ThreadStream* Stream)
 {
 	const uint32 ThreadId = FPlatformTLS::GetCurrentThreadId();
@@ -234,6 +242,11 @@ void HttpEventSink::OnProcessThreadBlock(const MicromegasTracing::ThreadBlockPtr
 }
 
 void HttpEventSink::OnProcessNetBlock(const MicromegasTracing::NetBlockPtr& Block)
+{
+	EnqueueBlock(Block, EUploadPriority::Traces);
+}
+
+void HttpEventSink::OnProcessImageBlock(const MicromegasTracing::ImageBlockPtr& Block)
 {
 	EnqueueBlock(Block, EUploadPriority::Traces);
 }
@@ -527,8 +540,9 @@ TSharedPtr<MicromegasTracing::EventSink> InitHttpEventSink(
 	constexpr size_t MetricsBufferSize = 10 * 1024 * 1024;
 	constexpr size_t ThreadBufferSize = 10 * 1024 * 1024;
 	constexpr size_t NetBufferSize = 8 * 1024 * 1024;
+	constexpr size_t ImageBufferSize = 256; // minimum pre-alloc; buffer grows on demand when screenshots are captured
 
-	Dispatch::Init(&CreateGuid, Process, Sink, LogBufferSize, MetricsBufferSize, ThreadBufferSize, NetBufferSize, Sampling->GetNetVerbosity());
+	Dispatch::Init(&CreateGuid, Process, Sink, LogBufferSize, MetricsBufferSize, ThreadBufferSize, NetBufferSize, ImageBufferSize, Sampling->GetNetVerbosity());
 	UE_LOG(LogMicromegasTelemetrySink, Log, TEXT("Initializing Micromegas Telemetry process_id=%s"), *Process->ProcessId);
 	return Sink;
 }

--- a/unreal/MicromegasTelemetrySink/Private/ImageDependencies.h
+++ b/unreal/MicromegasTelemetrySink/Private/ImageDependencies.h
@@ -1,0 +1,23 @@
+#pragma once
+//
+//  MicromegasTelemetrySink/ImageDependencies.h
+//
+#include "MicromegasTracing/HeterogeneousQueue.h"
+#include "MicromegasTracing/ImageEvents.h"
+#include "MicromegasTracing/StaticStringDependency.h"
+
+typedef MicromegasTracing::HeterogeneousQueue<
+	MicromegasTracing::StaticStringDependency>
+	ImageDependenciesQueue;
+
+struct ExtractImageDependencies
+{
+	ImageDependenciesQueue Dependencies;
+
+	ExtractImageDependencies()
+		: Dependencies(1024)
+	{
+	}
+
+	void operator()(const MicromegasTracing::ImageEvent&) {}
+};

--- a/unreal/MicromegasTelemetrySink/Private/InsertBlockRequest.cpp
+++ b/unreal/MicromegasTelemetrySink/Private/InsertBlockRequest.cpp
@@ -8,12 +8,14 @@ std::vector<uint8> CompressBuffer(const void* src, size_t size)
 {
 	MICROMEGAS_SPAN_FUNCTION("MicromegasTelemetrySink");
 	std::vector<uint8> buffer;
+	const uint8 dummy = 0;
+	const void* srcOrDummy = (src && size > 0) ? src : &dummy;
 	const int32 compressedBound = LZ4F_compressFrameBound(size, nullptr);
 	buffer.resize(compressedBound);
 	uint32 compressedSize = LZ4F_compressFrame(
 		&buffer[0],
 		compressedBound,
-		const_cast<void*>(src),
+		const_cast<void*>(srcOrDummy),
 		size,
 		nullptr);
 	buffer.resize(compressedSize);
@@ -50,4 +52,9 @@ TUniquePtr<ExtractNetDependencies> ExtractBlockDependencies(const MicromegasTrac
 	TUniquePtr<ExtractNetDependencies> extractDependencies(new ExtractNetDependencies());
 	block.GetEvents().ForEach(*extractDependencies);
 	return extractDependencies;
+}
+
+TUniquePtr<ExtractImageDependencies> ExtractBlockDependencies(const MicromegasTracing::ImageBlock& /*block*/)
+{
+	return TUniquePtr<ExtractImageDependencies>{};
 }

--- a/unreal/MicromegasTelemetrySink/Private/InsertBlockRequest.h
+++ b/unreal/MicromegasTelemetrySink/Private/InsertBlockRequest.h
@@ -4,11 +4,13 @@
 //
 #include "CborUtils.h"
 #include "FormatTime.h"
+#include "ImageDependencies.h"
 #include "LogDependencies.h"
 #include "MicromegasTracing/Macros.h"
 #include "MetricDependencies.h"
 #include "NetDependencies.h"
 #include "MicromegasTelemetrySink/Log.h"
+#include "MicromegasTracing/ImageBlock.h"
 #include "MicromegasTracing/LogBlock.h"
 #include "MicromegasTracing/MetricBlock.h"
 #include "MicromegasTracing/NetBlock.h"
@@ -22,6 +24,7 @@ TUniquePtr<ExtractLogDependencies> ExtractBlockDependencies(const MicromegasTrac
 TUniquePtr<ExtractMetricDependencies> ExtractBlockDependencies(const MicromegasTracing::MetricBlock& block);
 TUniquePtr<ExtractThreadDependencies> ExtractBlockDependencies(const MicromegasTracing::ThreadBlock& block);
 TUniquePtr<ExtractNetDependencies> ExtractBlockDependencies(const MicromegasTracing::NetBlock& block);
+TUniquePtr<ExtractImageDependencies> ExtractBlockDependencies(const MicromegasTracing::ImageBlock& block);
 
 template <typename BlockT>
 inline TArray<uint8> FormatBlockRequest(const MicromegasTracing::ProcessInfo& processInfo, const BlockT& block)
@@ -30,14 +33,14 @@ inline TArray<uint8> FormatBlockRequest(const MicromegasTracing::ProcessInfo& pr
 	using namespace MicromegasTracing;
 	auto& queue = block.GetEvents();
 
-	auto depExtrator = ExtractBlockDependencies(block);
+	auto depExtractor = ExtractBlockDependencies(block);
 
 	FString blockId = FGuid::NewGuid().ToString(EGuidFormats::DigitsWithHyphens);
 	MICROMEGAS_LOG("LogMicromegasTelemetrySink", MicromegasTracing::LogLevel::Debug, FString::Printf(TEXT("Sending block %s"), *blockId));
 
-	std::vector<uint8> compressedDep = CompressBuffer(
-		depExtrator->Dependencies.GetPtr(),
-		depExtrator->Dependencies.GetSizeBytes());
+	const void* depPtr = depExtractor ? depExtractor->Dependencies.GetPtr() : nullptr;
+	size_t depSize = depExtractor ? depExtractor->Dependencies.GetSizeBytes() : 0;
+	std::vector<uint8> compressedDep = CompressBuffer(depPtr, depSize);
 	std::vector<uint8> compressedObj = CompressBuffer(queue.GetPtr(), queue.GetSizeBytes());
 
 	std::vector<uint8> buffer;

--- a/unreal/MicromegasTelemetrySink/Private/InsertStreamRequest.cpp
+++ b/unreal/MicromegasTelemetrySink/Private/InsertStreamRequest.cpp
@@ -3,12 +3,14 @@
 //
 #include "InsertStreamRequest.h"
 #include "CborUtils.h"
+#include "ImageDependencies.h"
 #include "LogDependencies.h"
 #include "MetricDependencies.h"
 #include "NetDependencies.h"
 #include "MicromegasTelemetrySink/Log.h"
 #include "MicromegasTracing/EventBlock.h"
 #include "MicromegasTracing/EventStream.h"
+#include "MicromegasTracing/ImageMetadata.h"
 #include "MicromegasTracing/LogMetadata.h"
 #include "MicromegasTracing/MetricMetadata.h"
 #include "MicromegasTracing/NetMetadata.h"
@@ -126,4 +128,9 @@ TArray<uint8> FormatInsertThreadStreamRequest(const MicromegasTracing::ThreadStr
 TArray<uint8> FormatInsertNetStreamRequest(const MicromegasTracing::NetStream& stream)
 {
 	return FormatInsertStreamRequest<NetDependenciesQueue>(stream);
+}
+
+TArray<uint8> FormatInsertImageStreamRequest(const MicromegasTracing::ImageStream& stream)
+{
+	return FormatInsertStreamRequest<ImageDependenciesQueue>(stream);
 }

--- a/unreal/MicromegasTelemetrySink/Private/InsertStreamRequest.h
+++ b/unreal/MicromegasTelemetrySink/Private/InsertStreamRequest.h
@@ -10,3 +10,4 @@ TArray<uint8> FormatInsertLogStreamRequest(const MicromegasTracing::LogStream& s
 TArray<uint8> FormatInsertMetricStreamRequest(const MicromegasTracing::MetricStream& stream);
 TArray<uint8> FormatInsertThreadStreamRequest(const MicromegasTracing::ThreadStream& stream);
 TArray<uint8> FormatInsertNetStreamRequest(const MicromegasTracing::NetStream& stream);
+TArray<uint8> FormatInsertImageStreamRequest(const MicromegasTracing::ImageStream& stream);

--- a/unreal/MicromegasTelemetrySink/Private/MicromegasTelemetrySinkModule.cpp
+++ b/unreal/MicromegasTelemetrySink/Private/MicromegasTelemetrySinkModule.cpp
@@ -9,6 +9,7 @@
 #include "MicromegasTracing/Dispatch.h"
 #include "Misc/CoreDelegates.h"
 #include "SamplingController.h"
+#include "ScreenshotSender.h"
 #include "SystemErrorReporter.h"
 #include "Templates/UniquePtr.h"
 
@@ -35,6 +36,7 @@ private:
 
 	TUniquePtr<FAutoConsoleCommand> CmdEnable;
 	TUniquePtr<FAutoConsoleCommand> CmdFlush;
+	FScreenshotSender ScreenshotSender;
 	FString UploadBaseUrl;
 	SharedTelemetryAuthenticator Authenticator;
 	SharedSamplingController SamplingController;
@@ -79,6 +81,7 @@ void FMicromegasTelemetrySinkModule::OnEnable()
 
 void FMicromegasTelemetrySinkModule::OnFlush() const
 {
+	MICROMEGAS_SPAN_FUNCTION("MicromegasTelemetrySink");
 	if (Flusher.IsValid())
 	{
 		Flusher->Flush();

--- a/unreal/MicromegasTelemetrySink/Private/SamplingController.cpp
+++ b/unreal/MicromegasTelemetrySink/Private/SamplingController.cpp
@@ -47,6 +47,10 @@ FSamplingController::FSamplingController(const SharedFlushMonitor& InFlushMonito
 		  TEXT("telemetry.metrics.enable"),
 		  true,
 		  TEXT("Record the frame metrics")))
+	, CVarImagesEnable(new TAutoConsoleVariable<bool>(
+		  TEXT("telemetry.images.enable"),
+		  true,
+		  TEXT("Record images sent via SendImage")))
 	, CVarSpansEnable(new TAutoConsoleVariable<bool>(
 		  TEXT("telemetry.spans.enable"),
 		  SPANS_SAMPLING_ENABLED_BY_DEFAULT,
@@ -190,6 +194,11 @@ bool FSamplingController::ShouldSampleBlock(const MicromegasTracing::ThreadBlock
 bool FSamplingController::ShouldSampleBlock(const MicromegasTracing::NetBlockPtr& Block) const
 {
 	return MicromegasTracing::Dispatch::GetNetTraceVerbosity() != MicromegasTracing::ENetTraceVerbosity::Off;
+}
+
+bool FSamplingController::ShouldSampleBlock(const MicromegasTracing::ImageBlockPtr& Block) const
+{
+	return CVarImagesEnable->GetValueOnAnyThread();
 }
 
 MicromegasTracing::ENetTraceVerbosity FSamplingController::GetNetVerbosity() const

--- a/unreal/MicromegasTelemetrySink/Private/SamplingController.h
+++ b/unreal/MicromegasTelemetrySink/Private/SamplingController.h
@@ -24,6 +24,7 @@ public:
 	bool ShouldSampleBlock(const MicromegasTracing::MetricsBlockPtr& Block) const;
 	bool ShouldSampleBlock(const MicromegasTracing::ThreadBlockPtr& Block) const;
 	bool ShouldSampleBlock(const MicromegasTracing::NetBlockPtr& Block) const;
+	bool ShouldSampleBlock(const MicromegasTracing::ImageBlockPtr& Block) const;
 
 	MicromegasTracing::ENetTraceVerbosity GetNetVerbosity() const;
 
@@ -43,6 +44,7 @@ private:
 
 	TUniquePtr<TAutoConsoleVariable<bool>> CVarLogEnable;
 	TUniquePtr<TAutoConsoleVariable<bool>> CVarMetricsEnable;
+	TUniquePtr<TAutoConsoleVariable<bool>> CVarImagesEnable;
 	TUniquePtr<TAutoConsoleVariable<bool>> CVarSpansEnable;
 	TUniquePtr<TAutoConsoleVariable<bool>> CVarSpansAll;
 	TUniquePtr<TAutoConsoleVariable<int32>> CVarNetVerbosity;

--- a/unreal/MicromegasTelemetrySink/Private/ScreenshotSender.cpp
+++ b/unreal/MicromegasTelemetrySink/Private/ScreenshotSender.cpp
@@ -1,0 +1,86 @@
+//
+//  MicromegasTelemetrySink/ScreenshotSender.cpp
+//
+#include "ScreenshotSender.h"
+#include "Engine/Engine.h"
+#include "Engine/GameViewportClient.h"
+#include "Engine/GameViewportDelegates.h"
+#include "ImageUtils.h"
+#include "MicromegasTracing/Dispatch.h"
+#include "MicromegasTracing/Macros.h"
+#include "MicromegasTelemetrySink/Log.h"
+#include "UnrealClient.h"
+#if WITH_EDITOR
+	#include "Editor.h"
+#endif
+
+FScreenshotSender::FScreenshotSender()
+{
+	Cmd.Reset(new FAutoConsoleCommand(
+		TEXT("telemetry.screenshot"),
+		TEXT("Captures the game viewport and sends it as a telemetry image"),
+		FConsoleCommandDelegate::CreateRaw(this, &FScreenshotSender::OnCommand)));
+}
+
+FScreenshotSender::~FScreenshotSender()
+{
+	UGameViewportClient::OnScreenshotCaptured().Remove(Handle);
+}
+
+void FScreenshotSender::OnCommand()
+{
+	if (Handle.IsValid())
+	{
+		UE_LOG(LogMicromegasTelemetrySink, Warning, TEXT("telemetry.screenshot: capture already pending"));
+		return;
+	}
+
+	if (GEngine && GEngine->GameViewport)
+	{
+		Handle = UGameViewportClient::OnScreenshotCaptured().AddRaw(this, &FScreenshotSender::OnScreenshotCaptured);
+		FScreenshotRequest::RequestScreenshot(false);
+		return;
+	}
+
+#if WITH_EDITOR
+	if (GEditor)
+	{
+		FViewport* EditorViewport = GEditor->GetActiveViewport();
+		if (!EditorViewport)
+		{
+			UE_LOG(LogMicromegasTelemetrySink, Warning, TEXT("telemetry.screenshot: no editor viewport available"));
+			return;
+		}
+		TArray<FColor> Bitmap;
+		if (!EditorViewport->ReadPixels(Bitmap))
+		{
+			UE_LOG(LogMicromegasTelemetrySink, Warning, TEXT("telemetry.screenshot: ReadPixels failed"));
+			return;
+		}
+		OnScreenshotCaptured(EditorViewport->GetSizeXY().X, EditorViewport->GetSizeXY().Y, Bitmap);
+		return;
+	}
+#endif
+
+	UE_LOG(LogMicromegasTelemetrySink, Warning, TEXT("telemetry.screenshot: no game viewport available"));
+}
+
+void FScreenshotSender::OnScreenshotCaptured(int32 Width, int32 Height, const TArray<FColor>& Bitmap)
+{
+	MICROMEGAS_SPAN_FUNCTION("MicromegasTelemetrySink");
+	UGameViewportClient::OnScreenshotCaptured().Remove(Handle);
+	Handle.Reset();
+
+	TArray<FColor> FixedBitmap = Bitmap;
+	for (FColor& Pixel : FixedBitmap)
+	{
+		Pixel.A = 255;
+	}
+	TArray64<uint8> CompressedPng;
+	FImageUtils::PNGCompressImageArray(Width, Height, TArrayView64<const FColor>(FixedBitmap.GetData(), FixedBitmap.Num()), CompressedPng);
+	MicromegasTracing::Dispatch::SendImage(
+		TEXT("screenshot"),
+		TEXT("image/png"),
+		CompressedPng.GetData(),
+		static_cast<uint32>(CompressedPng.Num()));
+}

--- a/unreal/MicromegasTelemetrySink/Private/ScreenshotSender.h
+++ b/unreal/MicromegasTelemetrySink/Private/ScreenshotSender.h
@@ -1,0 +1,21 @@
+#pragma once
+//
+//  MicromegasTelemetrySink/ScreenshotSender.h
+//
+#include "CoreMinimal.h"
+#include "HAL/IConsoleManager.h"
+#include "Templates/UniquePtr.h"
+
+class FScreenshotSender
+{
+public:
+	FScreenshotSender();
+	~FScreenshotSender();
+
+private:
+	void OnCommand();
+	void OnScreenshotCaptured(int32 Width, int32 Height, const TArray<FColor>& Bitmap);
+
+	TUniquePtr<FAutoConsoleCommand> Cmd;
+	FDelegateHandle Handle;
+};

--- a/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/HttpEventSink.h
+++ b/unreal/MicromegasTelemetrySink/Public/MicromegasTelemetrySink/HttpEventSink.h
@@ -69,10 +69,12 @@ public:
 	virtual void OnInitMetricStream(const MicromegasTracing::MetricStreamPtr& Stream) override;
 	virtual void OnInitThreadStream(MicromegasTracing::ThreadStream* Stream) override;
 	virtual void OnInitNetStream(const MicromegasTracing::NetStreamPtr& Stream) override;
+	virtual void OnInitImageStream(const MicromegasTracing::ImageStreamPtr& Stream) override;
 	virtual void OnProcessLogBlock(const MicromegasTracing::LogBlockPtr& Block) override;
 	virtual void OnProcessMetricBlock(const MicromegasTracing::MetricsBlockPtr& Block) override;
 	virtual void OnProcessThreadBlock(const MicromegasTracing::ThreadBlockPtr& Block) override;
 	virtual void OnProcessNetBlock(const MicromegasTracing::NetBlockPtr& Block) override;
+	virtual void OnProcessImageBlock(const MicromegasTracing::ImageBlockPtr& Block) override;
 	virtual bool IsBusy() override;
 	virtual void OnAuthUpdated() override;
 

--- a/unreal/MicromegasTelemetrySink/ThirdParty/jsoncons-0.173.4/jsoncons_ext/jsonpath/json_location.hpp
+++ b/unreal/MicromegasTelemetrySink/ThirdParty/jsoncons-0.173.4/jsoncons_ext/jsonpath/json_location.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright 2013-2023 Daniel Parker
+// Copyright 2013-2023 Daniel Parker
 // Distributed under the Boost license, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/unreal/MicromegasTelemetrySink/ThirdParty/jsoncons-0.173.4/jsoncons_ext/jsonpath/json_location.hpp
+++ b/unreal/MicromegasTelemetrySink/ThirdParty/jsoncons-0.173.4/jsoncons_ext/jsonpath/json_location.hpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2023 Daniel Parker
+﻿// Copyright 2013-2023 Daniel Parker
 // Distributed under the Boost license, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/unreal/MicromegasTelemetrySink/ThirdParty/jsoncons-0.173.4/jsoncons_ext/jsonpath/path_node.hpp
+++ b/unreal/MicromegasTelemetrySink/ThirdParty/jsoncons-0.173.4/jsoncons_ext/jsonpath/path_node.hpp
@@ -1,4 +1,4 @@
-﻿// Copyright 2013-2023 Daniel Parker
+// Copyright 2013-2023 Daniel Parker
 // Distributed under the Boost license, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/unreal/MicromegasTelemetrySink/ThirdParty/jsoncons-0.173.4/jsoncons_ext/jsonpath/path_node.hpp
+++ b/unreal/MicromegasTelemetrySink/ThirdParty/jsoncons-0.173.4/jsoncons_ext/jsonpath/path_node.hpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2023 Daniel Parker
+﻿// Copyright 2013-2023 Daniel Parker
 // Distributed under the Boost license, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/unreal/MicromegasTracing/Private/Dispatch.cpp
+++ b/unreal/MicromegasTracing/Private/Dispatch.cpp
@@ -8,6 +8,8 @@
 #include "MicromegasTracing/EventSink.h"
 #include "MicromegasTracing/NetTraceWriter.h"
 #include "MicromegasTracing/EventStream.h"
+#include "MicromegasTracing/ImageBlock.h"
+#include "MicromegasTracing/ImageEvents.h"
 #include "MicromegasTracing/LogBlock.h"
 #include "MicromegasTracing/Macros.h"
 #include "MicromegasTracing/MetricEvents.h"
@@ -28,12 +30,14 @@ namespace MicromegasTracing
 		size_t InMetricBufferSize,
 		size_t InThreadBufferSize,
 		size_t InNetBufferSize,
+		size_t InImageBufferSize,
 		ENetTraceVerbosity InNetVerbosity)
 		: AllocNewGuid(InAllocNewGuid)
 		, Sink(InSink)
 		, CurrentProcessInfo(ProcessInfo)
 		, LogBufferSize(InLogBufferSize)
 		, MetricBufferSize(InMetricBufferSize)
+		, ImageBufferSize(InImageBufferSize)
 		, ThreadBufferSize(InThreadBufferSize)
 		, NetWriter(MakeUnique<NetTraceWriter>(InSink, InNetBufferSize, InNetVerbosity))
 		, PropertySets(new PropertySetStore())
@@ -58,6 +62,16 @@ namespace MicromegasTracing
 			MetricStreamId,
 			NewMetricBlock,
 			TArray<FString>({ TEXT("metrics") }));
+
+		FString ImageStreamId = AllocNewGuid();
+		ImageBlockPtr NewImageBlock = MakeShared<ImageBlock>(ImageStreamId,
+			ProcessInfo->StartTime,
+			ImageBufferSize,
+			0);
+		Images = MakeShared<ImageStream>(CurrentProcessInfo->ProcessId,
+			ImageStreamId,
+			NewImageBlock,
+			TArray<FString>({ TEXT("image") }));
 	}
 
 	Dispatch::~Dispatch()
@@ -71,19 +85,21 @@ namespace MicromegasTracing
 		size_t MetricBufferSize,
 		size_t ThreadBufferSize,
 		size_t NetBufferSize,
+		size_t ImageBufferSize,
 		ENetTraceVerbosity NetVerbosity)
 	{
 		if (GDispatch)
 		{
 			return;
 		}
-		GDispatch = new Dispatch(AllocNewGuid, ProcessInfo, Sink, LogBufferSize, MetricBufferSize, ThreadBufferSize, NetBufferSize, NetVerbosity);
+		GDispatch = new Dispatch(AllocNewGuid, ProcessInfo, Sink, LogBufferSize, MetricBufferSize, ThreadBufferSize, NetBufferSize, ImageBufferSize, NetVerbosity);
 		GDispatch->NetWriter->InitStream(ProcessInfo->ProcessId, AllocNewGuid(), ProcessInfo->StartTime);
 
 		Sink->OnStartup(ProcessInfo);
 		Sink->OnInitLogStream(GDispatch->LogEntries);
 		Sink->OnInitMetricStream(GDispatch->Metrics);
 		Sink->OnInitNetStream(GDispatch->NetWriter->GetStream());
+		Sink->OnInitImageStream(GDispatch->Images);
 	}
 
 	void Dispatch::FlushLogStreamImpl(UE::FMutex& Mutex)
@@ -124,6 +140,58 @@ namespace MicromegasTracing
 		FullBlock->Close(Now);
 		Mutex.Unlock();
 		Sink->OnProcessMetricBlock(FullBlock);
+	}
+
+	void Dispatch::FlushImageStreamImpl(UE::FMutex& Mutex)
+	{
+		MICROMEGAS_SPAN_FUNCTION("MicromegasTracing");
+		if (Images->GetCurrentBlock().IsEmpty())
+		{
+			Mutex.Unlock();
+			return;
+		}
+		DualTime Now = DualTime::Now();
+		size_t NewOffset = Images->GetCurrentBlock().GetOffset() + Images->GetCurrentBlock().GetEvents().GetNbEvents();
+		ImageBlockPtr NewBlock = MakeShared<ImageBlock>(Images->GetStreamId(),
+			Now,
+			ImageBufferSize,
+			NewOffset);
+		ImageBlockPtr FullBlock = Images->SwapBlocks(NewBlock);
+		FullBlock->Close(Now);
+		Mutex.Unlock();
+		Sink->OnProcessImageBlock(FullBlock);
+	}
+
+	void Dispatch::FlushImageStream()
+	{
+		Dispatch* Dispatch = GDispatch;
+		if (!Dispatch)
+		{
+			return;
+		}
+		Dispatch->ImageMutex.Lock();
+		Dispatch->FlushImageStreamImpl(Dispatch->ImageMutex); // unlocks the mutex
+	}
+
+	void Dispatch::SendImage(const TCHAR* Name, const TCHAR* Format, const uint8* Data, uint32 DataBytes)
+	{
+		Dispatch* Dispatch = GDispatch;
+		if (!Dispatch)
+		{
+			return;
+		}
+		uint64 Timestamp = DualTime::Now().Timestamp;
+		ImageEvent Event(Timestamp, DynamicString(Name), DynamicString(Format), DynamicBlob(Data, DataBytes));
+		Dispatch->ImageMutex.Lock();
+		Dispatch->Images->GetCurrentBlock().GetEvents().Push(Event);
+		if (Dispatch->Images->IsFull())
+		{
+			Dispatch->FlushImageStreamImpl(Dispatch->ImageMutex); // unlocks the mutex
+		}
+		else
+		{
+			Dispatch->ImageMutex.Unlock();
+		}
 	}
 
 	void Dispatch::FlushThreadStream(ThreadStream* Stream)

--- a/unreal/MicromegasTracing/Public/MicromegasTracing/Dispatch.h
+++ b/unreal/MicromegasTracing/Public/MicromegasTracing/Dispatch.h
@@ -28,6 +28,7 @@ namespace MicromegasTracing
 			size_t MetricBufferSize,
 			size_t ThreadBufferSize,
 			size_t NetBufferSize,
+			size_t ImageBufferSize,
 			ENetTraceVerbosity NetVerbosity);
 		~Dispatch();
 
@@ -36,6 +37,7 @@ namespace MicromegasTracing
 		static void FlushLogStream();
 		static void FlushMetricStream();
 		static void FlushNetStream();
+		static void FlushImageStream();
 		static void ShutdownNetStream();
 		static void FlushCurrentThreadStream();
 		static void LogInterop(uint64 Timestamp, LogLevel::Type InLevel, const StaticStringRef& InTarget, const DynamicString& Msg);
@@ -45,6 +47,7 @@ namespace MicromegasTracing
 		static void IntMetric(const MetricMetadata* Desc, const PropertySet* Properties, uint64 Value, uint64 Timestamp);
 		static void FloatMetric(const MetricMetadata* Desc, double Value, uint64 Timestamp);
 		static void FloatMetric(const MetricMetadata* Desc, const PropertySet* Properties, double Value, uint64 Timestamp);
+		static void SendImage(const TCHAR* Name, const TCHAR* Format, const uint8* Data, uint32 DataBytes);
 		static void BeginScope(const BeginThreadSpanEvent& Event);
 		static void EndScope(const EndThreadSpanEvent& Event);
 		static void BeginNamedSpan(const BeginThreadNamedSpanEvent& Event);
@@ -92,10 +95,12 @@ namespace MicromegasTracing
 			size_t MetricBufferSize,
 			size_t ThreadBufferSize,
 			size_t NetBufferSize,
+			size_t ImageBufferSize,
 			ENetTraceVerbosity NetVerbosity);
 
 		void FlushLogStreamImpl(UE::FMutex& Mutex);
 		void FlushMetricStreamImpl(UE::FMutex& Mutex);
+		void FlushImageStreamImpl(UE::FMutex& Mutex);
 		void FlushThreadStream(ThreadStream* Stream);
 		ThreadStream* AllocThreadStream();
 		void PublishThreadStream(ThreadStream* Stream);
@@ -112,6 +117,10 @@ namespace MicromegasTracing
 		UE::FMutex MetricMutex;
 		MetricStreamPtr Metrics;
 		size_t MetricBufferSize;
+
+		UE::FMutex ImageMutex;
+		ImageStreamPtr Images;
+		size_t ImageBufferSize;
 
 		UE::FMutex ThreadStreamsMutex;
 		TArray<ThreadStream*> ThreadStreams;

--- a/unreal/MicromegasTracing/Public/MicromegasTracing/EventSink.h
+++ b/unreal/MicromegasTracing/Public/MicromegasTracing/EventSink.h
@@ -18,11 +18,13 @@ namespace MicromegasTracing
 		virtual void OnInitMetricStream(const MetricStreamPtr& stream) = 0;
 		virtual void OnInitThreadStream(ThreadStream* stream) = 0;
 		virtual void OnInitNetStream(const NetStreamPtr& stream) = 0;
+		virtual void OnInitImageStream(const ImageStreamPtr& stream) = 0;
 
 		virtual void OnProcessLogBlock(const LogBlockPtr& block) = 0;
 		virtual void OnProcessMetricBlock(const MetricsBlockPtr& block) = 0;
 		virtual void OnProcessThreadBlock(const ThreadBlockPtr& block) = 0;
 		virtual void OnProcessNetBlock(const NetBlockPtr& block) = 0;
+		virtual void OnProcessImageBlock(const ImageBlockPtr& block) = 0;
 
 		virtual bool IsBusy() = 0;
 		virtual void OnAuthUpdated() = 0;

--- a/unreal/MicromegasTracing/Public/MicromegasTracing/Fwd.h
+++ b/unreal/MicromegasTracing/Public/MicromegasTracing/Fwd.h
@@ -54,6 +54,12 @@ namespace MicromegasTracing
 	typedef TSharedPtr<NetBlock, ESPMode::ThreadSafe> NetBlockPtr;
 	typedef EventStreamImpl<NetBlock, 256> NetStream;
 	typedef TSharedPtr<NetStream, ESPMode::ThreadSafe> NetStreamPtr;
+	struct ImageEvent;
+	typedef HeterogeneousQueue<ImageEvent> ImageEventQueue;
+	typedef EventBlock<ImageEventQueue> ImageBlock;
+	typedef TSharedPtr<ImageBlock, ESPMode::ThreadSafe> ImageBlockPtr;
+	typedef EventStreamImpl<ImageBlock, 128> ImageStream;
+	typedef TSharedPtr<ImageStream, ESPMode::ThreadSafe> ImageStreamPtr;
 	class NetTraceWriter;
 	enum class ENetTraceVerbosity : uint8;
 	class PropertySetStore;

--- a/unreal/MicromegasTracing/Public/MicromegasTracing/HeterogeneousQueue.h
+++ b/unreal/MicromegasTracing/Public/MicromegasTracing/HeterogeneousQueue.h
@@ -127,7 +127,7 @@ namespace MicromegasTracing
 
 		const uint8* GetPtr() const
 		{
-			return &Buffer[0];
+			return Buffer.GetData();
 		}
 
 		CheckPoint Snapshot() const

--- a/unreal/MicromegasTracing/Public/MicromegasTracing/ImageBlock.h
+++ b/unreal/MicromegasTracing/Public/MicromegasTracing/ImageBlock.h
@@ -1,0 +1,12 @@
+#pragma once
+//
+//  MicromegasTracing/ImageBlock.h
+//
+#include "MicromegasTracing/Fwd.h"
+#include "MicromegasTracing/EventBlock.h"
+#include "MicromegasTracing/HeterogeneousQueue.h"
+
+namespace MicromegasTracing
+{
+	typedef EventBlock<ImageEventQueue> ImageBlock;
+} // namespace MicromegasTracing

--- a/unreal/MicromegasTracing/Public/MicromegasTracing/ImageEvents.h
+++ b/unreal/MicromegasTracing/Public/MicromegasTracing/ImageEvents.h
@@ -1,0 +1,65 @@
+#pragma once
+//
+//  MicromegasTracing/ImageEvents.h
+//
+#include "Containers/Array.h"
+#include "MicromegasTracing/strings.h"
+
+namespace MicromegasTracing
+{
+	struct ImageEvent
+	{
+		uint64 Timestamp;
+		DynamicString Name;
+		DynamicString Format;
+		DynamicBlob Data;
+
+		ImageEvent(uint64 InTimestamp, DynamicString InName, DynamicString InFormat, DynamicBlob InData)
+			: Timestamp(InTimestamp)
+			, Name(InName)
+			, Format(InFormat)
+			, Data(InData)
+		{
+		}
+	};
+
+	template <>
+	struct Serializer<ImageEvent>
+	{
+		static bool IsSizeStatic() { return false; }
+
+		static uint32 GetSize(const ImageEvent& v)
+		{
+			return sizeof(uint64)
+				+ Serializer<DynamicString>::GetSize(v.Name)
+				+ Serializer<DynamicString>::GetSize(v.Format)
+				+ Serializer<DynamicBlob>::GetSize(v.Data);
+		}
+
+		static void Write(const ImageEvent& v, TArray<uint8>& buffer)
+		{
+			details::WritePOD(v.Timestamp, buffer);
+			Serializer<DynamicString>::Write(v.Name, buffer);
+			Serializer<DynamicString>::Write(v.Format, buffer);
+			Serializer<DynamicBlob>::Write(v.Data, buffer);
+		}
+
+		template <typename Callback>
+		static void Read(Callback& callback, const TArray<uint8>& buffer, size_t& cursor)
+		{
+			uint64 Timestamp = details::ReadPOD<uint64>(buffer, cursor);
+			Serializer<DynamicString>::Read([&](const DynamicString& Name) {
+				Serializer<DynamicString>::Read([&](const DynamicString& Format) {
+					Serializer<DynamicBlob>::Read([&](const DynamicBlob& Data) {
+						ImageEvent Event(Timestamp, Name, Format, Data);
+						callback(Event);
+					},
+						buffer, cursor);
+				},
+					buffer, cursor);
+			},
+				buffer, cursor);
+		}
+	};
+
+} // namespace MicromegasTracing

--- a/unreal/MicromegasTracing/Public/MicromegasTracing/ImageMetadata.h
+++ b/unreal/MicromegasTracing/Public/MicromegasTracing/ImageMetadata.h
@@ -1,0 +1,18 @@
+#pragma once
+//
+//  MicromegasTracing/ImageMetadata.h
+//
+#include "MicromegasTracing/ImageEvents.h"
+#include "MicromegasTracing/QueueMetadata.h"
+
+namespace MicromegasTracing
+{
+	template <>
+	struct GetEventMetadata<ImageEvent>
+	{
+		UserDefinedType operator()()
+		{
+			return UserDefinedType(TEXT("ImageEvent"), 0, false, {});
+		}
+	};
+} // namespace MicromegasTracing

--- a/unreal/MicromegasTracing/Public/MicromegasTracing/strings.h
+++ b/unreal/MicromegasTracing/Public/MicromegasTracing/strings.h
@@ -125,11 +125,49 @@ namespace MicromegasTracing
 		{
 			StringCodec::Type codec = details::ReadPOD<StringCodec::Type>(buffer, cursor);
 			uint32 bufferSize = details::ReadPOD<uint32>(buffer, cursor);
-			const void* ptr = &buffer[0] + cursor;
+			const void* ptr = buffer.GetData() + cursor;
 			cursor += bufferSize;
 
 			DynamicString dynStr(StringReference(ptr, bufferSize, codec));
 			callback(dynStr);
+		}
+	};
+
+	// DynamicBlob points to a temporary buffer; serializing copies the whole buffer.
+	struct DynamicBlob
+	{
+		const uint8* Ptr;
+		uint32 SizeBytes;
+
+		DynamicBlob(const uint8* InPtr, uint32 InSizeBytes)
+			: Ptr(InPtr)
+			, SizeBytes(InSizeBytes)
+		{
+		}
+	};
+
+	template <>
+	struct Serializer<DynamicBlob>
+	{
+		static uint32 GetSize(const DynamicBlob& value)
+		{
+			return sizeof(uint32)   // length prefix
+				+ value.SizeBytes;  // raw bytes (no codec)
+		}
+
+		static void Write(const DynamicBlob& value, TArray<uint8>& buffer)
+		{
+			details::WritePOD(value.SizeBytes, buffer);
+			buffer.Append(value.Ptr, value.SizeBytes);
+		}
+
+		template <typename Callback>
+		static void Read(Callback callback, const TArray<uint8>& buffer, size_t& cursor)
+		{
+			uint32 bufferSize = details::ReadPOD<uint32>(buffer, cursor);
+			const uint8* ptr = buffer.GetData() + cursor;
+			cursor += bufferSize;
+			callback(DynamicBlob(ptr, bufferSize));
 		}
 	};
 


### PR DESCRIPTION
## Summary

- Wire `ImageStream` / `ImageBlock` into `MicromegasTracing::Dispatch`, `EventSink`, and `HttpEventSink`, following the same pattern as the existing log, metric, net, and thread streams
- Add `DynamicBlob` type and its serializer to `strings.h` for embedding arbitrary binary payloads (e.g. PNG bytes) directly in a `HeterogeneousQueue`
- Add `ImageEvent` with timestamp, name, format, and data fields; serialization round-trips correctly
- Add `telemetry.screenshot` console command (`FScreenshotSender`) that captures the game viewport via `UGameViewportClient::OnScreenshotCaptured` or reads pixels directly from the active editor viewport (`WITH_EDITOR`), compresses to PNG, and calls `Dispatch::SendImage`
- Gate image capture with `telemetry.images.enable` CVar (default on)
- Fix null/empty-buffer UB in `CompressBuffer` (adds a dummy byte when `src` is null or `size` is 0)
- Fix `HeterogeneousQueue::GetPtr()` and `DynamicString::Read` to use `TArray::GetData()` instead of `&Buffer[0]` (safe on empty arrays)
- Remove accidental UTF-8 BOM from two vendored jsoncons headers

## Test plan

- Run `telemetry.screenshot` from the UE console in a game viewport; verify an image row appears in the `images` SQL table with `format = 'image/png'` and non-empty `data`
- Run `telemetry.screenshot` from within the Unreal Editor; verify the editor viewport pixels are captured
- Disable `telemetry.images.enable 0` and confirm no image blocks are uploaded
- Confirm `telemetry.images.enable 1` re-enables capture