### PR TITLE
dev_worker: add --size flag and extend --cleanup to delete cache volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file documents the historical progress of the Micromegas project. For curre
 * **Security:**
   * Upgrade `opentelemetry-proto` to 0.32 to resolve GHSA-w9wp-h8wv-79jx; treat the new profiling-only string-interning fields (`*_strindex`) as absent on non-profiling OTLP signals, per the OTLP spec (#336)
 * **Build:**
+  * Add `dev_worker.py --size` to report the runner container and cache volume sizes, and make `--cleanup` also delete the cache volume
   * Fix `build_blender_plugin.py` artifact lookup when `CARGO_TARGET_DIR` is set; add `x86_64-pc-windows-gnu` to the pinned toolchain so the Windows cross-target installs automatically on fresh checkouts
   * Add Docker Hub publish pipeline for release: `build_docker_images.py` gains an arm64 buildx `--push` path and an `--all-arches` flag that builds both architectures in one run, with `--push` independently controlling publishing; sync the release runbook with a both-arch Docker Images phase (#1165)
   * Make `build.py` the single canonical generator for committed datafusion-wasm bindings; prune known wasm-pack leftovers from the output dir after each build so the copy loop is self-healing; document that `wasm-pack build` must not be run into the output dir (#1169)

--- a/build/dev_worker.py
+++ b/build/dev_worker.py
@@ -242,13 +242,16 @@ def print_sizes():
         capture_output=True,
         text=True,
     )
-    lines = [line for line in result.stdout.splitlines() if line.strip()]
-    if lines:
-        print("Container(s):")
-        for line in lines:
-            print(f"  {line}")
+    if result.returncode != 0:
+        print(f"Container(s): error querying docker: {result.stderr.strip()}")
     else:
-        print("Container(s): none running")
+        lines = [line for line in result.stdout.splitlines() if line.strip()]
+        if lines:
+            print("Container(s):")
+            for line in lines:
+                print(f"  {line}")
+        else:
+            print("Container(s): none running")
 
     volume_size = get_volume_size()
     if volume_size is not None:

--- a/build/dev_worker.py
+++ b/build/dev_worker.py
@@ -207,6 +207,69 @@ def stop_container():
         subprocess.run(["docker", "stop", *ids], capture_output=True)
 
 
+def get_volume_size():
+    """Return the human-readable size of the cache volume, or None if unknown.
+
+    Parses `docker system df -v`, whose VOLUMES section lists each volume's
+    name, link count, and size.
+    """
+    result = subprocess.run(
+        ["docker", "system", "df", "-v"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if fields and fields[0] == CACHE_VOLUME:
+            return fields[-1]
+    return None
+
+
+def print_sizes():
+    """Print the size of the running runner container(s) and the cache volume."""
+    result = subprocess.run(
+        [
+            "docker",
+            "ps",
+            "-s",
+            "--filter",
+            f"label={CONTAINER_LABEL}",
+            "--format",
+            "{{.Names}}: {{.Size}}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    if lines:
+        print("Container(s):")
+        for line in lines:
+            print(f"  {line}")
+    else:
+        print("Container(s): none running")
+
+    volume_size = get_volume_size()
+    if volume_size is not None:
+        print(f"Cache volume ({CACHE_VOLUME}): {volume_size}")
+    else:
+        print(f"Cache volume ({CACHE_VOLUME}): not found")
+
+
+def delete_cache_volume():
+    """Delete the cache volume. No-op if it doesn't exist or is still in use."""
+    result = subprocess.run(
+        ["docker", "volume", "rm", CACHE_VOLUME],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        print(f"Deleted cache volume: {CACHE_VOLUME}")
+    else:
+        print(f"Could not delete cache volume {CACHE_VOLUME}: {result.stderr.strip()}")
+
+
 def cleanup_offline_runners(pat):
     """Remove any offline dev-worker runners from the repository."""
     try:
@@ -280,7 +343,12 @@ def main():
     parser.add_argument(
         "--cleanup",
         action="store_true",
-        help="Remove offline dev-worker runners from GitHub and exit",
+        help="Remove offline dev-worker runners from GitHub, delete the cache volume, and exit",
+    )
+    parser.add_argument(
+        "--size",
+        action="store_true",
+        help="Print the size of the runner container and cache volume, then exit",
     )
     args = parser.parse_args()
 
@@ -288,10 +356,15 @@ def main():
         build_image()
         return
 
+    if args.size:
+        print_sizes()
+        return
+
     pat = get_pat()
 
     if args.cleanup:
         cleanup_offline_runners(pat)
+        delete_cache_volume()
         return
 
     cleanup_offline_runners(pat)


### PR DESCRIPTION
## Summary
- Add `dev_worker.py --size` to print the runner container size(s) and the cache volume size, then exit
- Extend `--cleanup` to delete the cache volume after removing offline GitHub runners
- `print_sizes()` checks the `docker ps -s` return code and surfaces docker's stderr instead of masking a failed query as "none running" (matches the existing guards in `get_volume_size()` and `delete_cache_volume()`)

## Test plan
- `python3 build/dev_worker.py --size` with a runner container running → prints container size(s) and the cache volume size
- `--size` with no container running → prints "Container(s): none running" and the volume size (or "not found")
- Stop the docker daemon and run `--size` → prints "Container(s): error querying docker: ..." rather than "none running"
- `python3 build/dev_worker.py --cleanup` → removes offline runners and deletes the cache volume (no-op message if the volume is in use)