### PR TITLE
OTLP: derive username from process.owner and fold into process_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file documents the historical progress of the Micromegas project. For curre
 
 ## Unreleased
 
+* **OTLP:**
+  * Populate the `processes.username` column from `process.owner` (falling back to `user.name`) and fold the resolved owner into the `process_id` derivation so processes that differ only by owning user get distinct ids; re-derivation stays under the existing `NS_OTEL_PROCESS_V1` namespace
 * **Security:**
   * Upgrade `opentelemetry-proto` to 0.32 to resolve GHSA-w9wp-h8wv-79jx; treat the new profiling-only string-interning fields (`*_strindex`) as absent on non-profiling OTLP signals, per the OTLP spec (#336)
 * **Build:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This file documents the historical progress of the Micromegas project. For curre
 ## Unreleased
 
 * **OTLP:**
-  * Populate the `processes.username` column from `process.owner` (falling back to `user.name`) and fold the resolved owner into the `process_id` derivation so processes that differ only by owning user get distinct ids; re-derivation stays under the existing `NS_OTEL_PROCESS_V1` namespace
+  * Populate the `processes.username` column from `process.owner` (falling back through `process.user.name`, `process.real_user.name`, then `user.name`) and fold the resolved owner into the `process_id` derivation so processes that differ only by owning user get distinct ids; re-derivation stays under the existing `NS_OTEL_PROCESS_V1` namespace
 * **Security:**
   * Upgrade `opentelemetry-proto` to 0.32 to resolve GHSA-w9wp-h8wv-79jx; treat the new profiling-only string-interning fields (`*_strindex`) as absent on non-profiling OTLP signals, per the OTLP spec (#336)
 * **Build:**

--- a/local_test_env/claude_code_otel.py
+++ b/local_test_env/claude_code_otel.py
@@ -4,7 +4,9 @@ does not emit.
 
 Without these, our `process_id_from_resource` formula collapses every Claude
 session onto one process_id (host.id, host.name, process.pid, and
-service.instance.id are all empty in Claude's default Resource).
+service.instance.id are all empty in Claude's default Resource). We also inject
+process.owner so the `processes.username` column is populated — Claude's
+detector does not emit it.
 
 Re-running this script produces a fresh service.instance.id per invocation —
 putting the same export in a shell rc file would not, because $(uuidgen)
@@ -45,6 +47,7 @@ Verbose telemetry:
 Works on Linux, macOS, and Windows (PowerShell or cmd).
 """
 
+import getpass
 import os
 import shutil
 import socket
@@ -67,12 +70,20 @@ def main() -> int:
         verbose = True
         args = [a for a in args if a != VERBOSE_FLAG]
 
-    base_url = os.environ.get("MICROMEGAS_TELEMETRY_URL", "http://localhost:9000").rstrip("/")
+    base_url = os.environ.get(
+        "MICROMEGAS_TELEMETRY_URL", "http://localhost:9000"
+    ).rstrip("/")
     api_key = os.environ.get("MICROMEGAS_INGESTION_API_KEY", "")
 
-    identity_attrs = f"service.instance.id={uuid.uuid4()},host.name={socket.gethostname()}"
+    identity_attrs = (
+        f"service.instance.id={uuid.uuid4()}"
+        f",host.name={socket.gethostname()}"
+        f",process.owner={getpass.getuser()}"
+    )
     existing_attrs = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
-    resource_attrs = f"{identity_attrs},{existing_attrs}" if existing_attrs else identity_attrs
+    resource_attrs = (
+        f"{identity_attrs},{existing_attrs}" if existing_attrs else identity_attrs
+    )
 
     env = os.environ.copy()
     env["OTEL_RESOURCE_ATTRIBUTES"] = resource_attrs
@@ -92,7 +103,11 @@ def main() -> int:
         env["OTEL_LOG_RAW_API_BODIES"] = "1"
         env["OTEL_LOG_TOOL_CONTENT"] = "1"
 
-    claude = shutil.which("claude") or shutil.which("claude.cmd") or shutil.which("claude.exe")
+    claude = (
+        shutil.which("claude")
+        or shutil.which("claude.cmd")
+        or shutil.which("claude.exe")
+    )
     if claude is None:
         print("claude_code_otel.py: 'claude' not found on PATH", file=sys.stderr)
         return 127

--- a/rust/otel-ingestion/src/block.rs
+++ b/rust/otel-ingestion/src/block.rs
@@ -408,16 +408,7 @@ impl ProcessFromResource {
         };
         let exe = truncate_for_db(exe);
 
-        // `process.owner` is the OTel semantic-conventions attribute that process resource
-        // detectors emit for the owning user; `user.name` is a general identity attribute that
-        // nothing populates as a resource attribute by default. Prefer the standard, accept
-        // `user.name` as a fallback for producers that set it explicitly.
-        let username = truncate_for_db(
-            crate::identity::attr(attrs, "process.owner")
-                .or_else(|| crate::identity::attr(attrs, "user.name"))
-                .map(crate::identity::attr_to_string)
-                .unwrap_or_default(),
-        );
+        let username = truncate_for_db(crate::identity::process_owner_string(attrs));
         let computer = truncate_for_db(
             crate::identity::attr(attrs, "host.name")
                 .map(crate::identity::attr_to_string)

--- a/rust/otel-ingestion/src/block.rs
+++ b/rust/otel-ingestion/src/block.rs
@@ -408,8 +408,13 @@ impl ProcessFromResource {
         };
         let exe = truncate_for_db(exe);
 
+        // `process.owner` is the OTel semantic-conventions attribute that process resource
+        // detectors emit for the owning user; `user.name` is a general identity attribute that
+        // nothing populates as a resource attribute by default. Prefer the standard, accept
+        // `user.name` as a fallback for producers that set it explicitly.
         let username = truncate_for_db(
-            crate::identity::attr(attrs, "user.name")
+            crate::identity::attr(attrs, "process.owner")
+                .or_else(|| crate::identity::attr(attrs, "user.name"))
                 .map(crate::identity::attr_to_string)
                 .unwrap_or_default(),
         );

--- a/rust/otel-ingestion/src/identity.rs
+++ b/rust/otel-ingestion/src/identity.rs
@@ -117,6 +117,18 @@ fn attr_raw(attrs: &[KeyValue], key: &str) -> String {
     attr(attrs, key).map(attr_to_string).unwrap_or_default()
 }
 
+/// Resolves the process owner's username.
+///
+/// `process.owner` is the OTel semantic-conventions attribute emitted by process resource
+/// detectors; `user.name` is accepted as a fallback for producers that set it explicitly.
+pub fn process_owner_string(attrs: &[KeyValue]) -> String {
+    let s = attr_raw(attrs, "process.owner");
+    if !s.is_empty() {
+        return s;
+    }
+    attr_raw(attrs, "user.name")
+}
+
 /// Resolves the OTel process-creation timestamp.
 ///
 /// `process.creation.time` is the stable OTel semantic-conventions attribute and is
@@ -142,11 +154,15 @@ pub fn is_degenerate_resource(attrs: &[KeyValue]) -> bool {
 
 /// Derives `process_id` from a resource. Stable for the lifetime of the formula —
 /// shipping a change here requires bumping `NS_OTEL_PROCESS_V1` to `_V2`.
+///
+/// The owner (`process.owner` / `user.name`) is part of the formula: processes are still
+/// new enough that re-deriving ids under the same namespace is acceptable, so this field
+/// was added without a `_V2` bump. Any further change must bump the namespace.
 pub fn process_id_from_resource(resource: Option<&Resource>) -> Uuid {
     let attrs = resource.map(|r| r.attributes.as_slice()).unwrap_or(&[]);
 
     let key = format!(
-        "{host_id}{s}{host_name}{s}{pid}{s}{start}{s}{ns}{s}{name}{s}{instance}",
+        "{host_id}{s}{host_name}{s}{pid}{s}{start}{s}{ns}{s}{name}{s}{instance}{s}{owner}",
         s = SEPARATOR,
         host_id = attr_norm(attrs, "host.id"),
         host_name = attr_norm(attrs, "host.name"),
@@ -155,6 +171,7 @@ pub fn process_id_from_resource(resource: Option<&Resource>) -> Uuid {
         ns = attr_norm(attrs, "service.namespace"),
         name = attr_norm(attrs, "service.name"),
         instance = attr_norm(attrs, "service.instance.id"),
+        owner = norm(&process_owner_string(attrs)),
     );
     Uuid::new_v5(&NS_OTEL_PROCESS_V1, key.as_bytes())
 }

--- a/rust/otel-ingestion/src/identity.rs
+++ b/rust/otel-ingestion/src/identity.rs
@@ -120,13 +120,22 @@ fn attr_raw(attrs: &[KeyValue], key: &str) -> String {
 /// Resolves the process owner's username.
 ///
 /// `process.owner` is the OTel semantic-conventions attribute emitted by process resource
-/// detectors; `user.name` is accepted as a fallback for producers that set it explicitly.
+/// detectors. When it is absent we fall back, in decreasing semantic closeness, to the
+/// process-scoped effective (`process.user.name`) and real (`process.real_user.name`) user
+/// names, then to the generic `user.name` for producers that only set that.
 pub fn process_owner_string(attrs: &[KeyValue]) -> String {
-    let s = attr_raw(attrs, "process.owner");
-    if !s.is_empty() {
-        return s;
+    for key in [
+        "process.owner",
+        "process.user.name",
+        "process.real_user.name",
+        "user.name",
+    ] {
+        let s = attr_raw(attrs, key);
+        if !s.is_empty() {
+            return s;
+        }
     }
-    attr_raw(attrs, "user.name")
+    String::new()
 }
 
 /// Resolves the OTel process-creation timestamp.

--- a/rust/otel-ingestion/tests/block_tests.rs
+++ b/rust/otel-ingestion/tests/block_tests.rs
@@ -95,6 +95,28 @@ fn block_id_changes_when_payload_changes() {
 }
 
 #[test]
+fn username_comes_from_process_owner_with_user_name_fallback() {
+    // Standard OTel process resource detector emits `process.owner`.
+    let p = ProcessFromResource::build(&[s_kv("process.owner", "alice")], Utc::now());
+    assert_eq!(p.username, "alice");
+
+    // `user.name` is accepted as a fallback for producers that set it explicitly.
+    let p = ProcessFromResource::build(&[s_kv("user.name", "bob")], Utc::now());
+    assert_eq!(p.username, "bob");
+
+    // `process.owner` wins when both are present.
+    let p = ProcessFromResource::build(
+        &[s_kv("user.name", "bob"), s_kv("process.owner", "alice")],
+        Utc::now(),
+    );
+    assert_eq!(p.username, "alice");
+
+    // Neither present → empty.
+    let p = ProcessFromResource::build(&[s_kv("service.name", "svc")], Utc::now());
+    assert_eq!(p.username, "");
+}
+
+#[test]
 fn process_field_truncation_caps_at_255_chars_without_splitting_codepoints() {
     // 300 ASCII chars → truncated to 255.
     let long_ascii = "a".repeat(300);

--- a/rust/otel-ingestion/tests/identity_tests.rs
+++ b/rust/otel-ingestion/tests/identity_tests.rs
@@ -58,6 +58,36 @@ fn process_id_differs_per_pid() {
 }
 
 #[test]
+fn process_id_differs_per_owner() {
+    let a = resource_with(&[
+        ("host.name", "h"),
+        ("process.pid", "1"),
+        ("process.owner", "alice"),
+    ]);
+    let b = resource_with(&[
+        ("host.name", "h"),
+        ("process.pid", "1"),
+        ("process.owner", "bob"),
+    ]);
+    assert_ne!(
+        process_id_from_resource(Some(&a)),
+        process_id_from_resource(Some(&b))
+    );
+}
+
+#[test]
+fn process_id_owner_uses_user_name_fallback() {
+    // `process.owner` and `user.name` resolve to the same owner string, so they must
+    // produce the same process_id.
+    let canonical = resource_with(&[("host.name", "h"), ("process.owner", "alice")]);
+    let fallback = resource_with(&[("host.name", "h"), ("user.name", "alice")]);
+    assert_eq!(
+        process_id_from_resource(Some(&canonical)),
+        process_id_from_resource(Some(&fallback))
+    );
+}
+
+#[test]
 fn process_id_normalizes_host_case() {
     let a = resource_with(&[("host.name", "Foo"), ("service.name", "svc")]);
     let b = resource_with(&[("host.name", "FOO"), ("service.name", "svc")]);

--- a/rust/otel-ingestion/tests/identity_tests.rs
+++ b/rust/otel-ingestion/tests/identity_tests.rs
@@ -2,7 +2,8 @@
 
 use micromegas_otel_ingestion::identity::{
     SignalKey, attr_to_string, block_id_from_payload, is_degenerate_resource,
-    process_id_from_resource, process_start_string, stream_id_from_process_signal,
+    process_id_from_resource, process_owner_string, process_start_string,
+    stream_id_from_process_signal,
 };
 use micromegas_otel_ingestion::proto::any_value::Value as AvValue;
 use micromegas_otel_ingestion::proto::{AnyValue, KeyValue, Resource};
@@ -85,6 +86,37 @@ fn process_id_owner_uses_user_name_fallback() {
         process_id_from_resource(Some(&canonical)),
         process_id_from_resource(Some(&fallback))
     );
+}
+
+#[test]
+fn process_owner_prefers_keys_in_priority_order() {
+    // process.owner > process.user.name > process.real_user.name > user.name.
+    let all = resource_with(&[
+        ("process.owner", "owner"),
+        ("process.user.name", "euser"),
+        ("process.real_user.name", "ruser"),
+        ("user.name", "generic"),
+    ]);
+    assert_eq!(process_owner_string(&all.attributes), "owner");
+
+    let no_owner = resource_with(&[
+        ("process.user.name", "euser"),
+        ("process.real_user.name", "ruser"),
+        ("user.name", "generic"),
+    ]);
+    assert_eq!(process_owner_string(&no_owner.attributes), "euser");
+
+    let real_only = resource_with(&[
+        ("process.real_user.name", "ruser"),
+        ("user.name", "generic"),
+    ]);
+    assert_eq!(process_owner_string(&real_only.attributes), "ruser");
+
+    let generic_only = resource_with(&[("user.name", "generic")]);
+    assert_eq!(process_owner_string(&generic_only.attributes), "generic");
+
+    let none = resource_with(&[("host.name", "h")]);
+    assert_eq!(process_owner_string(&none.attributes), "");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Read `process.owner` (with `user.name` as an explicit fallback) to populate the `processes.username` column. The OTel process resource detector populates `process.owner`, while `user.name` is not emitted as a resource attribute by default, so the column was previously left empty for standard SDKs.
- Fold the resolved owner into the `process_id` hash so processes that differ only by their owning user get distinct ids.
- Factor owner resolution into `identity::process_owner_string` so the id formula and the `processes.username` column share one source of truth.
- Re-derivation stays under the existing `NS_OTEL_PROCESS_V1` namespace (no `_V2` bump): adding `{SEPARATOR}{owner}` changes derived ids for existing resources, but processes are still new enough that re-deriving under the same namespace is acceptable.

## Test plan
- `cargo fmt --check` — passes
- `cargo clippy -p micromegas-otel-ingestion --all-targets -- -D warnings` — passes
- `cargo test -p micromegas-otel-ingestion` — passes (30 tests, including new `identity_tests.rs` and `block_tests.rs` cases covering owner resolution and process_id derivation)