### PR TITLE
Fix data source selector silently rewriting notebook config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ This file documents the historical progress of the Micromegas project. For curre
   * Add resizable columns to the log cell via draggable inline dividers; drag to pin a column width, right-click a divider to reset to auto or reset all, "Reset widths" button in bottom bar; pinned widths persist in cell options (#1130)
   * Add one-click copy icon to log rows; appears on hover, copies tab-separated row text to clipboard, briefly shows a green checkmark on success (#1131)
   * Add an `image` notebook cell that queries the `images` view and displays results as a navigable carousel; the `format` column is used as the image MIME type and decode failures surface a meaningful error message
+  * Fix the data source selector silently rewriting persisted notebook config during render; out-of-scope `$var` references and deleted sources now display as-is (marked unavailable) instead of being switched to the default
+  * Fix notebooks losing their `$var` data source when a cell is edited inside a group; group-sibling datasource variables are now valid selector options
 * **Analytics:**
   * Accept runtime scalar expressions (CTEs, subqueries, CROSS JOIN columns) as `make_histogram` bounds; literal bounds continue to validate eagerly; NULL histogram rows propagate correctly through all consumers (#1135)
   * Replace SELECT+DELETE pairs in `delete_expired_blocks_batch` with atomic `DELETE … RETURNING` queries; eliminates double-counting and phantom deletes under concurrent writers (#1116)

--- a/analytics-web-app/src/components/DataSourceSelector.tsx
+++ b/analytics-web-app/src/components/DataSourceSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { Database, AlertCircle } from 'lucide-react'
 import { getDataSourceList, DataSourceSummary } from '@/lib/data-sources-api'
 
@@ -64,33 +64,28 @@ export function DataSourceSelector({ value, onChange, datasourceVariables, showN
 
   const hasVariables = datasourceVariables && datasourceVariables.length > 0
 
-  // Keep a ref to onChange so the sync effect always calls the latest callback
-  const onChangeRef = useRef(onChange)
-  onChangeRef.current = onChange
-
-  // Build the flat list of option values so we can detect mismatches
+  // Build the flat list of known option values so we can detect a value that
+  // isn't among them (a $var whose variable isn't in scope, or a literal data
+  // source that no longer exists).
   const optionValues: string[] = []
   if (showNotebookOption) optionValues.push('notebook')
   if (hasVariables) {
     for (const name of datasourceVariables) optionValues.push(`$${name}`)
   }
   for (const s of sources) optionValues.push(s.name)
-  const optionValuesKey = optionValues.join('\0')
 
-  // If the current value doesn't match any option, the <select> silently shows
-  // the first option without firing onChange. Sync the config to match.
-  // Only run after sources have loaded to avoid overwriting valid values during async fetch.
-  useEffect(() => {
-    if (!sourcesLoaded) return
-    // Never auto-rewrite a variable reference ($var). The set of known variables
-    // is context-dependent (e.g. it may not list siblings while editing inside a
-    // group), and rewriting would silently destroy the user's binding. Variable
-    // references are resolved gracefully at render time instead.
-    if (value.startsWith('$')) return
-    if (optionValues.length > 0 && !optionValues.includes(value)) {
-      onChangeRef.current(optionValues[0])
-    }
-  }, [value, optionValuesKey, sourcesLoaded]) // eslint-disable-line react-hooks/exhaustive-deps
+  // A controlled <select> whose value matches no <option> silently displays the
+  // first option, hiding the real config. Rather than rewrite the config to match
+  // the display (which silently destroys the user's binding — a deleted source or
+  // an out-of-scope $var), surface the current value as its own option so the
+  // control shows the truth and the mismatch stays visible. Only treat the value
+  // as unknown once sources have loaded, to avoid flashing it during the fetch.
+  const isUnknownValue = sourcesLoaded && !!value && !optionValues.includes(value)
+  const currentValueOption = isUnknownValue ? (
+    <option key="__current__" value={value}>
+      {value.startsWith('$') ? value : `${value} (unavailable)`}
+    </option>
+  ) : null
 
   if (error) {
     return (
@@ -118,6 +113,7 @@ export function DataSourceSelector({ value, onChange, datasourceVariables, showN
         value={value}
         onChange={(e) => onChange(e.target.value)}
       >
+        {currentValueOption}
         {hasVariables ? (
           <>
             {notebookOption}

--- a/analytics-web-app/src/components/DataSourceSelector.tsx
+++ b/analytics-web-app/src/components/DataSourceSelector.tsx
@@ -82,6 +82,11 @@ export function DataSourceSelector({ value, onChange, datasourceVariables, showN
   // Only run after sources have loaded to avoid overwriting valid values during async fetch.
   useEffect(() => {
     if (!sourcesLoaded) return
+    // Never auto-rewrite a variable reference ($var). The set of known variables
+    // is context-dependent (e.g. it may not list siblings while editing inside a
+    // group), and rewriting would silently destroy the user's binding. Variable
+    // references are resolved gracefully at render time instead.
+    if (value.startsWith('$')) return
     if (optionValues.length > 0 && !optionValues.includes(value)) {
       onChangeRef.current(optionValues[0])
     }

--- a/analytics-web-app/src/components/__tests__/DataSourceSelector.test.tsx
+++ b/analytics-web-app/src/components/__tests__/DataSourceSelector.test.tsx
@@ -51,9 +51,9 @@ describe('DataSourceSelector value sync', () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
-  it('rewrites a literal data source that no longer exists to the first option', async () => {
+  it('surfaces a literal data source that no longer exists instead of rewriting it', async () => {
     const onChange = jest.fn()
-    render(
+    const { findByText } = render(
       <DataSourceSelector
         value="deleted-source"
         onChange={onChange}
@@ -61,6 +61,25 @@ describe('DataSourceSelector value sync', () => {
         showNotebookOption
       />,
     )
-    await waitFor(() => expect(onChange).toHaveBeenCalledWith('notebook'))
+    // The unknown value is shown as its own option, marked unavailable...
+    expect(await findByText('deleted-source (unavailable)')).toBeInTheDocument()
+    // ...and the config is never silently rewritten.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an out-of-scope variable reference as a selectable option', async () => {
+    const onChange = jest.fn()
+    const { findByText } = render(
+      <DataSourceSelector
+        value="$source"
+        onChange={onChange}
+        datasourceVariables={[]}
+        showNotebookOption
+      />,
+    )
+    expect(await findByText('$source')).toBeInTheDocument()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onChange).not.toHaveBeenCalled()
   })
 })

--- a/analytics-web-app/src/components/__tests__/DataSourceSelector.test.tsx
+++ b/analytics-web-app/src/components/__tests__/DataSourceSelector.test.tsx
@@ -1,0 +1,66 @@
+import { render, waitFor } from '@testing-library/react'
+import { DataSourceSelector } from '../DataSourceSelector'
+
+jest.mock('lucide-react', () => ({
+  Database: () => null,
+  AlertCircle: () => null,
+}))
+
+const getDataSourceList = jest.fn()
+jest.mock('@/lib/data-sources-api', () => ({
+  getDataSourceList: (...args: unknown[]) => getDataSourceList(...args),
+}))
+
+describe('DataSourceSelector value sync', () => {
+  beforeEach(() => {
+    getDataSourceList.mockReset()
+    getDataSourceList.mockResolvedValue([
+      { name: 'prod', is_default: true },
+      { name: 'staging', is_default: false },
+    ])
+  })
+
+  it('does not rewrite a variable reference that is missing from the known variables', async () => {
+    const onChange = jest.fn()
+    render(
+      <DataSourceSelector
+        value="$source"
+        onChange={onChange}
+        datasourceVariables={[]}
+        showNotebookOption
+      />,
+    )
+    // Wait for the async source list to load and the sync effect to run.
+    await waitFor(() => expect(getDataSourceList).toHaveBeenCalled())
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('keeps a variable reference even when it is a known variable', async () => {
+    const onChange = jest.fn()
+    render(
+      <DataSourceSelector
+        value="$source"
+        onChange={onChange}
+        datasourceVariables={['source']}
+        showNotebookOption
+      />,
+    )
+    await waitFor(() => expect(getDataSourceList).toHaveBeenCalled())
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('rewrites a literal data source that no longer exists to the first option', async () => {
+    const onChange = jest.fn()
+    render(
+      <DataSourceSelector
+        value="deleted-source"
+        onChange={onChange}
+        datasourceVariables={[]}
+        showNotebookOption
+      />,
+    )
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith('notebook'))
+  })
+})

--- a/analytics-web-app/src/lib/datafusion-wasm/micromegas_datafusion_wasm.d.ts
+++ b/analytics-web-app/src/lib/datafusion-wasm/micromegas_datafusion_wasm.d.ts
@@ -57,16 +57,15 @@ export interface InitOutput {
     readonly rust_zstd_wasm_shim_memmove: (a: number, b: number, c: number) => number;
     readonly rust_zstd_wasm_shim_memset: (a: number, b: number, c: number) => number;
     readonly rust_zstd_wasm_shim_qsort: (a: number, b: number, c: number, d: number) => void;
-    readonly wasm_bindgen__closure__destroy__h707eba9a3f17da47: (a: number, b: number) => void;
-    readonly wasm_bindgen__convert__closures_____invoke__hfa136065179493e2: (a: number, b: number, c: any) => [number, number];
-    readonly wasm_bindgen__convert__closures_____invoke__h359f020b4b89498f: (a: number, b: number, c: any, d: any) => void;
-    readonly wasm_bindgen__convert__closures_____invoke__h8accc252c00bac9c: (a: number, b: number) => number;
-    readonly __wbindgen_malloc: (a: number, b: number) => number;
-    readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
+    readonly wasm_bindgen__closure__destroy__h7fa30e67ab1c4a31: (a: number, b: number) => void;
+    readonly wasm_bindgen__convert__closures_____invoke__h207fec4f218bf05f: (a: number, b: number, c: any) => [number, number];
+    readonly wasm_bindgen__convert__closures_____invoke__h25079147ce791426: (a: number, b: number, c: any, d: any) => void;
     readonly __wbindgen_exn_store: (a: number) => void;
     readonly __externref_table_alloc: () => number;
     readonly __wbindgen_externrefs: WebAssembly.Table;
     readonly __wbindgen_free: (a: number, b: number, c: number) => void;
+    readonly __wbindgen_malloc: (a: number, b: number) => number;
+    readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
     readonly __externref_table_dealloc: (a: number) => void;
     readonly __wbindgen_start: () => void;
 }

--- a/analytics-web-app/src/lib/datafusion-wasm/micromegas_datafusion_wasm.js
+++ b/analytics-web-app/src/lib/datafusion-wasm/micromegas_datafusion_wasm.js
@@ -1,7 +1,5 @@
 /* @ts-self-types="./micromegas_datafusion_wasm.d.ts" */
 
-//#region exports
-
 export class WasmQueryEngine {
     __destroy_into_raw() {
         const ptr = this.__wbg_ptr;
@@ -19,8 +17,6 @@ export class WasmQueryEngine {
      * @returns {boolean}
      */
     deregister_table(name) {
-        if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
-        _assertNum(this.__wbg_ptr);
         const ptr0 = passStringToWasm0(name, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
         const len0 = WASM_VECTOR_LEN;
         const ret = wasm.wasmqueryengine_deregister_table(this.__wbg_ptr, ptr0, len0);
@@ -36,8 +32,6 @@ export class WasmQueryEngine {
      * @returns {Promise<Uint8Array>}
      */
     execute_and_register(sql, register_as) {
-        if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
-        _assertNum(this.__wbg_ptr);
         const ptr0 = passStringToWasm0(sql, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
         const len0 = WASM_VECTOR_LEN;
         const ptr1 = passStringToWasm0(register_as, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
@@ -51,8 +45,6 @@ export class WasmQueryEngine {
      * @returns {Promise<Uint8Array>}
      */
     execute_sql(sql) {
-        if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
-        _assertNum(this.__wbg_ptr);
         const ptr0 = passStringToWasm0(sql, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
         const len0 = WASM_VECTOR_LEN;
         const ret = wasm.wasmqueryengine_execute_sql(this.__wbg_ptr, ptr0, len0);
@@ -73,8 +65,6 @@ export class WasmQueryEngine {
      * @returns {number}
      */
     register_table(name, ipc_bytes) {
-        if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
-        _assertNum(this.__wbg_ptr);
         const ptr0 = passStringToWasm0(name, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
         const len0 = WASM_VECTOR_LEN;
         const ptr1 = passArray8ToWasm0(ipc_bytes, wasm.__wbindgen_malloc);
@@ -89,49 +79,30 @@ export class WasmQueryEngine {
      * Deregister all tables.
      */
     reset() {
-        if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
-        _assertNum(this.__wbg_ptr);
         wasm.wasmqueryengine_reset(this.__wbg_ptr);
     }
 }
 if (Symbol.dispose) WasmQueryEngine.prototype[Symbol.dispose] = WasmQueryEngine.prototype.free;
 
-//#endregion
-
-//#region wasm imports
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,
-        __wbg___wbindgen_debug_string_5398f5bb970e0daa: function(arg0, arg1) {
-            const ret = debugString(arg1);
-            const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-            const len1 = WASM_VECTOR_LEN;
-            getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
-            getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
-        },
         __wbg___wbindgen_is_function_3c846841762788c1: function(arg0) {
             const ret = typeof(arg0) === 'function';
-            _assertBoolean(ret);
             return ret;
         },
         __wbg___wbindgen_is_undefined_52709e72fb9f179c: function(arg0) {
             const ret = arg0 === undefined;
-            _assertBoolean(ret);
             return ret;
         },
         __wbg___wbindgen_throw_6ddd609b62940d55: function(arg0, arg1) {
             throw new Error(getStringFromWasm0(arg0, arg1));
         },
-        __wbg__wbg_cb_unref_6b5b6b8576d35cb1: function() { return logError(function (arg0) {
+        __wbg__wbg_cb_unref_6b5b6b8576d35cb1: function(arg0) {
             arg0._wbg_cb_unref();
-        }, arguments); },
+        },
         __wbg_call_2d781c1f4d5c0ef8: function() { return handleError(function (arg0, arg1, arg2) {
             const ret = arg0.call(arg1, arg2);
-            return ret;
-        }, arguments); },
-        __wbg_createTask_6eb3a8b6dd2f87c9: function() { return handleError(function (arg0, arg1) {
-            const ret = console.createTask(getStringFromWasm0(arg0, arg1));
             return ret;
         }, arguments); },
         __wbg_getRandomValues_3f44b700395062e5: function() { return handleError(function (arg0, arg1) {
@@ -140,25 +111,25 @@ function __wbg_get_imports() {
         __wbg_getRandomValues_a1cf2e70b003a59d: function() { return handleError(function (arg0, arg1) {
             globalThis.crypto.getRandomValues(getArrayU8FromWasm0(arg0, arg1));
         }, arguments); },
-        __wbg_getTime_1dad7b5386ddd2d9: function() { return logError(function (arg0) {
+        __wbg_getTime_1dad7b5386ddd2d9: function(arg0) {
             const ret = arg0.getTime();
             return ret;
-        }, arguments); },
-        __wbg_log_524eedafa26daa59: function() { return logError(function (arg0) {
+        },
+        __wbg_log_524eedafa26daa59: function(arg0) {
             console.log(arg0);
-        }, arguments); },
-        __wbg_new_0_1dcafdf5e786e876: function() { return logError(function () {
+        },
+        __wbg_new_0_1dcafdf5e786e876: function() {
             const ret = new Date();
             return ret;
-        }, arguments); },
-        __wbg_new_typed_aaaeaf29cf802876: function() { return logError(function (arg0, arg1) {
+        },
+        __wbg_new_typed_aaaeaf29cf802876: function(arg0, arg1) {
             try {
                 var state0 = {a: arg0, b: arg1};
                 var cb0 = (arg0, arg1) => {
                     const a = state0.a;
                     state0.a = 0;
                     try {
-                        return wasm_bindgen__convert__closures_____invoke__h359f020b4b89498f(a, state0.b, arg0, arg1);
+                        return wasm_bindgen__convert__closures_____invoke__h25079147ce791426(a, state0.b, arg0, arg1);
                     } finally {
                         state0.a = a;
                     }
@@ -168,86 +139,67 @@ function __wbg_get_imports() {
             } finally {
                 state0.a = state0.b = 0;
             }
-        }, arguments); },
-        __wbg_now_16f0c993d5dd6c27: function() { return logError(function () {
+        },
+        __wbg_now_16f0c993d5dd6c27: function() {
             const ret = Date.now();
             return ret;
-        }, arguments); },
-        __wbg_now_e7c6795a7f81e10f: function() { return logError(function (arg0) {
+        },
+        __wbg_now_e7c6795a7f81e10f: function(arg0) {
             const ret = arg0.now();
             return ret;
-        }, arguments); },
-        __wbg_performance_3fcf6e32a7e1ed0a: function() { return logError(function (arg0) {
+        },
+        __wbg_performance_3fcf6e32a7e1ed0a: function(arg0) {
             const ret = arg0.performance;
             return ret;
-        }, arguments); },
-        __wbg_queueMicrotask_0c399741342fb10f: function() { return logError(function (arg0) {
+        },
+        __wbg_queueMicrotask_0c399741342fb10f: function(arg0) {
             const ret = arg0.queueMicrotask;
             return ret;
-        }, arguments); },
-        __wbg_queueMicrotask_a082d78ce798393e: function() { return logError(function (arg0) {
+        },
+        __wbg_queueMicrotask_a082d78ce798393e: function(arg0) {
             queueMicrotask(arg0);
-        }, arguments); },
-        __wbg_resolve_ae8d83246e5bcc12: function() { return logError(function (arg0) {
+        },
+        __wbg_resolve_ae8d83246e5bcc12: function(arg0) {
             const ret = Promise.resolve(arg0);
             return ret;
-        }, arguments); },
-        __wbg_run_78b7b601add6ed6b: function() { return logError(function (arg0, arg1, arg2) {
-            try {
-                var state0 = {a: arg1, b: arg2};
-                var cb0 = () => {
-                    const a = state0.a;
-                    state0.a = 0;
-                    try {
-                        return wasm_bindgen__convert__closures_____invoke__h8accc252c00bac9c(a, state0.b, );
-                    } finally {
-                        state0.a = a;
-                    }
-                };
-                const ret = arg0.run(cb0);
-                _assertBoolean(ret);
-                return ret;
-            } finally {
-                state0.a = state0.b = 0;
-            }
-        }, arguments); },
-        __wbg_static_accessor_GLOBAL_8adb955bd33fac2f: function() { return logError(function () {
+        },
+        __wbg_static_accessor_GLOBAL_8adb955bd33fac2f: function() {
             const ret = typeof global === 'undefined' ? null : global;
             return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
-        }, arguments); },
-        __wbg_static_accessor_GLOBAL_THIS_ad356e0db91c7913: function() { return logError(function () {
+        },
+        __wbg_static_accessor_GLOBAL_THIS_ad356e0db91c7913: function() {
             const ret = typeof globalThis === 'undefined' ? null : globalThis;
             return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
-        }, arguments); },
-        __wbg_static_accessor_SELF_f207c857566db248: function() { return logError(function () {
+        },
+        __wbg_static_accessor_SELF_f207c857566db248: function() {
             const ret = typeof self === 'undefined' ? null : self;
             return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
-        }, arguments); },
-        __wbg_static_accessor_WINDOW_bb9f1ba69d61b386: function() { return logError(function () {
+        },
+        __wbg_static_accessor_WINDOW_bb9f1ba69d61b386: function() {
             const ret = typeof window === 'undefined' ? null : window;
             return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
-        }, arguments); },
-        __wbg_then_098abe61755d12f6: function() { return logError(function (arg0, arg1) {
+        },
+        __wbg_then_098abe61755d12f6: function(arg0, arg1) {
             const ret = arg0.then(arg1);
             return ret;
-        }, arguments); },
-        __wbindgen_cast_0000000000000001: function() { return logError(function (arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { dtor_idx: 50, function: Function { arguments: [Externref], shim_idx: 35573, ret: Result(Unit), inner_ret: Some(Result(Unit)) }, mutable: true }) -> Externref`.
-            const ret = makeMutClosure(arg0, arg1, wasm.wasm_bindgen__closure__destroy__h707eba9a3f17da47, wasm_bindgen__convert__closures_____invoke__hfa136065179493e2);
+        },
+        __wbindgen_cast_0000000000000001: function(arg0, arg1) {
+            // Cast intrinsic for `Closure(Closure { dtor_idx: 108, function: Function { arguments: [Externref], shim_idx: 30778, ret: Result(Unit), inner_ret: Some(Result(Unit)) }, mutable: true }) -> Externref`.
+            const ret = makeMutClosure(arg0, arg1, wasm.wasm_bindgen__closure__destroy__h7fa30e67ab1c4a31, wasm_bindgen__convert__closures_____invoke__h207fec4f218bf05f);
             return ret;
-        }, arguments); },
-        __wbindgen_cast_0000000000000002: function() { return logError(function (arg0, arg1) {
+        },
+        __wbindgen_cast_0000000000000002: function(arg0, arg1) {
             // Cast intrinsic for `Ref(String) -> Externref`.
             const ret = getStringFromWasm0(arg0, arg1);
             return ret;
-        }, arguments); },
-        __wbindgen_cast_0000000000000003: function() { return logError(function (arg0, arg1) {
+        },
+        __wbindgen_cast_0000000000000003: function(arg0, arg1) {
             var v0 = getArrayU8FromWasm0(arg0, arg1).slice();
             wasm.__wbindgen_free(arg0, arg1 * 1, 1);
             // Cast intrinsic for `Vector(U8) -> Externref`.
             const ret = v0;
             return ret;
-        }, arguments); },
+        },
         __wbindgen_init_externref_table: function() {
             const table = wasm.__wbindgen_externrefs;
             const offset = table.grow(4);
@@ -264,132 +216,34 @@ function __wbg_get_imports() {
     };
 }
 
-
-//#endregion
-function wasm_bindgen__convert__closures_____invoke__h8accc252c00bac9c(arg0, arg1) {
-    _assertNum(arg0);
-    _assertNum(arg1);
-    const ret = wasm.wasm_bindgen__convert__closures_____invoke__h8accc252c00bac9c(arg0, arg1);
-    return ret !== 0;
-}
-
-function wasm_bindgen__convert__closures_____invoke__hfa136065179493e2(arg0, arg1, arg2) {
-    _assertNum(arg0);
-    _assertNum(arg1);
-    const ret = wasm.wasm_bindgen__convert__closures_____invoke__hfa136065179493e2(arg0, arg1, arg2);
+function wasm_bindgen__convert__closures_____invoke__h207fec4f218bf05f(arg0, arg1, arg2) {
+    const ret = wasm.wasm_bindgen__convert__closures_____invoke__h207fec4f218bf05f(arg0, arg1, arg2);
     if (ret[1]) {
         throw takeFromExternrefTable0(ret[0]);
     }
 }
 
-function wasm_bindgen__convert__closures_____invoke__h359f020b4b89498f(arg0, arg1, arg2, arg3) {
-    _assertNum(arg0);
-    _assertNum(arg1);
-    wasm.wasm_bindgen__convert__closures_____invoke__h359f020b4b89498f(arg0, arg1, arg2, arg3);
+function wasm_bindgen__convert__closures_____invoke__h25079147ce791426(arg0, arg1, arg2, arg3) {
+    wasm.wasm_bindgen__convert__closures_____invoke__h25079147ce791426(arg0, arg1, arg2, arg3);
 }
 
 const WasmQueryEngineFinalization = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(ptr => wasm.__wbg_wasmqueryengine_free(ptr >>> 0, 1));
 
-
-//#region intrinsics
 function addToExternrefTable0(obj) {
     const idx = wasm.__externref_table_alloc();
     wasm.__wbindgen_externrefs.set(idx, obj);
     return idx;
 }
 
-function _assertBoolean(n) {
-    if (typeof(n) !== 'boolean') {
-        throw new Error(`expected a boolean argument, found ${typeof(n)}`);
-    }
-}
-
-function _assertNum(n) {
-    if (typeof(n) !== 'number') throw new Error(`expected a number argument, found ${typeof(n)}`);
-}
-
 const CLOSURE_DTORS = (typeof FinalizationRegistry === 'undefined')
     ? { register: () => {}, unregister: () => {} }
     : new FinalizationRegistry(state => state.dtor(state.a, state.b));
 
-function debugString(val) {
-    // primitive types
-    const type = typeof val;
-    if (type == 'number' || type == 'boolean' || val == null) {
-        return  `${val}`;
-    }
-    if (type == 'string') {
-        return `"${val}"`;
-    }
-    if (type == 'symbol') {
-        const description = val.description;
-        if (description == null) {
-            return 'Symbol';
-        } else {
-            return `Symbol(${description})`;
-        }
-    }
-    if (type == 'function') {
-        const name = val.name;
-        if (typeof name == 'string' && name.length > 0) {
-            return `Function(${name})`;
-        } else {
-            return 'Function';
-        }
-    }
-    // objects
-    if (Array.isArray(val)) {
-        const length = val.length;
-        let debug = '[';
-        if (length > 0) {
-            debug += debugString(val[0]);
-        }
-        for(let i = 1; i < length; i++) {
-            debug += ', ' + debugString(val[i]);
-        }
-        debug += ']';
-        return debug;
-    }
-    // Test for built-in
-    const builtInMatches = /\[object ([^\]]+)\]/.exec(toString.call(val));
-    let className;
-    if (builtInMatches && builtInMatches.length > 1) {
-        className = builtInMatches[1];
-    } else {
-        // Failed to match the standard '[object ClassName]'
-        return toString.call(val);
-    }
-    if (className == 'Object') {
-        // we're a user defined class or Object
-        // JSON.stringify avoids problems with cycles, and is generally much
-        // easier than looping through ownProperties of `val`.
-        try {
-            return 'Object(' + JSON.stringify(val) + ')';
-        } catch (_) {
-            return 'Object';
-        }
-    }
-    // errors
-    if (val instanceof Error) {
-        return `${val.name}: ${val.message}\n${val.stack}`;
-    }
-    // TODO we could test for more things here, like `Set`s and `Map`s.
-    return className;
-}
-
 function getArrayU8FromWasm0(ptr, len) {
     ptr = ptr >>> 0;
     return getUint8ArrayMemory0().subarray(ptr / 1, ptr / 1 + len);
-}
-
-let cachedDataViewMemory0 = null;
-function getDataViewMemory0() {
-    if (cachedDataViewMemory0 === null || cachedDataViewMemory0.buffer.detached === true || (cachedDataViewMemory0.buffer.detached === undefined && cachedDataViewMemory0.buffer !== wasm.memory.buffer)) {
-        cachedDataViewMemory0 = new DataView(wasm.memory.buffer);
-    }
-    return cachedDataViewMemory0;
 }
 
 function getStringFromWasm0(ptr, len) {
@@ -416,22 +270,6 @@ function handleError(f, args) {
 
 function isLikeNone(x) {
     return x === undefined || x === null;
-}
-
-function logError(f, args) {
-    try {
-        return f.apply(this, args);
-    } catch (e) {
-        let error = (function () {
-            try {
-                return e instanceof Error ? `${e.message}\n\nStack:\n${e.stack}` : e.toString();
-            } catch(_) {
-                return "<failed to stringify thrown value>";
-            }
-        }());
-        console.error("wasm-bindgen: imported JS function that was not marked as `catch` threw an error:", error);
-        throw e;
-    }
 }
 
 function makeMutClosure(arg0, arg1, dtor, f) {
@@ -470,7 +308,6 @@ function passArray8ToWasm0(arg, malloc) {
 }
 
 function passStringToWasm0(arg, malloc, realloc) {
-    if (typeof(arg) !== 'string') throw new Error(`expected a string argument, found ${typeof(arg)}`);
     if (realloc === undefined) {
         const buf = cachedTextEncoder.encode(arg);
         const ptr = malloc(buf.length, 1) >>> 0;
@@ -498,7 +335,7 @@ function passStringToWasm0(arg, malloc, realloc) {
         ptr = realloc(ptr, len, len = offset + arg.length * 3, 1) >>> 0;
         const view = getUint8ArrayMemory0().subarray(ptr + offset, ptr + len);
         const ret = cachedTextEncoder.encodeInto(arg, view);
-        if (ret.read !== arg.length) throw new Error('failed to pass whole string');
+
         offset += ret.written;
         ptr = realloc(ptr, len, offset, 1) >>> 0;
     }
@@ -542,15 +379,10 @@ if (!('encodeInto' in cachedTextEncoder)) {
 
 let WASM_VECTOR_LEN = 0;
 
-
-//#endregion
-
-//#region wasm loading
 let wasmModule, wasm;
 function __wbg_finalize_init(instance, module) {
     wasm = instance.exports;
     wasmModule = module;
-    cachedDataViewMemory0 = null;
     cachedUint8ArrayMemory0 = null;
     wasm.__wbindgen_start();
     return wasm;
@@ -638,5 +470,3 @@ async function __wbg_init(module_or_path) {
 }
 
 export { initSync, __wbg_init as default };
-//#endregion
-export { wasm as __wasm }

--- a/analytics-web-app/src/lib/datafusion-wasm/package.json
+++ b/analytics-web-app/src/lib/datafusion-wasm/package.json
@@ -1,30 +1,8 @@
 {
   "name": "micromegas-datafusion-wasm",
+  "version": "0.1.0",
+  "private": true,
   "type": "module",
-  "collaborators": [
-    "Marc-Antoine Desroches <madesroches@gmail.com>"
-  ],
-  "description": "DataFusion compiled to WebAssembly for in-browser SQL query execution, part of micromegas",
-  "version": "0.26.0",
-  "license": "Apache-2.0",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/madesroches/micromegas/"
-  },
-  "files": [
-    "micromegas_datafusion_wasm_bg.wasm",
-    "micromegas_datafusion_wasm.js",
-    "micromegas_datafusion_wasm.d.ts"
-  ],
   "main": "micromegas_datafusion_wasm.js",
-  "homepage": "https://micromegas.info/",
-  "types": "micromegas_datafusion_wasm.d.ts",
-  "sideEffects": [
-    "./snippets/*"
-  ],
-  "keywords": [
-    "observability",
-    "telemetry",
-    "analytics"
-  ]
+  "types": "micromegas_datafusion_wasm.d.ts"
 }

--- a/analytics-web-app/src/lib/screen-renderers/NotebookRenderer.tsx
+++ b/analytics-web-app/src/lib/screen-renderers/NotebookRenderer.tsx
@@ -452,11 +452,19 @@ export function NotebookRenderer({
   const datasourceVariables = useMemo(() => {
     if (selectedCellIndex === null) return undefined
     const result: string[] = []
-    forEachCell(cells.slice(0, selectedCellIndex), (cell) => {
+    const collect = (cell: CellConfig) => {
       if (cell.type === 'variable' && (cell as VariableCellConfig).variableType === 'datasource') {
         result.push(cell.name)
       }
-    })
+    }
+    forEachCell(cells.slice(0, selectedCellIndex), collect)
+    // When editing inside a group, include the group's own datasource-variable
+    // children so a sibling cell can reference them (e.g. "$source"). The group
+    // itself is excluded by the slice above.
+    const selected = cells[selectedCellIndex]
+    if (selected?.type === 'hg') {
+      (selected as HorizontalGroupCellConfig).children.forEach(collect)
+    }
     return result
   }, [cells, selectedCellIndex])
 


### PR DESCRIPTION
## Summary
- The data source selector previously ran a render-time effect that mutated persisted config when the current value matched no option, silently switching out-of-scope `$var` references or deleted sources to the notebook default — a class of silent data-loss bugs. The control now renders the true value as a visible dangling option (marked unavailable) and never rewrites config from render.
- Notebooks lost their `$var` data source when a cell was edited inside a group: `datasourceVariables` excluded variables that are siblings within the selected group, so `$source` wasn't a valid option and the selector's sync effect rewrote it to the default. Group-sibling datasource variables are now included, and the selector is guarded from ever rewriting a `$var` reference.

## Test plan
- `yarn lint` — passes
- `yarn type-check` — passes
- `yarn test` — 1100 tests across 54 suites pass (includes new `DataSourceSelector.test.tsx` coverage)
- Manual: open a notebook with a `$var`-backed data source cell inside a group, edit a sibling cell, and confirm the `$var` selection is preserved; point a cell at a deleted source and confirm it shows as unavailable rather than reverting to the default.