### PR TITLE
Blender build fixes and version logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ This file documents the historical progress of the Micromegas project. For curre
   * Upgrade `opentelemetry-proto` to 0.32 to resolve GHSA-w9wp-h8wv-79jx; treat the new profiling-only string-interning fields (`*_strindex`) as absent on non-profiling OTLP signals, per the OTLP spec (#336)
 * **Build:**
   * Fix `build_blender_plugin.py` artifact lookup when `CARGO_TARGET_DIR` is set; add `x86_64-pc-windows-gnu` to the pinned toolchain so the Windows cross-target installs automatically on fresh checkouts
-* **Build:**
   * Add Docker Hub publish pipeline for release: `build_docker_images.py` gains an arm64 buildx `--push` path and an `--all-arches` flag that builds both architectures in one run, with `--push` independently controlling publishing; sync the release runbook with a both-arch Docker Images phase (#1165)
   * Make `build.py` the single canonical generator for committed datafusion-wasm bindings; prune known wasm-pack leftovers from the output dir after each build so the copy loop is self-healing; document that `wasm-pack build` must not be run into the output dir (#1169)
   * Fix `capi-release`: route both build legs through the dev-worker runner (mold + mingw-w64 in the image), cross-compile the Windows artifacts on the Linux runner, and add the cross target to the pinned `1.96.0` toolchain the build actually uses (#1175)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This file documents the historical progress of the Micromegas project. For curre
 * **Security:**
   * Upgrade `opentelemetry-proto` to 0.32 to resolve GHSA-w9wp-h8wv-79jx; treat the new profiling-only string-interning fields (`*_strindex`) as absent on non-profiling OTLP signals, per the OTLP spec (#336)
 * **Build:**
+  * Fix `build_blender_plugin.py` artifact lookup when `CARGO_TARGET_DIR` is set; add `x86_64-pc-windows-gnu` to the pinned toolchain so the Windows cross-target installs automatically on fresh checkouts
+* **Build:**
   * Add Docker Hub publish pipeline for release: `build_docker_images.py` gains an arm64 buildx `--push` path and an `--all-arches` flag that builds both architectures in one run, with `--push` independently controlling publishing; sync the release runbook with a both-arch Docker Images phase (#1165)
   * Make `build.py` the single canonical generator for committed datafusion-wasm bindings; prune known wasm-pack leftovers from the output dir after each build so the copy loop is self-healing; document that `wasm-pack build` must not be run into the output dir (#1169)
   * Fix `capi-release`: route both build legs through the dev-worker runner (mold + mingw-w64 in the image), cross-compile the Windows artifacts on the Linux runner, and add the cross target to the pinned `1.96.0` toolchain the build actually uses (#1175)
@@ -20,6 +22,7 @@ This file documents the historical progress of the Micromegas project. For curre
   * Add docs for native C ABI integration (`mkdocs/docs/native/`) and the Blender add-on (`mkdocs/docs/blender/`) (#1160)
   * Make Blender per-process memory cross-platform and periodically sampled, and fix the misleading `blender.eval_ms` metric (renamed, no longer spans the file-load boundary) (#1168)
   * Expand the Blender process fingerprint and add Python exception capture via `sys.excepthook` plus semantic user-action capture, closing root-cause-analysis telemetry gaps (#1168)
+  * Log add-on version and git commit hash on registration for easier triaging of field reports
 
 ## June 2026 - v0.26.0
 

--- a/blender/.gitignore
+++ b/blender/.gitignore
@@ -1,2 +1,3 @@
 micromegas_blender/lib/
+micromegas_blender/_build_info.py
 micromegas_blender.zip

--- a/blender/micromegas_blender/__init__.py
+++ b/blender/micromegas_blender/__init__.py
@@ -21,6 +21,8 @@ import re
 import sys
 import uuid
 
+from . import _build_info
+
 
 def _read_addon_version() -> str:
     """Read the add-on version from the bundled manifest so telemetry reports
@@ -297,7 +299,7 @@ def register():
     except Exception:
         pass
 
-    lib.log(handle, 4, "blender.addon", "Micromegas add-on registered")  # INFO=4
+    lib.log(handle, 4, "blender.addon", f"Micromegas add-on registered version={_ADDON_VERSION} commit={_build_info.COMMIT}")  # INFO=4
     # Use INFO level (4) for the startup log
     lib.log(handle, 4, "blender.addon", f"session_id={_session_id}")
 

--- a/blender/micromegas_blender/__init__.py
+++ b/blender/micromegas_blender/__init__.py
@@ -21,7 +21,14 @@ import re
 import sys
 import uuid
 
-from . import _build_info
+try:
+    from . import _build_info
+
+    _COMMIT = _build_info.COMMIT
+except ImportError:
+    # _build_info.py is generated at build time (see build/build_blender_plugin.py)
+    # and is not tracked in git; running from source before a build is fine.
+    _COMMIT = "unknown"
 
 
 def _read_addon_version() -> str:
@@ -299,7 +306,7 @@ def register():
     except Exception:
         pass
 
-    lib.log(handle, 4, "blender.addon", f"Micromegas add-on registered version={_ADDON_VERSION} commit={_build_info.COMMIT}")  # INFO=4
+    lib.log(handle, 4, "blender.addon", f"Micromegas add-on registered version={_ADDON_VERSION} commit={_COMMIT}")  # INFO=4
     # Use INFO level (4) for the startup log
     lib.log(handle, 4, "blender.addon", f"session_id={_session_id}")
 

--- a/blender/micromegas_blender/_build_info.py
+++ b/blender/micromegas_blender/_build_info.py
@@ -1,2 +1,0 @@
-# Stamped at build time by build/build_blender_plugin.py.
-COMMIT = "4d515f3da"

--- a/blender/micromegas_blender/_build_info.py
+++ b/blender/micromegas_blender/_build_info.py
@@ -1,0 +1,2 @@
+# Stamped at build time by build/build_blender_plugin.py.
+COMMIT = "4d515f3da"

--- a/build/build_blender_plugin.py
+++ b/build/build_blender_plugin.py
@@ -128,6 +128,24 @@ def workspace_version() -> str:
     raise RuntimeError(f"could not find [workspace.package] version in {cargo_toml}")
 
 
+def stamp_build_info() -> None:
+    """Write the current git commit hash into _build_info.py."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    commit = result.stdout.strip()
+    build_info = REPO_ROOT / "blender" / "micromegas_blender" / "_build_info.py"
+    build_info.write_text(
+        f"# Stamped at build time by build/build_blender_plugin.py.\nCOMMIT = \"{commit}\"\n",
+        encoding="utf-8",
+    )
+    print(f"build info: commit={commit}")
+
+
 def sync_manifest_version() -> None:
     """Stamp blender_manifest.toml's version to the workspace version so the
     add-on ships the same version as the rest of the workspace."""
@@ -145,6 +163,7 @@ def sync_manifest_version() -> None:
 
 
 def build_zip() -> None:
+    stamp_build_info()
     sync_manifest_version()
     # Warn if a platform library is absent — a single-platform local build
     # (or a partial lib/) produces a zip that won't load on the missing OS.

--- a/build/build_blender_plugin.py
+++ b/build/build_blender_plugin.py
@@ -48,9 +48,10 @@ def run(cmd: list[str], cwd: pathlib.Path, extra_env: dict | None = None) -> Non
 
 
 def cargo_output_dir(target: str | None) -> pathlib.Path:
+    base = pathlib.Path(os.environ.get("CARGO_TARGET_DIR", RUST_DIR / "target"))
     if target:
-        return RUST_DIR / "target" / target / "release"
-    return RUST_DIR / "target" / "release"
+        return base / target / "release"
+    return base / "release"
 
 
 def build_linux() -> None:

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.96.0"
 components = ["clippy", "rustfmt"]
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32-unknown-unknown", "x86_64-pc-windows-gnu"]


### PR DESCRIPTION
## Summary

- Fix `build_blender_plugin.py` to respect `CARGO_TARGET_DIR` when locating compiled artifacts — previously broke when the env var redirected the target directory
- Add `x86_64-pc-windows-gnu` to `rust-toolchain.toml` so the Windows cross-compilation target installs automatically on fresh checkouts (no manual `rustup target add` needed)
- Stamp git commit hash into `_build_info.py` at build time and include it in the add-on's registration log message alongside the version, making field reports easier to triage

## Test plan

- Run `./build/build_blender_plugin.py` — should complete without errors for both Linux and Windows targets
- Confirm `_build_info.py` in the zip contains the current short commit hash
- Install the extension in Blender and check the telemetry log for `Micromegas add-on registered version=X.Y.Z commit=<hash>`