### PR TITLE
Fix 24 Dependabot alerts: undici < 6.27.0 across all yarn workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file documents the historical progress of the Micromegas project. For curre
 ## Unreleased
 
 * **Security:**
+  * Fix 24 Dependabot alerts: bump undici to ≥6.27.0 (resolves to 8.5.0) across all yarn workspaces (analytics-web-app, welcome, doc/intro-micromegas, doc/notebooks, doc/unified-observability-for-games, root) (#335, #334, #333, #332, #331, #330, #329, #328, #327, #326, #325, #324, #323, #322, #321, #320, #319, #318, #317, #316, #315, #314, #313, #312)
   * Fix 20 Dependabot alerts: bump protobufjs (≥7.6.3), tar (7.5.16), js-yaml (4.2.0), @babel/core (≥7.29.6), ws (8.21.0) across all npm workspaces; bump vite (≥7.3.5) in doc workspaces; bump cryptography (49.0.0) in Python; bump chi (5.2.4) in Grafana backend (#311, #310, #309, #308, #307, #306, #305, #304, #303, #302, #301, #300, #299, #298, #297, #296, #295, #294, #293, #292)
 * **Tracing:**
   * Add image streams: instrumented applications can send screenshots or other images as telemetry via `send_image()`; images are queryable via the `images` SQL table with a `data Binary` column holding raw bytes

--- a/analytics-web-app/package.json
+++ b/analytics-web-app/package.json
@@ -58,6 +58,7 @@
     "postcss": "^8.5.10",
     "rollup": "^4.59.0",
     "tar": "^7.5.16",
+    "undici": ">=6.27.0",
     "ws": "^8.21.0"
   },
   "devDependencies": {

--- a/analytics-web-app/yarn.lock
+++ b/analytics-web-app/yarn.lock
@@ -9181,10 +9181,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.25.0":
-  version: 6.25.0
-  resolution: "undici@npm:6.25.0"
-  checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
+"undici@npm:>=6.27.0":
+  version: 8.5.0
+  resolution: "undici@npm:8.5.0"
+  checksum: 10c0/7c25fd96a4dcc607b905995f6feec948f74a6759cadbea4c6eb9402517aab4887987c8001c80d482297d04f975f44a383325b89577ac21e587983ed088408065
   languageName: node
   linkType: hard
 

--- a/doc/intro-micromegas/package.json
+++ b/doc/intro-micromegas/package.json
@@ -28,6 +28,7 @@
     "lodash-es": "^4.17.23",
     "rollup": "^4.59.0",
     "tar": "^7.5.16",
+    "undici": ">=6.27.0",
     "uuid": "^14.0.0"
   },
   "packageManager": "yarn@4.14.1"

--- a/doc/intro-micromegas/yarn.lock
+++ b/doc/intro-micromegas/yarn.lock
@@ -1797,10 +1797,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.25.0":
-  version: 6.25.0
-  resolution: "undici@npm:6.25.0"
-  checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
+"undici@npm:>=6.27.0":
+  version: 8.5.0
+  resolution: "undici@npm:8.5.0"
+  checksum: 10c0/7c25fd96a4dcc607b905995f6feec948f74a6759cadbea4c6eb9402517aab4887987c8001c80d482297d04f975f44a383325b89577ac21e587983ed088408065
   languageName: node
   linkType: hard
 

--- a/doc/notebooks/package.json
+++ b/doc/notebooks/package.json
@@ -24,6 +24,7 @@
     "esbuild": "0.28.1",
     "postcss": "^8.5.10",
     "tar": "^7.5.16",
+    "undici": ">=6.27.0",
     "vite": "^7.3.5"
   },
   "packageManager": "yarn@4.14.1"

--- a/doc/notebooks/yarn.lock
+++ b/doc/notebooks/yarn.lock
@@ -773,10 +773,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.25.0":
-  version: 6.25.0
-  resolution: "undici@npm:6.25.0"
-  checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
+"undici@npm:>=6.27.0":
+  version: 8.5.0
+  resolution: "undici@npm:8.5.0"
+  checksum: 10c0/7c25fd96a4dcc607b905995f6feec948f74a6759cadbea4c6eb9402517aab4887987c8001c80d482297d04f975f44a383325b89577ac21e587983ed088408065
   languageName: node
   linkType: hard
 

--- a/doc/unified-observability-for-games/package.json
+++ b/doc/unified-observability-for-games/package.json
@@ -22,6 +22,7 @@
     "postcss": "^8.5.10",
     "rollup": "^4.59.0",
     "tar": "^7.5.16",
+    "undici": ">=6.27.0",
     "vite": "^7.3.5"
   },
   "devDependencies": {

--- a/doc/unified-observability-for-games/yarn.lock
+++ b/doc/unified-observability-for-games/yarn.lock
@@ -764,10 +764,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.25.0":
-  version: 6.25.0
-  resolution: "undici@npm:6.25.0"
-  checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
+"undici@npm:>=6.27.0":
+  version: 8.5.0
+  resolution: "undici@npm:8.5.0"
+  checksum: 10c0/7c25fd96a4dcc607b905995f6feec948f74a6759cadbea4c6eb9402517aab4887987c8001c80d482297d04f975f44a383325b89577ac21e587983ed088408065
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-router": "^6.30.4",
     "serialize-javascript": "^7.0.5",
     "tar": "^7.5.16",
+    "undici": ">=6.27.0",
     "uuid": "^14.0.0",
     "ws": "^8.21.0"
   }

--- a/welcome/package.json
+++ b/welcome/package.json
@@ -23,7 +23,8 @@
     "minimatch": "^9.0.7",
     "postcss": "^8.5.10",
     "rollup": "^4.59.0",
-    "tar": "^7.5.16"
+    "tar": "^7.5.16",
+    "undici": ">=6.27.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.0",

--- a/welcome/yarn.lock
+++ b/welcome/yarn.lock
@@ -2348,10 +2348,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.25.0":
-  version: 6.25.0
-  resolution: "undici@npm:6.25.0"
-  checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
+"undici@npm:>=6.27.0":
+  version: 8.5.0
+  resolution: "undici@npm:8.5.0"
+  checksum: 10c0/7c25fd96a4dcc607b905995f6feec948f74a6759cadbea4c6eb9402517aab4887987c8001c80d482297d04f975f44a383325b89577ac21e587983ed088408065
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11466,10 +11466,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.25.0":
-  version: 6.25.0
-  resolution: "undici@npm:6.25.0"
-  checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
+"undici@npm:>=6.27.0":
+  version: 8.5.0
+  resolution: "undici@npm:8.5.0"
+  checksum: 10c0/7c25fd96a4dcc607b905995f6feec948f74a6759cadbea4c6eb9402517aab4887987c8001c80d482297d04f975f44a383325b89577ac21e587983ed088408065
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

* Add `undici >=6.27.0` as a direct dependency to 6 yarn workspaces (root, analytics-web-app, welcome, doc/intro-micromegas, doc/notebooks, doc/unified-observability-for-games) to force resolution to 8.5.0
* Resolves four undici CVEs per workspace: Set-Cookie SameSite downgrade, HTTP header injection, WebSocket DoS, and HTTP response queue poisoning

## Test plan

* Dependabot alerts #312–#335 should auto-close once GitHub scans the updated lock files
* All affected `yarn.lock` files now resolve `undici` to 8.5.0 (up from 6.25.0)
* `yarn lint` (analytics-web-app) and `yarn lint:fix` (grafana) pass clean