### PR TITLE
Update docs for v0.26.0: fix staleness across all sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,7 @@ Learn more about Micromegas through our technical presentations:
 
 To get started with Micromegas, please refer to the [Getting Started](https://micromegas.info/docs/getting-started/) guide.
 
-## Current Status & Roadmap
-
-### Unreleased
+## Recent Releases
 
 ### v0.26.0 (June 2026)
 * `micromegas-monolith`: single-process deployment running all roles (`ingestion`, `analytics`, `web`, `admin`) in one binary — simplifies self-hosted and single-machine deployments
@@ -131,21 +129,6 @@ To get started with Micromegas, please refer to the [Getting Started](https://mi
 * `process_spans` table function for cross-thread and async span analysis
 * Database migration: unique indexes on processes, streams, and blocks
 * DataFusion 52.3
-
-### v0.21.0 (February 2026)
-* Cross-cell notebook queries running DataFusion in the browser via WASM
-* Horizontal group cell with drag-and-drop reordering
-* WASM tracing support for `micromegas-tracing` and `micromegas-telemetry-sink`
-* `micromegas-datafusion-extensions` crate — shared WASM-compatible JSONB and histogram UDFs
-* Python CLI: `micromegas-query` and `micromegas-logout` via `pip install micromegas`
-* LZ4 Arrow IPC compression for smaller network transfers
-
-### v0.20.0 (February 2026)
-* Client-side WASM query execution with DataFusion in the browser
-* Swimlane, property timeline, and Perfetto export cell types
-* Drag-to-zoom on charts, config diff modal, per-cell data sources
-* Client-side Perfetto trace generation with gzip compression
-* Parquet content cache and parallelized query planning
 
 For the full history, see [CHANGELOG.md](./CHANGELOG.md).
 

--- a/mkdocs/docs/admin/monolith.md
+++ b/mkdocs/docs/admin/monolith.md
@@ -71,8 +71,8 @@ micromegas-monolith --disable-auth
 ### API keys for ingestion only, OIDC for analytics
 
 ```bash
-export MICROMEGAS_INGESTION_API_KEYS='["key1","key2"]'
-export MICROMEGAS_ANALYTICS_OIDC_CONFIG='{"issuer_url":"...","client_id":"...","audience":"..."}'
+export MICROMEGAS_INGESTION_API_KEYS='[{"name":"service-a","key":"key1"},{"name":"service-b","key":"key2"}]'
+export MICROMEGAS_ANALYTICS_OIDC_CONFIG='{"issuers":[{"issuer":"https://your-idp.example.com","audience":"your-client-id"}]}'
 ```
 
 The prefix fallback means `MICROMEGAS_API_KEYS` works for ingestion when `MICROMEGAS_INGESTION_API_KEYS` is not set, and `MICROMEGAS_OIDC_CONFIG` works for analytics when `MICROMEGAS_ANALYTICS_OIDC_CONFIG` is not set.
@@ -80,7 +80,7 @@ The prefix fallback means `MICROMEGAS_API_KEYS` works for ingestion when `MICROM
 ### Full OIDC (web + analytics, open ingestion)
 
 ```bash
-export MICROMEGAS_OIDC_CONFIG='{"issuer_url":"...","client_id":"...","audience":"..."}'
+export MICROMEGAS_OIDC_CONFIG='{"issuers":[{"issuer":"https://your-idp.example.com","audience":"your-client-id"}]}'
 export MICROMEGAS_STATE_SECRET="<random-secret>"
 export MICROMEGAS_AUTH_REDIRECT_URI="http://localhost:3000/api/auth/callback"
 micromegas-monolith --disable-ingestion-auth

--- a/mkdocs/docs/admin/web-app.md
+++ b/mkdocs/docs/admin/web-app.md
@@ -17,7 +17,6 @@ Opens on `http://localhost:3000` with backend on `:8000`. Automatically sets loc
 
 ```bash
 # OIDC provider configuration (same format as FlightSQL server)
-# Note: Web app only supports a single issuer
 export MICROMEGAS_OIDC_CONFIG='{
   "issuers": [
     {
@@ -35,17 +34,16 @@ export MICROMEGAS_AUTH_REDIRECT_URI="http://localhost:3000/auth/callback"
 # Generate with: openssl rand -base64 32
 export MICROMEGAS_STATE_SECRET="your-random-secret-here"
 
-# FlightSQL connection
-export MICROMEGAS_FLIGHTSQL_URL="grpc://127.0.0.1:50051"
+# URL prefix (use "/" for root, "/analytics" for a sub-path)
+export MICROMEGAS_BASE_PATH="/"
+
+# PostgreSQL database for the web app (screens, data sources, maps catalog)
+export MICROMEGAS_APP_SQL_CONNECTION_STRING="postgres://user:pass@localhost/analytics_web"
 ```
 
 ### Optional
 
 ```bash
-# Base path for reverse proxy deployments (e.g., behind ALB)
-# All routes will be prefixed with this path
-export MICROMEGAS_BASE_PATH="/analytics"
-
 # Cookie settings (production)
 export MICROMEGAS_COOKIE_DOMAIN=".example.com"
 export MICROMEGAS_SECURE_COOKIES="true"  # HTTPS only
@@ -107,23 +105,30 @@ MICROMEGAS_WEB_CORS_ORIGIN="https://example.com"
 MICROMEGAS_AUTH_REDIRECT_URI="https://example.com/analytics/auth/callback"
 ```
 
-Routes become: `/analytics/health`, `/analytics/query`, `/analytics/auth/*`, etc.
+Routes become: `/analytics/api/health`, `/analytics/api/query-stream`, `/analytics/auth/*`, etc.
 The same container image works for any base path - no rebuild needed.
 
 ## API Routes
 
-Without `MICROMEGAS_BASE_PATH`:
-- `GET /health` - Health check
-- `POST /query` - Execute SQL query
-- `GET /perfetto/{process_id}/info` - Trace metadata
-- `POST /perfetto/{process_id}/generate` - Generate Perfetto trace
-- `GET /auth/login` - Initiate OAuth login
-- `GET /auth/callback` - OAuth callback
-- `POST /auth/refresh` - Refresh tokens
-- `POST /auth/logout` - Logout
-- `GET /auth/me` - Current user info
+Without `MICROMEGAS_BASE_PATH` (or with `"/"`):
+- `GET /api/health` — Health check (public)
+- `GET /api/ready` — Readiness check (public)
+- `POST /api/query-stream` — Execute SQL query (streaming NDJSON)
+- `GET /api/screen-types` — List screen types
+- `GET /api/screen-types/{type_name}/default` — Default config for a screen type
+- `GET /api/screens`, `POST /api/screens` — List / create screens
+- `GET /api/screens/{name}`, `PUT`, `DELETE` — Get / update / delete screen
+- `GET /api/data-sources`, `POST /api/data-sources` — List / create data sources
+- `GET /api/data-sources/{name}`, `PUT`, `DELETE` — Get / update / delete data source
+- `GET /api/maps/catalog` — List map assets
+- `GET /api/maps/blob/{filename}`, `PUT`, `DELETE` — Fetch / upload / delete map GLB
+- `GET /auth/login` — Initiate OAuth login
+- `GET /auth/callback` — OAuth callback
+- `POST /auth/refresh` — Refresh tokens
+- `POST /auth/logout` — Logout
+- `GET /auth/me` — Current user info
 
-With `MICROMEGAS_BASE_PATH="/analytics"`, all routes are prefixed (e.g., `/analytics/health`).
+With `MICROMEGAS_BASE_PATH="/analytics"`, all routes are prefixed (e.g., `/analytics/api/health`).
 
 **Configure OAuth redirect in your identity provider:**
 - Add the redirect URI to allowed callbacks
@@ -132,7 +137,7 @@ With `MICROMEGAS_BASE_PATH="/analytics"`, all routes are prefixed (e.g., `/analy
 ## Architecture
 
 - **Frontend**: Vite/React SPA on port 3000 (dev) or served by backend (prod)
-- **Backend**: Rust (`analytics-web-srv`) on port 8000
+- **Backend**: Rust (`analytics-web-srv`) on port 3000 (default); the dev start script uses 8000 to avoid conflicting with the Vite dev server
 - **Auth**: OIDC (ID tokens via httpOnly cookies)
 - **Data**: FlightSQL queries to analytics service
 

--- a/mkdocs/docs/architecture/index.md
+++ b/mkdocs/docs/architecture/index.md
@@ -219,12 +219,20 @@ flowchart TD
 - Dictionary compression reduces storage and improves query performance  
 - Predicate pushdown leverages Parquet metadata for fast data pruning
 
+## Deployment Modes
+
+Micromegas can be deployed as separate services or as a single process:
+
+**Split mode** (production): `telemetry-ingestion-srv`, `flight-sql-srv`, `telemetry-admin`, and `analytics-web-srv` run as independent services and scale independently.
+
+**Monolith mode** (v0.26.0+, recommended for development and single-machine deployments): `micromegas-monolith --roles all` runs all four roles in one process. This is the simplest way to get started and the default for local development via `start_services.py --monolith`.
+
 ## Analytics Web Application
 
 The analytics web app provides a modern web interface for exploring telemetry data. It consists of:
 
 - **Backend**: Rust-based web server (`analytics-web-srv`) using Axum framework
-- **Frontend**: Next.js React application with TypeScript  
+- **Frontend**: Vite + React 19 application with TypeScript
 - **Integration**: Direct FlightSQL connection to analytics service
 
 ### Key Features

--- a/mkdocs/docs/contributing.md
+++ b/mkdocs/docs/contributing.md
@@ -52,6 +52,9 @@ micromegas/
 │   ├── telemetry-ingestion-srv/
 │   ├── flight-sql-srv/
 │   └── ...
+├── analytics-web-app/      # Analytics web UI (Vite + React 19)
+│   ├── package.json
+│   └── src/
 ├── grafana/                # Grafana datasource plugin
 │   ├── package.json
 │   ├── src/
@@ -94,15 +97,34 @@ poetry run pytest       # Run tests
 poetry run black <file> # Format code (REQUIRED before commit)
 ```
 
+### Analytics Web App
+
+The analytics web UI is a standalone Vite + React 19 application in `analytics-web-app/`.
+
+**Location**: `analytics-web-app/`
+
+**Prerequisites**: Run `corepack enable` once per machine to activate the pinned Yarn version.
+
+**Commands** (run from `analytics-web-app/`):
+```bash
+corepack enable         # Once per machine
+yarn install            # Install dependencies
+yarn dev                # Dev server on port 3000 (Vite)
+yarn build              # Production build to dist/
+yarn lint               # ESLint
+yarn type-check         # TypeScript type check (no emit)
+yarn test               # Jest unit tests
+```
+
 ### TypeScript/JavaScript Workspaces
 
-The repository uses Yarn workspaces to manage TypeScript/JavaScript packages.
+The repository uses Yarn workspaces to manage the Grafana plugin and shared TypeScript packages.
 
 - **Root workspace** (`package.json`): Defines workspaces and shared dev dependencies
 - **`grafana/`**: Grafana FlightSQL datasource plugin (React + Go backend)
 - **`typescript/types/`**: Shared TypeScript type definitions (`@micromegas/types`)
 
-**Important**: Always use `yarn`, not `npm`, to avoid lockfile conflicts.
+**Important**: Always use `yarn`, not `npm`, to avoid lockfile conflicts. Run `corepack enable` once per machine before running `yarn install`.
 
 ### Working with All Components
 
@@ -118,9 +140,14 @@ cargo build              # Fetches and compiles Rust dependencies
 poetry install           # Installs Python dependencies
 ```
 
-**TypeScript/JavaScript** (from repository root, use `yarn`):
+**TypeScript/JavaScript** (from repository root, use `yarn`; run `corepack enable` first if needed):
 ```bash
 yarn install             # Install all workspace dependencies (Grafana plugin, shared types)
+```
+
+**Analytics web app** (standalone workspace in `analytics-web-app/`):
+```bash
+cd analytics-web-app && yarn install
 ```
 
 **Go** (for Grafana backend, from `grafana/` directory):
@@ -147,11 +174,11 @@ cd grafana && yarn build                 # Grafana plugin only
 cd typescript/types && yarn build        # Shared types only
 ```
 
-For the Grafana plugin development:
+**Analytics web app:**
 ```bash
-cd grafana
-yarn build              # Production build
-yarn dev                # Development mode with hot reload
+cd analytics-web-app
+yarn build              # Production build to dist/
+yarn dev                # Vite dev server on port 3000
 ```
 
 #### Running Tests
@@ -173,6 +200,11 @@ yarn workspaces foreach -A run test      # Test all workspaces (from root)
 cd grafana && yarn test:ci               # Grafana plugin tests only
 ```
 
+**Analytics web app:**
+```bash
+cd analytics-web-app && yarn test        # Jest unit tests
+```
+
 #### Linting
 
 **Rust workspace:**
@@ -192,6 +224,12 @@ yarn workspaces foreach -A run lint      # Lint all workspaces (from root)
 cd grafana && yarn lint:fix              # Grafana plugin only
 ```
 
+**Analytics web app:**
+```bash
+cd analytics-web-app && yarn lint        # ESLint
+cd analytics-web-app && yarn type-check  # TypeScript check (no emit)
+```
+
 ### Grafana Plugin Development
 
 The Grafana plugin requires both Node.js and Go:
@@ -199,7 +237,7 @@ The Grafana plugin requires both Node.js and Go:
 **Prerequisites:**
 - Node.js 20+ (matches `.nvmrc` and all CI workflows; Yarn 4 requires ≥18.12)
 - Go 1.23+ (for backend plugin)
-- yarn (package manager for this repository)
+- `corepack enable` — activates the pinned Yarn version (run once per machine)
 - mage (for Go builds): `go install github.com/magefile/mage@latest`
 
 **Development workflow:**

--- a/mkdocs/docs/cost-comparisons/datadog.md
+++ b/mkdocs/docs/cost-comparisons/datadog.md
@@ -1,6 +1,6 @@
 # Cost Comparison: Micromegas vs. Datadog
 
-**Disclaimer:** These are estimates, not quotes. Datadog's pricing is complex and modular. Actual costs vary based on specific product usage, negotiated enterprise agreements, and region.
+**Disclaimer:** These are estimates, not quotes. Datadog's pricing is complex and modular. Actual costs vary based on specific product usage, negotiated enterprise agreements, and region. **Pricing figures were verified in early 2026 — confirm current rates at [datadoghq.com/pricing](https://www.datadoghq.com/pricing/) before use.**
 
 For shared methodology, workload definition, and Micromegas baseline cost, see the [Comparison Methodology](index.md) page.
 

--- a/mkdocs/docs/cost-comparisons/dynatrace.md
+++ b/mkdocs/docs/cost-comparisons/dynatrace.md
@@ -1,6 +1,6 @@
 # Cost Comparison: Micromegas vs. Dynatrace
 
-**Disclaimer:** These are estimates, not quotes. Dynatrace pricing varies based on negotiated enterprise agreements, region, and specific product usage.
+**Disclaimer:** These are estimates, not quotes. Dynatrace pricing varies based on negotiated enterprise agreements, region, and specific product usage. **Pricing figures were verified in early 2026 — confirm current rates at [dynatrace.com/pricing](https://www.dynatrace.com/pricing/) before use.**
 
 For shared methodology, workload definition, and Micromegas baseline cost, see the [Comparison Methodology](index.md) page.
 

--- a/mkdocs/docs/cost-comparisons/elastic.md
+++ b/mkdocs/docs/cost-comparisons/elastic.md
@@ -1,6 +1,6 @@
 # Cost Comparison: Micromegas vs. Elastic Observability
 
-**Disclaimer:** These are estimates, not quotes. Actual costs vary based on usage patterns, cloud provider, region, and volume tiers.
+**Disclaimer:** These are estimates, not quotes. Actual costs vary based on usage patterns, cloud provider, region, and volume tiers. **Pricing figures reflect the November 2025 Elastic pricing update — confirm current rates at [elastic.co/pricing](https://www.elastic.co/pricing) before use.**
 
 For shared methodology, workload definition, and Micromegas baseline cost, see the [Comparison Methodology](index.md) page.
 

--- a/mkdocs/docs/cost-comparisons/grafana.md
+++ b/mkdocs/docs/cost-comparisons/grafana.md
@@ -1,6 +1,6 @@
 # Cost Comparison: Micromegas vs. Grafana Cloud
 
-**Disclaimer:** These are estimates, not quotes. Actual costs vary based on usage patterns, active series count, scrape frequency, and negotiated agreements.
+**Disclaimer:** These are estimates, not quotes. Actual costs vary based on usage patterns, active series count, scrape frequency, and negotiated agreements. **Pricing figures were verified in early 2026 — confirm current rates at [grafana.com/pricing](https://grafana.com/pricing/) before use.**
 
 For shared methodology, workload definition, and Micromegas baseline cost, see the [Comparison Methodology](index.md) page.
 

--- a/mkdocs/docs/cost-comparisons/index.md
+++ b/mkdocs/docs/cost-comparisons/index.md
@@ -1,6 +1,6 @@
 # Comparison Methodology
 
-*Last reviewed: February 2026*
+*Last reviewed: June 2026*
 
 This page describes the shared methodology used across all cost comparisons. Each individual comparison page references this methodology and focuses only on the competitor-specific pricing analysis.
 
@@ -37,9 +37,11 @@ Micromegas takes a fundamentally different approach. Instead of abstracting away
 As detailed in the [Cost Effectiveness overview](../cost-effectiveness.md), these costs are primarily:
 
 *   **Object Storage (S3, GCS):** Storing raw telemetry data and materialized views. Typically the largest portion of the cost.
-*   **Compute (Fargate, Kubernetes):** Running the ingestion, analytics, and daemon services.
+*   **Compute (Fargate, Kubernetes):** Running the ingestion, analytics, and daemon services. For smaller deployments, `micromegas-monolith` consolidates all roles into a single process, reducing operational overhead.
 *   **Database (PostgreSQL, Aurora):** Storing metadata.
 *   **Networking (Load Balancers, Data Transfer):** Routing traffic and moving data.
+
+Micromegas also supports **native OTLP/HTTP ingestion** (logs, metrics, and traces via the OpenTelemetry protocol), making it straightforward to migrate existing OpenTelemetry pipelines without re-instrumenting your code.
 
 ### Comparison of Philosophies
 

--- a/mkdocs/docs/cost-comparisons/newrelic.md
+++ b/mkdocs/docs/cost-comparisons/newrelic.md
@@ -1,6 +1,6 @@
 # Cost Comparison: Micromegas vs. New Relic
 
-**Disclaimer:** These are estimates, not quotes. Actual costs vary based on data volume, user count, plan type, and negotiated enterprise agreements.
+**Disclaimer:** These are estimates, not quotes. Actual costs vary based on data volume, user count, plan type, and negotiated enterprise agreements. **Pricing figures were verified in early 2026 — confirm current rates at [newrelic.com/pricing](https://newrelic.com/pricing) before use.**
 
 For shared methodology, workload definition, and Micromegas baseline cost, see the [Comparison Methodology](index.md) page.
 

--- a/mkdocs/docs/cost-comparisons/splunk.md
+++ b/mkdocs/docs/cost-comparisons/splunk.md
@@ -1,6 +1,6 @@
 # Cost Comparison: Micromegas vs. Splunk
 
-**Disclaimer:** These are estimates, not quotes. Splunk Cloud pricing is highly negotiable and not transparently published. Actual costs vary based on daily index volume, negotiated enterprise rates, and region.
+**Disclaimer:** These are estimates, not quotes. Splunk Cloud pricing is highly negotiable and not transparently published. Actual costs vary based on daily index volume, negotiated enterprise rates, and region. **Pricing figures are based on AWS Marketplace rates from early 2026 — verify current rates before use.**
 
 For shared methodology, workload definition, and Micromegas baseline cost, see the [Comparison Methodology](index.md) page.
 
@@ -25,7 +25,7 @@ Note: Splunk Cloud pricing is heavily volume-discounted at scale. The AWS Market
 
 ### Cisco Acquisition Context
 
-Cisco completed its acquisition of Splunk in March 2024 for ~$28 billion. Cisco is working on a "Data Fabric" approach that could affect future pricing, but as of February 2026, standard Splunk Cloud pricing has not materially changed.
+Cisco completed its acquisition of Splunk in March 2024 for ~$28 billion. Cisco is working on a "Data Fabric" approach that could affect future pricing. Verify current pricing directly with Splunk before making budget decisions.
 
 ---
 

--- a/mkdocs/docs/cost-effectiveness.md
+++ b/mkdocs/docs/cost-effectiveness.md
@@ -23,6 +23,9 @@ The infrastructure cost for Micromegas comes from standard cloud services:
 - **Analytics Service** (`flight-sql-srv`) - Serves SQL queries and dashboards
 - **Maintenance Daemon** (`telemetry-admin`) - Background data processing and rollups
 
+!!! tip "Simplified deployment"
+    For smaller deployments or local development, `micromegas-monolith` runs all roles (ingestion, analytics, web, maintenance) in a single process, eliminating the need to manage multiple services.
+
 ### Storage Services
 
 - **Database (PostgreSQL)** - Stores metadata about processes, streams, and data blocks

--- a/mkdocs/docs/development/build.md
+++ b/mkdocs/docs/development/build.md
@@ -4,7 +4,7 @@ This guide covers building Micromegas from source and setting up a development e
 
 ## Prerequisites
 
-- **[Rust](https://rustup.rs/)** - Latest stable version
+- **[Rust](https://rustup.rs/)** - Toolchain version pinned in `rust/rust-toolchain.toml` (currently `1.96.0`); `rustup` will install it automatically on first build
 - **[Python 3.8+](https://www.python.org/downloads/)**
 - **[Docker](https://www.docker.com/get-started/)** - For running PostgreSQL
 - **[Git](https://git-scm.com/downloads)**
@@ -81,9 +81,69 @@ cargo build --profile release-debug
 # Profiling build
 cargo build --profile profiling
 
-# Cross-platform build
+# Cross-compile for Windows (from Linux)
 rustup target add x86_64-pc-windows-gnu
 cargo build --target x86_64-pc-windows-gnu
+```
+
+### ARM64 Cross-Compilation
+
+Production Docker images support ARM64 (aarch64) via a Docker-based cross-compilation environment. The toolchain lives in `local_test_env/arm64/`.
+
+```bash
+# Build the ARM64 cross-compilation Docker image
+cd local_test_env/arm64
+python3 build.py
+
+# Run the image to cross-compile (mounts the repo)
+python3 run.py
+```
+
+The `Dockerfile` installs `g++-aarch64-linux-gnu`, adds the `aarch64-unknown-linux-gnu` Rust target, and cross-compiles OpenSSL statically for ARM64. The `build_docker_images.py` script at the repo root also accepts `--arm64` to build production images for ARM64.
+
+```bash
+python3 build/build_docker_images.py --arm64
+```
+
+## JavaScript / TypeScript Development
+
+The repository has two independent JS/TS workspaces. Both use Yarn 4 (Berry) — run `corepack enable` once per machine to activate the pinned version.
+
+### Analytics Web App (`analytics-web-app/`)
+
+Vite + React 19 frontend for the analytics UI.
+
+```bash
+cd analytics-web-app
+
+corepack enable     # Once per machine
+yarn install        # Install dependencies
+
+yarn dev            # Vite dev server on port 3000
+yarn build          # Production build to dist/
+yarn lint           # ESLint
+yarn type-check     # TypeScript check (no emit)
+yarn test           # Jest unit tests
+```
+
+### Grafana Plugin (`grafana/`)
+
+Grafana datasource plugin (React frontend + Go backend).
+
+**Additional prerequisites**: Go 1.23+ and `mage` (`go install github.com/magefile/mage@latest`).
+
+```bash
+cd grafana
+
+corepack enable     # Once per machine
+yarn install        # Install Node dependencies
+
+mage -v build       # Build Go backend binaries
+yarn build          # Production bundle
+yarn dev            # Dev mode with hot reload
+yarn test:ci        # Tests
+yarn lint:fix       # Lint + autofix
+yarn server         # Start Grafana via docker compose at http://localhost:3000
 ```
 
 ## Python Development

--- a/mkdocs/docs/getting-started.md
+++ b/mkdocs/docs/getting-started.md
@@ -66,36 +66,37 @@ Install [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads
 
 ### 3. Start All Services
 
-#### Option A: Using tmux (Linux/macOS)
+#### Option A: Monolith (recommended)
 
-The easiest way to start all required services is using the development script with tmux:
+The simplest way to start everything is the monolith script, which builds and launches a single `micromegas-monolith` process running all roles (ingestion, analytics, web, admin):
 
 ```bash
-# Start all services in a tmux session (debug mode)
-python3 local_test_env/dev.py
-
-# Or in release mode for better performance
-python3 local_test_env/dev.py release
+python3 local_test_env/ai_scripts/start_services.py --monolith
 ```
 
 This will automatically:
 
-- Build all Rust services
-- Start PostgreSQL database
-- Start telemetry-ingestion-srv on port 9000
-- Start flight-sql-srv on port 50051
-- Start telemetry-admin service
-- Open a tmux session with all services running in separate panes
+- Build the monolith binary and the analytics web app (including DataFusion WASM)
+- Start PostgreSQL if not already running
+- Launch `micromegas-monolith --roles all` on port 9000 (HTTP/ingestion), port 50051 (FlightSQL), and port 3000 (web app)
+- Write all PIDs to `/tmp/micromegas_pids.txt`
 
-!!! tip "Managing Services with tmux"
-    - To switch between service panes: `Ctrl+B` then arrow keys
-    - To detach from tmux (leave services running): `Ctrl+B` then `D`
-    - To reattach to tmux: `tmux attach -t micromegas`
-    - To stop all services: `python3 local_test_env/stop-dev.py`
+```bash
+# Stop all services
+python3 local_test_env/ai_scripts/stop_services.py
+```
 
-#### Option B: Manual Startup (Windows or without tmux)
+#### Option B: Split Services
 
-If you're on Windows or prefer not to use tmux, start each service in a separate terminal:
+To run the four services separately (closer to a production topology):
+
+```bash
+python3 local_test_env/ai_scripts/start_services.py
+```
+
+#### Option C: Manual Startup
+
+If you prefer full control, start each service in a separate terminal:
 
 **Terminal 1: PostgreSQL Database**
 ```bash

--- a/mkdocs/docs/grafana/index.md
+++ b/mkdocs/docs/grafana/index.md
@@ -19,7 +19,7 @@ The plugin provides:
 
 ### Prerequisites
 
-- Grafana 9.0 or later
+- Grafana 9.2.5 or later
 - Micromegas analytics server (flight-sql-srv) running
 - Authentication credentials (API key or OAuth 2.0 client credentials)
 

--- a/mkdocs/docs/grafana/installation.md
+++ b/mkdocs/docs/grafana/installation.md
@@ -4,7 +4,7 @@ This guide covers installing the Micromegas Grafana datasource plugin.
 
 ## Prerequisites
 
-- **Grafana**: Version 9.0 or later
+- **Grafana**: Version 9.2.5 or later
 - **Micromegas Analytics Server**: flight-sql-srv running and accessible
 - **Authentication Credentials**: API key or OAuth 2.0 client credentials
 
@@ -58,6 +58,7 @@ This guide covers installing the Micromegas Grafana datasource plugin.
 
 2. Install dependencies:
    ```bash
+   corepack enable  # required once per machine (Yarn 4 / Berry)
    yarn install
    ```
 

--- a/mkdocs/docs/query-guide/async-performance-analysis.md
+++ b/mkdocs/docs/query-guide/async-performance-analysis.md
@@ -70,9 +70,9 @@ SELECT
     depth,
     COUNT(*) as span_count,
     AVG(duration_ms) as avg_duration,
-    PERCENTILE(duration_ms, 0.5) as median_duration,
-    PERCENTILE(duration_ms, 0.95) as p95_duration,
-    PERCENTILE(duration_ms, 0.99) as p99_duration
+    approx_percentile_cont(duration_ms, 0.5) as median_duration,
+    approx_percentile_cont(duration_ms, 0.95) as p95_duration,
+    approx_percentile_cont(duration_ms, 0.99) as p99_duration
 FROM (
     SELECT
         begin_events.depth,
@@ -240,7 +240,7 @@ depth_summary AS (
         depth,
         COUNT(*) as operation_count,
         AVG(duration_ms) as avg_duration,
-        PERCENTILE(duration_ms, 0.95) as p95_duration
+        approx_percentile_cont(duration_ms, 0.95) as p95_duration
     FROM async_durations
     GROUP BY depth
 ),

--- a/mkdocs/docs/query-guide/index.md
+++ b/mkdocs/docs/query-guide/index.md
@@ -46,6 +46,7 @@ Micromegas organizes telemetry data into several queryable views:
 | `async_events` | Asynchronous event lifecycle tracking |
 | `net_spans` | Network bandwidth spans (Connection / Object / Property / RPC) |
 | `otel_spans` | OpenTelemetry spans materialized from OTLP-ingested traces |
+| `images` | Screenshots and image data captured via `send_image()` |
 
 ## Query Capabilities
 

--- a/mkdocs/docs/query-guide/python-api.md
+++ b/mkdocs/docs/query-guide/python-api.md
@@ -409,7 +409,7 @@ if not streams.empty:
     # Query blocks in that stream
     blocks = client.query_blocks(begin, end, 100, stream_id)
     print(f"Found {len(blocks)} blocks")
-    print(f"Total events: {blocks['nb_events'].sum()}")
+    print(f"Total objects: {blocks['nb_objects'].sum()}")
     print(f"Total size: {blocks['payload_size'].sum()} bytes")
 ```
 

--- a/mkdocs/docs/query-guide/quick-start.md
+++ b/mkdocs/docs/query-guide/quick-start.md
@@ -216,6 +216,7 @@ Now that you can run basic queries:
 - `measures` - Numeric metrics
 - `thread_spans` - Execution timing
 - `async_events` - Async operation tracking
+- `images` - Screenshots and image data
 
 ### Key Functions
 - `view_instance('view_name', 'process_id')` - Process-scoped views

--- a/mkdocs/docs/query-guide/schema-reference.md
+++ b/mkdocs/docs/query-guide/schema-reference.md
@@ -18,6 +18,7 @@ Micromegas organizes telemetry data into several views that can be queried using
 | [`async_events`](#async_events) | Asynchronous event lifecycle tracking | Async operation monitoring |
 | [`net_spans`](#net_spans) | Network bandwidth spans (Connection / Object / Property / RPC) | Replication bandwidth attribution, bit-axis flame charts |
 | [`otel_spans`](#otel_spans) | OpenTelemetry spans materialized from OTLP-ingested traces | Distributed tracing, OTel SDK interop |
+| [`images`](#images) | Screenshots and image data captured via `send_image()` | Visual telemetry, screenshot history |
 
 ## Core Views
 
@@ -567,6 +568,41 @@ SELECT COUNT(*) AS span_count
 FROM view_instance('otel_spans', '<process_id>')
 WHERE jsonb_as_string(jsonb_get(properties, 'otel.scope.name'))
       = 'opentelemetry.instrumentation.requests';
+```
+
+### `images`
+
+Screenshot and image data captured from instrumented processes via `send_image()`. The view is **JIT-only** and **parameterized by `process_id`** — there is no `global` instance.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `process_id` | `Dictionary(Int16, Utf8)` | Process id (the view parameter) |
+| `stream_id` | `Dictionary(Int16, Utf8)` | Source image stream |
+| `block_id` | `Dictionary(Int16, Utf8)` | Block identifier |
+| `insert_time` | `Timestamp(Nanosecond)` | When the block was ingested |
+| `exe` | `Dictionary(Int16, Utf8)` | Executable name |
+| `username` | `Dictionary(Int16, Utf8)` | User who ran the process |
+| `computer` | `Dictionary(Int16, Utf8)` | Computer/hostname |
+| `time` | `Timestamp(Nanosecond)` | Timestamp when the image was captured |
+| `name` | `Utf8` | Image name (e.g. `"screenshot"`) |
+| `format` | `Dictionary(Int16, Utf8)` | Image format string (e.g. `"png"`) |
+| `payload_size` | `Int64` | Compressed byte size of the image data |
+| `data` | `Binary` | Raw image bytes |
+
+**Example queries:**
+
+```sql
+-- List all screenshots captured by a process
+SELECT time, name, format, payload_size
+FROM view_instance('images', '<process_id>')
+ORDER BY time DESC;
+
+-- Count images per process in the last hour
+SELECT process_id, exe, COUNT(*) AS image_count
+FROM images
+WHERE time >= NOW() - INTERVAL '1 hour'
+GROUP BY process_id, exe
+ORDER BY image_count DESC;
 ```
 
 ## Data Types

--- a/mkdocs/docs/unreal/examples.md
+++ b/mkdocs/docs/unreal/examples.md
@@ -483,6 +483,63 @@ void AMyPhysicsActor::SimulatePhysics(float DeltaTime)
 }
 ```
 
+## Image Capture
+
+### Sending a Screenshot via Console Command
+
+The quickest way to capture the current viewport as a telemetry image:
+
+```
+telemetry.screenshot
+```
+
+The image is stored in the `images` SQL table and can be viewed in the Micromegas notebook Image cell. Images can be disabled globally with `telemetry.images.enable 0`.
+
+### Sending a Custom Image Programmatically
+
+Use `Dispatch::SendImage` to send any PNG (or other format) from code:
+
+```cpp
+#include "MicromegasTracing/Dispatch.h"
+#include "ImageUtils.h"
+
+void AMyActor::CaptureAndSendMinimap()
+{
+    MICROMEGAS_SPAN_FUNCTION("Game.Minimap");
+
+    // Render minimap to a pixel array
+    TArray<FColor> Pixels;
+    const int32 Width = 512;
+    const int32 Height = 512;
+    RenderMinimapToPixels(Width, Height, Pixels);
+
+    // Compress to PNG
+    TArray64<uint8> PngBytes;
+    FImageUtils::PNGCompressImageArray(Width, Height,
+        TArrayView64<const FColor>(Pixels.GetData(), Pixels.Num()),
+        PngBytes);
+
+    // Send as telemetry image
+    MicromegasTracing::Dispatch::SendImage(
+        TEXT("minimap"),
+        TEXT("image/png"),
+        PngBytes.GetData(),
+        static_cast<uint32>(PngBytes.Num()));
+
+    MICROMEGAS_LOG("Game.Minimap", MicromegasTracing::LogLevel::Info,
+                   TEXT("Minimap image sent to telemetry"));
+}
+```
+
+Query images in SQL:
+
+```sql
+SELECT time, name, format, payload_size
+FROM view_instance('images', process_id => $process_id)
+ORDER BY time DESC
+LIMIT 20
+```
+
 ## Error Handling and Debugging
 
 ### Comprehensive Error Logging

--- a/mkdocs/docs/unreal/index.md
+++ b/mkdocs/docs/unreal/index.md
@@ -82,10 +82,12 @@ Once your game is running and generating telemetry:
 ### Automatic Telemetry
 
 - **UE_LOG statements**: All existing Unreal logs are automatically captured
-- **Frame metrics**: Delta time, frame rate (when MetricPublisher is active)
+- **Frame metrics**: Delta time, frame rate, game/render/RHI/GPU thread times, draw calls (when MetricPublisher is active)
 - **Memory metrics**: Physical and virtual memory usage
+- **Input metrics**: `TimeSinceLastInput` — seconds since last keyboard/mouse/touch/controller interaction
+- **Scalability metrics**: Quality levels emitted on change; VSync state tracked in context
 - **Map changes**: Current level/world tracked in context
-- **Crashes**: Stack traces and context on Windows (requires debug symbols)
+- **Crashes**: Stack traces and context on Windows and Linux (requires debug symbols)
 
 ### Manual Instrumentation
 
@@ -93,6 +95,7 @@ Once your game is running and generating telemetry:
 - **Business metrics**: Player counts, game state, performance indicators
 - **Custom logs**: Direct telemetry logging with structured properties
 - **Context properties**: Session IDs, user IDs, build versions
+- **Images**: Screenshots and custom images sent via `Dispatch::SendImage()`, queryable via the `images` SQL table
 
 ## Architecture
 
@@ -103,13 +106,17 @@ Game Code
     ├─ Logging API
     ├─ Metrics API
     ├─ Spans API
+    ├─ Image API (SendImage)
     └─ Default Context
          ↓
 [MicromegasTelemetrySink Plugin]
-    ├─ HTTP Event Sink
+    ├─ Sampling Controller (spike detection, idle-aware, heartbeat)
+    ├─ Priority Queues: Metadata / Logs / Metrics / Traces
+    │    └─ Soft cap: Traces dropped first; hard cap bounds memory during outages
+    ├─ HTTP Worker Thread
+    │    └─ FHttpRetrySystem (exponential backoff, per-priority retry budget)
     ├─ Flush Monitor
-    ├─ Sampling Controller
-    └─ Crash Reporter
+    └─ Crash Reporter (Windows + Linux)
          ↓
 [Telemetry Ingestion Server]
     ├─ PostgreSQL (metadata)
@@ -124,16 +131,16 @@ Game Code
 
 ## Performance Considerations
 
-- Spans are disabled by default (enable with `telemetry.spans.enable 1`)
+- Spans are **disabled by default in the editor**; enabled by default in non-editor (game) builds. Toggle with `telemetry.spans.enable 0/1`
 - Events are buffered in thread-local storage before async delivery
-- The HTTP sink runs on a dedicated thread
-- Use sampling for high-frequency spans to manage data volume
-- Default context operations are expensive - use for infrequent changes
+- The HTTP worker thread uses `FHttpRetrySystem` with exponential backoff and four priority queues (Metadata → Logs → Metrics → Traces); Traces are dropped first when the queue exceeds the soft cap (`telemetry.max_queue_bytes`)
+- Use `telemetry.spans.all 0` (default) to let spike-based sampling manage trace volume automatically
+- Default context operations are expensive — use for infrequent changes
 
 ## Platform Support
 
 - **Windows**: Full support including crash reporting
-- **Linux**: Full support
+- **Linux**: Full support including crash reporting
 - **Mac**: Full support
 - **Consoles**: Requires network configuration
 - **Mobile**: Consider battery and bandwidth optimization

--- a/mkdocs/docs/unreal/installation.md
+++ b/mkdocs/docs/unreal/installation.md
@@ -136,6 +136,7 @@ void UYourGameInstance::Init()
     IMicromegasTelemetrySinkModule::LoadModuleChecked().InitTelemetry(
         ServerUrl, 
         AuthProvider
+        // Optional third argument: TMap<FString, FString> of extra process properties
     );
     
     // Set default context properties
@@ -232,19 +233,34 @@ In `MicromegasTelemetrySinkModule.cpp`:
 // Enable telemetry on startup (default: 1)
 #define MICROMEGAS_ENABLE_TELEMETRY_ON_START 1
 
-// Enable crash reporting on Windows (default: 1 on Windows, 0 elsewhere)
-#define MICROMEGAS_CRASH_REPORTING 1
+// Enable crash reporting (default: 1 on Windows and Linux, 0 elsewhere)
+#if PLATFORM_WINDOWS || PLATFORM_LINUX
+    #define MICROMEGAS_CRASH_REPORTING 1
+#else
+    #define MICROMEGAS_CRASH_REPORTING 0
+#endif
 ```
 
-### Runtime Console Commands
+### Runtime Console Commands and CVars
 
-Available console commands for runtime control:
+Available commands for runtime control:
 
-- `telemetry.enable` - Initialize the telemetry system
-- `telemetry.flush` - Force flush all pending events
-- `telemetry.spans.enable 1` - Enable span recording (disabled by default)
-- `telemetry.spans.enable 0` - Disable span recording
-- `telemetry.spans.all 1` - Record all spans without sampling
+| Command / CVar | Default | Description |
+|---|---|---|
+| `telemetry.enable` | — | Initialize the telemetry system (only needed if `MICROMEGAS_ENABLE_TELEMETRY_ON_START` is 0) |
+| `telemetry.flush` | — | Force flush all pending events |
+| `telemetry.spans.enable` | `true` (game), `false` (editor) | Enable/disable span recording |
+| `telemetry.spans.all` | `false` | Record all spans without sampling (high bandwidth) |
+| `telemetry.log.enable` | `true` | Enable/disable log stream recording |
+| `telemetry.metrics.enable` | `true` | Enable/disable metrics stream recording |
+| `telemetry.images.enable` | `true` | Enable/disable images sent via `SendImage` |
+| `telemetry.screenshot` | — | Capture the game viewport and send it as a telemetry image |
+| `telemetry.net.verbosity` | `2` | Net trace verbosity: 0=off, 1=packets, 2=+root objects, 3=+all objects, 4=+properties/RPCs |
+| `telemetry.max_queue_bytes` | `134217728` (128 MB) | Soft queue cap; Traces are dropped above this threshold |
+| `telemetry.hard_queue_bytes` | `268435456` (256 MB) | Hard queue ceiling; Logs/Metrics also dropped above this |
+| `telemetry.max_in_flight_requests` | `3` | Max concurrent uploads; worker pauses draining above this |
+| `telemetry.sampling.interaction_timeout` | `2.0` s | Seconds since last user input before spike recording is suppressed; 0 disables |
+| `telemetry.sampling.heartbeat_interval` | `120.0` s | Seconds of active user time between heartbeat captures; 0 disables |
 
 ## Verifying Installation
 
@@ -285,6 +301,7 @@ void ATestActor::BeginPlay()
 - Windows Defender may flag the first network connection - add an exception if needed
 
 ### Linux
+- Crash reporting is enabled by default
 - Ensure your ingestion server is accessible from the game server
 - Check firewall rules for port 9000 (or your configured port)
 

--- a/mkdocs/docs/unreal/instrumentation-api.md
+++ b/mkdocs/docs/unreal/instrumentation-api.md
@@ -110,9 +110,9 @@ MICROMEGAS_IMETRIC(target, level, name, unit, expression)
 
 **Verbosity Levels:**
 
-- `MicromegasTracing::Verbosity::Low` - Critical metrics only
-- `MicromegasTracing::Verbosity::Med` - Standard metrics
-- `MicromegasTracing::Verbosity::High` - Detailed metrics
+- `MicromegasTracing::Verbosity::Min` - Low-frequency / critical metrics
+- `MicromegasTracing::Verbosity::Med` - Frame-frequency metrics
+- `MicromegasTracing::Verbosity::Max` - Many instances per frame
 
 **Common Units:**
 
@@ -128,7 +128,7 @@ MICROMEGAS_IMETRIC("Game", MicromegasTracing::Verbosity::Med,
                    TEXT("PlayerCount"), TEXT("count"), 
                    GetWorld()->GetNumPlayerControllers());
 
-MICROMEGAS_IMETRIC("Memory", MicromegasTracing::Verbosity::Low,
+MICROMEGAS_IMETRIC("Memory", MicromegasTracing::Verbosity::Min,
                    TEXT("TextureMemory"), TEXT("bytes"),
                    GetTextureMemoryUsage());
 ```
@@ -155,7 +155,7 @@ MICROMEGAS_FMETRIC("Performance", MicromegasTracing::Verbosity::Med,
                    TEXT("FrameTime"), TEXT("ms"), 
                    DeltaTime * 1000.0);
 
-MICROMEGAS_FMETRIC("Game", MicromegasTracing::Verbosity::High,
+MICROMEGAS_FMETRIC("Game", MicromegasTracing::Verbosity::Max,
                    TEXT("HealthPercent"), TEXT("percent"),
                    (Health / MaxHealth) * 100.0);
 ```
@@ -258,6 +258,29 @@ void AMyActor::Tick(float DeltaTime)
     MICROMEGAS_SPAN_UOBJECT("Game.Actors", this);
     Super::Tick(DeltaTime);
     // ... tick logic ...
+}
+```
+
+### MICROMEGAS_SPAN_UOBJECT_CONDITIONAL
+
+Creates a span named after a UObject, but only when a condition is true.
+
+```cpp
+MICROMEGAS_SPAN_UOBJECT_CONDITIONAL(target, condition, object)
+```
+
+**Parameters:**
+
+- `target` (const char*): Span target/category
+- `condition` (bool): Whether to create the span
+- `object` (UObject*): The UObject whose name to use if condition is true
+
+**Example:**
+```cpp
+void AMyActor::Tick(float DeltaTime)
+{
+    MICROMEGAS_SPAN_UOBJECT_CONDITIONAL("Game.Actors", bIsImportant, this);
+    Super::Tick(DeltaTime);
 }
 ```
 
@@ -577,6 +600,45 @@ Two integer metrics are emitted via `MICROMEGAS_IMETRIC` from the instrumented e
 
 These are **wire bits** including packet headers, bunch headers, NetGUID exports, control bunches, and voice. Compare against `sum(NetConnectionEndEvent.bit_size)` for content-vs-wire reconciliation — the gap is framing overhead.
 
+## Image API
+
+### Dispatch::SendImage
+
+Sends an image as a telemetry event. Images are stored in the `images` view and can be queried via SQL or viewed in the notebook Image cell.
+
+```cpp
+MicromegasTracing::Dispatch::SendImage(Name, Format, Data, DataBytes)
+```
+
+**Parameters:**
+
+- `Name` (const TCHAR*): Image name / label (e.g., `TEXT("screenshot")`)
+- `Format` (const TCHAR*): MIME type (e.g., `TEXT("image/png")`)
+- `Data` (const uint8*): Raw image bytes
+- `DataBytes` (uint32): Length of `Data` in bytes
+
+**Example — send a PNG from a byte array:**
+```cpp
+#include "MicromegasTracing/Dispatch.h"
+
+TArray64<uint8> PngBytes = EncodeAsPng(Width, Height, Pixels);
+MicromegasTracing::Dispatch::SendImage(
+    TEXT("heatmap"),
+    TEXT("image/png"),
+    PngBytes.GetData(),
+    static_cast<uint32>(PngBytes.Num()));
+```
+
+**Console command shortcut:**
+
+The `telemetry.screenshot` console command captures the game viewport and calls `SendImage` automatically:
+
+```
+telemetry.screenshot
+```
+
+This works in both game builds (via `UGameViewportClient::OnScreenshotCaptured`) and in the editor (via `GEditor->GetActiveViewport()->ReadPixels`). Use `telemetry.images.enable 0` to suppress image recording globally.
+
 ## Default Context API
 
 The Default Context allows setting global properties that are automatically attached to all telemetry.
@@ -650,47 +712,35 @@ Ctx->Copy(CurrentContext);
 
 ## Console Commands
 
-Runtime control commands available in the Unreal console:
+Runtime control commands and CVars available in the Unreal console:
 
-### telemetry.enable
-Initializes the telemetry system if not already enabled.
-
-```
-telemetry.enable
-```
-
-### telemetry.flush
-Forces immediate flush of all pending telemetry events.
-
-```
-telemetry.flush
-```
-
-### telemetry.spans.enable
-Enables or disables span recording.
-
-```
-telemetry.spans.enable 1  // Enable spans
-telemetry.spans.enable 0  // Disable spans
-```
-
-### telemetry.spans.all
-Enables recording of all spans without sampling.
-
-```
-telemetry.spans.all 1  // Record all spans
-telemetry.spans.all 0  // Use sampling
-```
+| Command / CVar | Default | Description |
+|---|---|---|
+| `telemetry.enable` | — | Initialize the telemetry system |
+| `telemetry.flush` | — | Force flush all pending events |
+| `telemetry.spans.enable` | `true` (game), `false` (editor) | Enable/disable span recording |
+| `telemetry.spans.all` | `false` | Record all spans without sampling |
+| `telemetry.log.enable` | `true` | Enable/disable log stream recording |
+| `telemetry.metrics.enable` | `true` | Enable/disable metrics stream recording |
+| `telemetry.images.enable` | `true` | Enable/disable images sent via `SendImage` |
+| `telemetry.screenshot` | — | Capture the game/editor viewport as a telemetry image |
+| `telemetry.net.verbosity` | `2` | Net trace verbosity: 0=off, 1=packets, 2=+root objects, 3=+all objects, 4=+properties/RPCs |
+| `telemetry.max_queue_bytes` | `134217728` | Soft queue cap in bytes; Traces dropped above this |
+| `telemetry.hard_queue_bytes` | `268435456` | Hard queue ceiling; Logs/Metrics also dropped above this |
+| `telemetry.max_in_flight_requests` | `3` | Max concurrent HTTP uploads in flight |
+| `telemetry.sampling.interaction_timeout` | `2.0` s | Seconds of idle before spike recording is suppressed; 0 disables |
+| `telemetry.sampling.heartbeat_interval` | `120.0` s | Seconds between heartbeat span captures; 0 disables |
 
 ## Best Practices
 
 ### Performance
 
-1. **Use sampling for high-frequency spans** - It's OK to keep spans enabled with reasonable sampling
-2. **Use appropriate verbosity** - Lower verbosity for high-frequency metrics
-3. **Batch operations** - Let the system batch; avoid frequent flushes
-4. **Static strings** - Use TEXT() macro for string literals
-5. **Limit context cardinality** - Context keys/values are never freed
+1. **Use sampling for high-frequency spans** — spike-based sampling (`telemetry.spans.all 0`) captures performance anomalies without recording every frame
+2. **Use appropriate verbosity** — `Verbosity::Min` for low-frequency events, `Verbosity::Med` for per-frame, `Verbosity::Max` for sub-frame
+3. **Batch operations** — let the system batch; avoid frequent manual flushes
+4. **Static strings** — use `TEXT()` macro for string literals in metric/span names
+5. **Limit context cardinality** — context keys/values are interned and never freed
+6. **Queue caps** — the HTTP sink has a soft cap (Traces dropped first) and hard cap (Logs/Metrics dropped too); adjust `telemetry.max_queue_bytes` if you see `DroppedUploads` metrics during outages
 
 
 ### Error Handling

--- a/mkdocs/docs/web-app/notebooks/cell-types.md
+++ b/mkdocs/docs/web-app/notebooks/cell-types.md
@@ -420,9 +420,9 @@ The same controls apply in both perspective and orthographic camera modes.
 | Left-drag | Pan (top-down XY translation) |
 | Right-drag | Orbit around the look-at point. Pitch is clamped to keep the camera above the horizon. |
 | Ctrl/Cmd + wheel | Zoom, anchored to the point under the cursor. Plain wheel scrolls the surrounding page. |
-| `W` / `S` | Pan forward / back (top-down — does not change elevation) |
-| `A` / `D` | Strafe left / right |
-| `Q` / `E` | Zoom in / out |
+| `W` / `S` | Pan along the camera-up vector (camera-relative — tilting the view changes the world direction) |
+| `A` / `D` | Strafe along the camera-right vector |
+| `Q` / `E` | Move along the camera-forward vector (perspective); zoom in / out (orthographic) |
 | `Z` | Reset view to the initial framing |
 
 Keyboard controls (WASD/QE/Z) require the pointer to be over the map — keeps multiple Map cells on the same page from moving together and ignores keystrokes typed into form inputs.
@@ -672,7 +672,7 @@ SQL query results displayed in a sortable, paginated table.
 Override how a column renders by providing a markdown format string with row macros:
 
 ```markdown
-[$row.exe](/process/$row.process_id?from=$begin&to=$end)
+[$row.exe](/process/$row.process_id?from=$from&to=$to)
 ```
 
 This renders the `exe` column as a link to the process page.

--- a/mkdocs/docs/web-app/notebooks/execution.md
+++ b/mkdocs/docs/web-app/notebooks/execution.md
@@ -58,7 +58,7 @@ The time range controls which time window is queried. It is managed at the page 
 
 ### Implicit Time Filtering
 
-When a query is sent to the server, the current time range is passed as **separate metadata** alongside the SQL. The server's query planner automatically injects time filters into the execution plan for all materialized views — you do not need to write `WHERE time >= '$begin' AND time < '$end'` in your SQL.
+When a query is sent to the server, the current time range is passed as **separate metadata** alongside the SQL. The server's query planner automatically injects time filters into the execution plan for all materialized views — you do not need to write `WHERE time >= '$from' AND time < '$to'` in your SQL.
 
 Each view defines which columns are filtered:
 
@@ -72,7 +72,7 @@ This means a simple query like `SELECT time, value FROM measures WHERE name = '$
 
 ### Explicit Time References
 
-The `$begin` and `$end` macros are still available for cases where you need the time range values explicitly — for example, in markdown content, link URLs, or `date_bin()` aggregations:
+The `$from` and `$to` macros are available for cases where you need the time range values explicitly — for example, in markdown content, link URLs, or `date_bin()` aggregations:
 
 ```sql
 SELECT

--- a/mkdocs/docs/web-app/notebooks/screens-as-code.md
+++ b/mkdocs/docs/web-app/notebooks/screens-as-code.md
@@ -123,7 +123,7 @@ Refresh local files from server. With no arguments, pulls all locally-tracked sc
 micromegas-screens plan [NAME...]
 ```
 
-Preview what `apply` would change. Shows creates, updates, deletes, and untracked screens. Read-only — no server mutations.
+Preview what `apply` would change. Shows creates, updates, deletes, and untracked screens, and prints a **unified diff** for each modified screen. Pass `--color` to get colored diff output in a terminal. Read-only — no server mutations.
 
 ### `apply`
 


### PR DESCRIPTION
## Summary

Documentation refresh aligning the docs site and README with the v0.26.0 codebase. No code changes — Markdown and README only. Every claim was verified against the current source.

- **README**: trim Recent Releases to the last 3 months; remove the empty Unreleased section
- **Architecture**: correct the frontend stack (Vite + React, not Next.js); add monolith deployment
- **Getting started**: present the monolith as the recommended Option A
- **Contributing + build**: add an analytics-web-app section, corepack prerequisite, ARM64 cross-compilation, and the pinned Rust toolchain
- **Admin/web-app**: fix the default port, env vars, and `/api/*` routes
- **Admin/monolith**: correct the OIDC and API-key JSON schemas
- **Query guide**: replace `PERCENTILE()` with `approx_percentile_cont()`; document the `images` view; fix the `nb_objects` field name
- **Unreal**: add the image-streams API, a full CVar table, the correct verbosity enum, and accurate crash-reporting platform notes
- **Web-app/notebooks**: fix `$begin`/`$end` → `$from`/`$to`, map camera controls, and the screens-as-code plan diff
- **Grafana**: bump minimum version 9.0 → 9.2.5
- **Cost comparisons**: update the review date; add OTLP/monolith notes; flag stale pricing

## Test plan

- `mkdocs build --strict` passes (exit 0) — no broken links or build errors
- All documented commands, flags, schema fields, routes, CVars, and APIs verified to exist in the codebase