### PR TITLE
Fix capi-release: mold + Windows cross-build on the Linux runner

### DIFF
--- a/.github/workflows/capi-release.yml
+++ b/.github/workflows/capi-release.yml
@@ -24,22 +24,32 @@ permissions:
   contents: write
 
 jobs:
+  check-runner:
+    uses: ./.github/workflows/check-runner.yml
+    secrets: inherit
+
   build:
+    needs: check-runner
     strategy:
       matrix:
         include:
           - os: ubuntu-latest
           - os: windows-latest
-    runs-on: ${{ matrix.os }}
+    # The Linux leg routes to the dev-worker custom runner when it's online
+    # (trusted authors only), otherwise falls back to ubuntu-latest. Windows
+    # always uses the GitHub-hosted runner. matrix.os stays a stable identity
+    # label used for naming/conditionals regardless of the actual runner.
+    runs-on: ${{ matrix.os == 'windows-latest' && 'windows-latest' || needs.check-runner.outputs.runner }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
       # .cargo/config.toml forces the mold linker for x86_64-unknown-linux-gnu
       # (clang -fuse-ld=mold), so it must be present before any cargo build on
-      # Linux. Mirrors the install step in rust.yml. Not needed on Windows.
+      # Linux. The dev-worker image already ships mold; only the GitHub-hosted
+      # fallback needs the apt install. Mirrors rust.yml. Not needed on Windows.
       - name: Install mold linker
-        if: runner.os == 'Linux'
+        if: matrix.os == 'ubuntu-latest' && needs.check-runner.outputs.runner == 'ubuntu-latest'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y mold

--- a/.github/workflows/capi-release.yml
+++ b/.github/workflows/capi-release.yml
@@ -58,7 +58,11 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y mold mingw-w64
 
+      # Run from rust/ so rustup honors rust-toolchain.toml and adds the target
+      # to the *pinned* toolchain that cargo actually builds with — not the
+      # default `stable`, which the build never uses.
       - name: Add Rust target
+        working-directory: rust
         run: rustup target add ${{ matrix.target }}
 
       - name: Resolve version argument

--- a/.github/workflows/capi-release.yml
+++ b/.github/workflows/capi-release.yml
@@ -33,26 +33,33 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
-          - os: windows-latest
-    # The Linux leg routes to the dev-worker custom runner when it's online
-    # (trusted authors only), otherwise falls back to ubuntu-latest. Windows
-    # always uses the GitHub-hosted runner. matrix.os stays a stable identity
-    # label used for naming/conditionals regardless of the actual runner.
-    runs-on: ${{ matrix.os == 'windows-latest' && 'windows-latest' || needs.check-runner.outputs.runner }}
+          - name: linux
+            target: x86_64-unknown-linux-gnu
+          - name: windows
+            target: x86_64-pc-windows-gnu
+    # Both legs run on the Linux runner (dev-worker when online for trusted
+    # authors, otherwise the ubuntu-latest fallback). The Windows artifacts are
+    # cross-compiled with the mingw-w64 toolchain — see the toolchain step.
+    runs-on: ${{ needs.check-runner.outputs.runner }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
-      # .cargo/config.toml forces the mold linker for x86_64-unknown-linux-gnu
-      # (clang -fuse-ld=mold), so it must be present before any cargo build on
-      # Linux. The dev-worker image already ships mold; only the GitHub-hosted
-      # fallback needs the apt install. Mirrors rust.yml. Not needed on Windows.
-      - name: Install mold linker
-        if: matrix.os == 'ubuntu-latest' && needs.check-runner.outputs.runner == 'ubuntu-latest'
+      # Toolchain for the build:
+      #   - mold: .cargo/config.toml forces -fuse-ld=mold for the native
+      #     x86_64-unknown-linux-gnu target.
+      #   - mingw-w64: provides x86_64-w64-mingw32-gcc, the linker used to
+      #     cross-compile the x86_64-pc-windows-gnu target.
+      # The dev-worker image is expected to ship both; only the GitHub-hosted
+      # fallback needs the apt install (mirrors rust.yml's mold convention).
+      - name: Install cross toolchain
+        if: needs.check-runner.outputs.runner == 'ubuntu-latest'
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y mold
+          sudo apt-get install -y mold mingw-w64
+
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Resolve version argument
         id: ver
@@ -79,20 +86,23 @@ jobs:
             echo "arg=" >> "$GITHUB_OUTPUT"
           fi
 
+      # The dev-worker image already ships python3; only the GitHub-hosted
+      # fallback needs setup-python (which can be flaky on self-hosted runners).
       - name: Set up Python
+        if: needs.check-runner.outputs.runner == 'ubuntu-latest'
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
       - name: Package (build + archive)
-        run: python3 build/package_capi.py --build ${{ steps.ver.outputs.arg }}
+        run: python3 build/package_capi.py --build --target ${{ matrix.target }} ${{ steps.ver.outputs.arg }}
 
-      # Each runner produces exactly one archive (Linux -> .tar.gz,
-      # Windows -> .zip). Upload whichever exists and fail loudly if
+      # Each matrix leg produces exactly one archive (linux -> .tar.gz,
+      # windows -> .zip). Upload whichever exists and fail loudly if
       # packaging produced nothing.
       - uses: actions/upload-artifact@v4
         with:
-          name: capi-${{ matrix.os }}
+          name: capi-${{ matrix.name }}
           path: |
             dist/*.tar.gz
             dist/*.zip

--- a/.github/workflows/capi-release.yml
+++ b/.github/workflows/capi-release.yml
@@ -35,6 +35,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # .cargo/config.toml forces the mold linker for x86_64-unknown-linux-gnu
+      # (clang -fuse-ld=mold), so it must be present before any cargo build on
+      # Linux. Mirrors the install step in rust.yml. Not needed on Windows.
+      - name: Install mold linker
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y mold
+
       - name: Resolve version argument
         id: ver
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file documents the historical progress of the Micromegas project. For curre
   * Upgrade `opentelemetry-proto` to 0.32 to resolve GHSA-w9wp-h8wv-79jx; treat the new profiling-only string-interning fields (`*_strindex`) as absent on non-profiling OTLP signals, per the OTLP spec (#336)
 * **Build:**
   * Make `build.py` the single canonical generator for committed datafusion-wasm bindings; prune known wasm-pack leftovers from the output dir after each build so the copy loop is self-healing; document that `wasm-pack build` must not be run into the output dir (#1169)
+  * Fix `capi-release`: route both build legs through the dev-worker runner (mold + mingw-w64 in the image), cross-compile the Windows artifacts on the Linux runner, and add the cross target to the pinned `1.96.0` toolchain the build actually uses (#1175)
 * **Dependencies:**
   * Update DataFusion to 54.0 and rebuild the datafusion-wasm bindings
 * **Native / Blender:**

--- a/build/package_capi.py
+++ b/build/package_capi.py
@@ -21,24 +21,31 @@ import subprocess
 import sys
 
 
-def lib_patterns():
-    """Return (matched-by-suffix, exact-names) the cdylib/staticlib/import-lib
-    artifacts cargo emits for the current platform."""
-    if sys.platform == "win32":
-        # cdylib -> micromegas_capi.dll, its import lib -> micromegas_capi.dll.lib
-        # staticlib -> micromegas_capi.lib
-        return [".dll", ".dll.lib", ".lib"]
-    if sys.platform == "darwin":
-        return [".dylib", ".a"]
-    return [".so", ".a"]
+def target_profile(target):
+    """Return (lib-suffixes, platform-tag) for a cargo target triple. When
+    target is None, profile the host platform instead.
 
-
-def platform_tag():
-    if sys.platform == "win32":
-        return "windows-x86_64"
-    if sys.platform == "darwin":
-        return "macos-x86_64"
-    return "linux-x86_64"
+    The lib suffixes select the cdylib/staticlib/import-lib artifacts cargo
+    emits for that platform; everything else in the target dir (.rlib, .d, ...)
+    is ignored.
+    """
+    if target is None:
+        if sys.platform == "win32":
+            return [".dll", ".dll.lib", ".lib"], "windows-x86_64"
+        if sys.platform == "darwin":
+            return [".dylib", ".a"], "macos-x86_64"
+        return [".so", ".a"], "linux-x86_64"
+    # Cross-compilation: select by target triple, not the host.
+    if "windows-gnu" in target:
+        # mingw: cdylib -> micromegas_capi.dll, import lib ->
+        # libmicromegas_capi.dll.a, staticlib -> libmicromegas_capi.a
+        return [".dll", ".dll.a", ".a"], "windows-x86_64"
+    if "windows" in target:
+        # MSVC: cdylib -> .dll, import lib -> .dll.lib, staticlib -> .lib
+        return [".dll", ".dll.lib", ".lib"], "windows-x86_64"
+    if "darwin" in target:
+        return [".dylib", ".a"], "macos-x86_64"
+    return [".so", ".a"], "linux-x86_64"
 
 
 def workspace_version(repo_root):
@@ -71,11 +78,14 @@ def main():
         help="run `cargo build -p micromegas-capi --release` before packaging",
     )
     parser.add_argument(
+        "--target",
+        help="cargo target triple to (cross-)build and package for, e.g. "
+        "x86_64-pc-windows-gnu (defaults to the host target)",
+    )
+    parser.add_argument(
         "--target-dir",
-        default=os.path.join(
-            os.path.dirname(__file__), "..", "rust", "target", "release"
-        ),
-        help="cargo release output directory containing the built libraries",
+        help="cargo release output directory containing the built libraries "
+        "(defaults to rust/target[/<target>]/release)",
     )
     parser.add_argument(
         "--out-dir",
@@ -85,19 +95,39 @@ def main():
     args = parser.parse_args()
 
     repo_root = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
-    target_dir = os.path.normpath(args.target_dir)
+    cargo_cwd = os.path.join(repo_root, "rust")
+    if args.target_dir:
+        base = args.target_dir
+    else:
+        # Honor CARGO_TARGET_DIR (the dev-worker points it at a persistent
+        # cache outside rust/target); cargo resolves a relative value against
+        # its working directory. Otherwise default to rust/target.
+        env_dir = os.environ.get("CARGO_TARGET_DIR")
+        if env_dir:
+            base = (
+                env_dir if os.path.isabs(env_dir) else os.path.join(cargo_cwd, env_dir)
+            )
+        else:
+            base = os.path.join(cargo_cwd, "target")
+    # cargo nests cross-compiled output under <base>/<triple>/release.
+    parts = [base, args.target, "release"] if args.target else [base, "release"]
+    target_dir = os.path.normpath(os.path.join(*parts))
     out_dir = os.path.normpath(args.out_dir)
     header = os.path.join(repo_root, "rust", "capi", "include", "micromegas.h")
     version = args.version or workspace_version(repo_root)
 
     if args.build:
+        cmd = ["cargo", "build", "-p", "micromegas-capi", "--release"]
+        if args.target:
+            cmd += ["--target", args.target]
         subprocess.run(
-            ["cargo", "build", "-p", "micromegas-capi", "--release"],
-            cwd=os.path.join(repo_root, "rust"),
+            cmd,
+            cwd=cargo_cwd,
             check=True,
         )
 
-    name = f"micromegas-capi-{version}-{platform_tag()}"
+    suffixes, tag = target_profile(args.target)
+    name = f"micromegas-capi-{version}-{tag}"
     stage = os.path.join(out_dir, name)
     if os.path.isdir(stage):
         shutil.rmtree(stage)
@@ -107,7 +137,6 @@ def main():
     # Header is checked in (cbindgen-generated); ship it as-is.
     shutil.copy2(header, os.path.join(stage, "include", "micromegas.h"))
 
-    suffixes = lib_patterns()
     copied = []
     for entry in sorted(os.listdir(target_dir)):
         if not entry.startswith(("libmicromegas_capi", "micromegas_capi")):
@@ -125,7 +154,7 @@ def main():
         )
         return 1
 
-    fmt = "zip" if sys.platform == "win32" else "gztar"
+    fmt = "zip" if tag.startswith("windows") else "gztar"
     archive = shutil.make_archive(stage, fmt, root_dir=out_dir, base_dir=name)
 
     print(f"staged libraries: {', '.join(copied)}")

--- a/docker/github-runner.Dockerfile
+++ b/docker/github-runner.Dockerfile
@@ -32,6 +32,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     jq \
     libicu-dev \
     libssl-dev \
+    mingw-w64 \
     mold \
     pkg-config \
     python3 \
@@ -99,8 +100,9 @@ USER runner
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 ENV PATH="/home/runner/.cargo/bin:${PATH}"
 
-# Rust WASM target and cargo tools
+# Rust targets (WASM; windows-gnu for the capi-release cross-build) and cargo tools
 RUN rustup target add wasm32-unknown-unknown \
+    && rustup target add x86_64-pc-windows-gnu \
     && cargo install cargo-machete \
     && cargo install wasm-pack
 


### PR DESCRIPTION
## Summary

Makes the `capi-release` workflow actually build and package the `micromegas-capi` libraries for both Linux and Windows.

- **Run on the dev-worker runner** so mold and the mingw-w64 cross toolchain are available from the image; the `ubuntu-latest` fallback installs `mold` + `mingw-w64` via apt (mirrors `rust.yml`'s mold convention).
- **Cross-compile the Windows (`x86_64-pc-windows-gnu`) artifacts on the Linux runner** instead of a separate Windows runner. `package_capi.py` learns `--target`/`--target-dir`, selects the right cdylib/staticlib/import-lib suffixes per target triple, and honors `CARGO_TARGET_DIR`.
- **Add the cross target to the *pinned* toolchain.** `rust/rust-toolchain.toml` pins cargo to `1.96.0`, but `rustup target add` was running at the repo root (no toolchain file) and adding the target to the default `stable`. The build runs from `rust/` with `1.96.0`, which lacked the windows-gnu std (`can't find crate for core/std`). The step now runs from `rust/` so the target lands on the toolchain the build actually uses.
- Add `mingw-w64` to the dev-worker image.

Manual `workflow_dispatch` stops at uploaded artifacts (`capi-linux`, `capi-windows`); pushing a `capi-v*` tag additionally publishes a GitHub Release.

Fixes #1175

## Test plan

- Dispatched the workflow against this branch: both `build (linux, x86_64-unknown-linux-gnu)` and `build (windows, x86_64-pc-windows-gnu)` legs pass, including the Windows cross-compile and mingw link step. Run: https://github.com/madesroches/micromegas/actions/runs/28256750202
- Verified the run produces `capi-linux` (.tar.gz) and `capi-windows` (.zip) artifacts, each containing the shared lib, static lib, and `include/micromegas.h`.
- `black --check` and `py_compile` clean on `build/package_capi.py`.