### PR TITLE
transit: arena-based block parsing with near-zero allocations

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3829,6 +3829,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.22.1",
+ "bumpalo",
  "bytes",
  "chrono",
  "ciborium",
@@ -4085,6 +4086,7 @@ name = "micromegas-tracing"
 version = "0.27.0"
 dependencies = [
  "anyhow",
+ "bumpalo",
  "chrono",
  "criterion",
  "futures",
@@ -4123,6 +4125,7 @@ name = "micromegas-transit"
 version = "0.27.0"
 dependencies = [
  "anyhow",
+ "bumpalo",
  "lazy_static",
  "log",
  "memoffset",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -38,6 +38,7 @@ async-stream = "0.3"
 async-trait = "0.1"
 axum = "0.8"
 base64 = "0.22"
+bumpalo = { version = "3", features = ["collections"] }
 bytes = "1.11.1"
 cfg-if = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/rust/analytics/Cargo.toml
+++ b/rust/analytics/Cargo.toml
@@ -22,6 +22,7 @@ arrow-flight.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 base64.workspace = true
+bumpalo.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 ciborium.workspace = true
@@ -52,4 +53,8 @@ criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]
 name = "property_get"
+harness = false
+
+[[bench]]
+name = "parse_block"
 harness = false

--- a/rust/analytics/benches/parse_block.rs
+++ b/rust/analytics/benches/parse_block.rs
@@ -1,0 +1,161 @@
+//! Benchmark for the transit block parse path (`parse_block`).
+//!
+//! Measures per-object parse time for the representative paths:
+//! - `thread_spans`: pure POD objects (`parse_pod_instance`)
+//! - `measures`: POD metric objects (`parse_pod_instance`)
+//! - `log_static`: string-bearing objects (interned `StaticString` dependencies)
+//!
+//! Run with: `cargo bench -p micromegas-analytics --bench parse_block`
+
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use micromegas_analytics::metadata::StreamMetadata;
+use micromegas_analytics::payload::parse_block;
+use micromegas_telemetry::block_wire_format::{Block, BlockPayload};
+use micromegas_telemetry_sink::{stream_block::StreamBlock, stream_info::make_stream_info};
+use micromegas_tracing::dispatch::make_process_info;
+use micromegas_tracing::event::TracingBlock;
+use micromegas_tracing::logs::{LogBlock, LogStaticStrInteropEvent, LogStream};
+use micromegas_tracing::metrics::{
+    IntegerMetricEvent, MetricsBlock, MetricsStream, StaticMetricMetadata,
+};
+use micromegas_tracing::prelude::*;
+use micromegas_tracing::spans::{
+    BeginThreadNamedSpanEvent, SpanLocation, ThreadBlock, ThreadStream,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const N: usize = 4096;
+const BUF: usize = 16 * 1024 * 1024;
+
+fn build_span_block() -> (StreamMetadata, BlockPayload) {
+    let process_id = uuid::Uuid::new_v4();
+    let process_info = make_process_info(process_id, Some(uuid::Uuid::new_v4()), HashMap::new());
+    let mut stream = ThreadStream::new(BUF, process_id, &[], HashMap::new());
+    let stream_id = stream.stream_id();
+    static LOC: SpanLocation = SpanLocation {
+        lod: Verbosity::Med,
+        target: "target",
+        module_path: "module_path",
+        file: "file",
+        line: 123,
+    };
+    for i in 0..N {
+        stream.get_events_mut().push(BeginThreadNamedSpanEvent {
+            thread_span_location: &LOC,
+            name: "my_function".into(),
+            time: i as i64,
+        });
+    }
+    let mut block = stream.replace_block(Arc::new(ThreadBlock::new(BUF, process_id, stream_id, 0)));
+    Arc::get_mut(&mut block).unwrap().close();
+    let encoded = block.encode_bin(&process_info).unwrap();
+    let received: Block = ciborium::from_reader(&encoded[..]).unwrap();
+    let stream_info = make_stream_info(&stream);
+    let meta = StreamMetadata::from_stream_info(&stream_info).unwrap();
+    (meta, received.payload)
+}
+
+fn build_log_block() -> (StreamMetadata, BlockPayload) {
+    let process_id = uuid::Uuid::new_v4();
+    let process_info = make_process_info(process_id, Some(uuid::Uuid::new_v4()), HashMap::new());
+    let mut stream = LogStream::new(BUF, process_id, &[], HashMap::new());
+    let stream_id = stream.stream_id();
+    for i in 0..N {
+        stream.get_events_mut().push(LogStaticStrInteropEvent {
+            time: i as i64,
+            level: 2,
+            target: "target_name".into(),
+            msg: "my log message".into(),
+        });
+    }
+    let mut block = stream.replace_block(Arc::new(LogBlock::new(BUF, process_id, stream_id, 0)));
+    Arc::get_mut(&mut block).unwrap().close();
+    let encoded = block.encode_bin(&process_info).unwrap();
+    let received: Block = ciborium::from_reader(&encoded[..]).unwrap();
+    let stream_info = make_stream_info(&stream);
+    let meta = StreamMetadata::from_stream_info(&stream_info).unwrap();
+    (meta, received.payload)
+}
+
+fn build_metric_block() -> (StreamMetadata, BlockPayload) {
+    let process_id = uuid::Uuid::new_v4();
+    let process_info = make_process_info(process_id, Some(uuid::Uuid::new_v4()), HashMap::new());
+    let mut stream = MetricsStream::new(BUF, process_id, &[], HashMap::new());
+    let stream_id = stream.stream_id();
+    static DESC: StaticMetricMetadata = StaticMetricMetadata {
+        lod: Verbosity::Med,
+        name: "my_metric",
+        unit: "ms",
+        target: "target",
+        file: "file",
+        line: 123,
+    };
+    for i in 0..N {
+        stream.get_events_mut().push(IntegerMetricEvent {
+            desc: &DESC,
+            value: i as u64,
+            time: i as i64,
+        });
+    }
+    let mut block =
+        stream.replace_block(Arc::new(MetricsBlock::new(BUF, process_id, stream_id, 0)));
+    Arc::get_mut(&mut block).unwrap().close();
+    let encoded = block.encode_bin(&process_info).unwrap();
+    let received: Block = ciborium::from_reader(&encoded[..]).unwrap();
+    let stream_info = make_stream_info(&stream);
+    let meta = StreamMetadata::from_stream_info(&stream_info).unwrap();
+    (meta, received.payload)
+}
+
+fn bench_parse(c: &mut Criterion) {
+    let span = build_span_block();
+    let metrics = build_metric_block();
+    let logs = build_log_block();
+    let mut group = c.benchmark_group("parse_block");
+    group.throughput(Throughput::Elements(N as u64));
+
+    group.bench_function("thread_spans", |b| {
+        b.iter(|| {
+            let mut count = 0u64;
+            parse_block(&span.0, &span.1, |v| {
+                black_box(&v);
+                count += 1;
+                Ok(true)
+            })
+            .unwrap();
+            black_box(count);
+        });
+    });
+
+    group.bench_function("measures", |b| {
+        b.iter(|| {
+            let mut count = 0u64;
+            parse_block(&metrics.0, &metrics.1, |v| {
+                black_box(&v);
+                count += 1;
+                Ok(true)
+            })
+            .unwrap();
+            black_box(count);
+        });
+    });
+
+    group.bench_function("log_static", |b| {
+        b.iter(|| {
+            let mut count = 0u64;
+            parse_block(&logs.0, &logs.1, |v| {
+                black_box(&v);
+                count += 1;
+                Ok(true)
+            })
+            .unwrap();
+            black_box(count);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_parse);
+criterion_main!(benches);

--- a/rust/analytics/src/arrow_properties.rs
+++ b/rust/analytics/src/arrow_properties.rs
@@ -65,19 +65,19 @@ pub fn add_properties_to_builder(
 ///
 /// The properties are added as a new entry in the list builder.
 pub fn add_property_set_to_builder(
-    properties: &PropertySet,
+    properties: &PropertySet<'_>,
     property_list_builder: &mut ListBuilder<StructBuilder>,
 ) -> Result<()> {
     let properties_builder = property_list_builder.values();
-    properties.for_each_property(|prop| {
+    properties.for_each_property(|key, value| {
         let key_builder = properties_builder
             .field_builder::<StringBuilder>(0)
             .with_context(|| "getting key field builder")?;
-        key_builder.append_value(prop.key_str());
+        key_builder.append_value(key);
         let value_builder = properties_builder
             .field_builder::<StringBuilder>(1)
             .with_context(|| "getting value field builder")?;
-        value_builder.append_value(prop.value_str());
+        value_builder.append_value(value);
         properties_builder.append(true);
         Ok(())
     })?;
@@ -101,7 +101,7 @@ pub fn add_properties_to_jsonb_builder(
 ///
 /// The properties are converted to JSONB format and added as a new entry in the dictionary builder.
 pub fn add_property_set_to_jsonb_builder(
-    properties: &PropertySet,
+    properties: &PropertySet<'_>,
     jsonb_builder: &mut BinaryDictionaryBuilder<Int32Type>,
 ) -> Result<()> {
     let jsonb_bytes = serialize_property_set_to_jsonb(properties)?;
@@ -113,13 +113,13 @@ pub fn add_property_set_to_jsonb_builder(
 ///
 /// This function converts a PropertySet to JSONB binary format
 /// using the same serialization approach as `add_property_set_to_jsonb_builder`.
-pub fn serialize_property_set_to_jsonb(properties: &PropertySet) -> Result<Vec<u8>> {
+pub fn serialize_property_set_to_jsonb(properties: &PropertySet<'_>) -> Result<Vec<u8>> {
     let mut btree_map = BTreeMap::new();
 
-    properties.for_each_property(|prop| {
+    properties.for_each_property(|key, value| {
         btree_map.insert(
-            prop.key_str().to_string(),
-            Value::String(Cow::Owned(prop.value_str().to_string())),
+            key.to_string(),
+            Value::String(Cow::Owned(value.to_string())),
         );
         Ok(())
     })?;

--- a/rust/analytics/src/async_block_processing.rs
+++ b/rust/analytics/src/async_block_processing.rs
@@ -1,34 +1,33 @@
-use crate::{metadata::StreamMetadata, payload::parse_block, scope::ScopeDesc};
+use crate::{metadata::StreamMetadata, payload::parse_block, scope::BorrowedScopeDesc};
 use anyhow::{Context, Result};
 use micromegas_telemetry::block_wire_format::BlockPayload;
 use micromegas_tracing::prelude::*;
 use micromegas_transit::value::{Object, Value};
-use std::sync::Arc;
 
 /// Helper function to extract async event fields
-fn on_async_event<F>(obj: &Object, mut fun: F) -> Result<bool>
+fn on_async_event<'a, F>(obj: &Object<'a>, mut fun: F) -> Result<bool>
 where
-    F: FnMut(Arc<Object>, u64, u64, u32, i64) -> Result<bool>,
+    F: FnMut(&'a Object<'a>, u64, u64, u32, i64) -> Result<bool>,
 {
     let span_id = obj.get::<u64>("span_id")?;
     let parent_span_id = obj.get::<u64>("parent_span_id")?;
     let depth = obj.get::<u32>("depth")?;
     let time = obj.get::<i64>("time")?;
-    let span_desc = obj.get::<Arc<Object>>("span_desc")?;
+    let span_desc = obj.get::<&Object>("span_desc")?;
     fun(span_desc, span_id, parent_span_id, depth, time)
 }
 
 /// Helper function to extract async named event fields
-fn on_async_named_event<F>(obj: &Object, mut fun: F) -> Result<bool>
+fn on_async_named_event<'a, F>(obj: &Object<'a>, mut fun: F) -> Result<bool>
 where
-    F: FnMut(Arc<Object>, Arc<String>, u64, u64, u32, i64) -> Result<bool>,
+    F: FnMut(&'a Object<'a>, &'a str, u64, u64, u32, i64) -> Result<bool>,
 {
     let span_id = obj.get::<u64>("span_id")?;
     let parent_span_id = obj.get::<u64>("parent_span_id")?;
     let depth = obj.get::<u32>("depth")?;
     let time = obj.get::<i64>("time")?;
-    let span_location = obj.get::<Arc<Object>>("span_location")?;
-    let name = obj.get::<Arc<String>>("name")?;
+    let span_location = obj.get::<&Object>("span_location")?;
+    let name = obj.get::<&str>("name")?;
     fun(span_location, name, span_id, parent_span_id, depth, time)
 }
 
@@ -37,7 +36,7 @@ pub trait AsyncBlockProcessor {
     fn on_begin_async_scope(
         &mut self,
         block_id: &str,
-        scope: ScopeDesc,
+        scope: BorrowedScopeDesc<'_>,
         ts: i64,
         span_id: i64,
         parent_span_id: i64,
@@ -46,7 +45,7 @@ pub trait AsyncBlockProcessor {
     fn on_end_async_scope(
         &mut self,
         block_id: &str,
-        scope: ScopeDesc,
+        scope: BorrowedScopeDesc<'_>,
         ts: i64,
         span_id: i64,
         parent_span_id: i64,
@@ -65,14 +64,14 @@ pub fn parse_async_block_payload<Proc: AsyncBlockProcessor>(
 ) -> Result<bool> {
     parse_block(stream, payload, |val| {
         if let Value::Object(obj) = val {
-            match obj.type_name.as_str() {
+            match obj.type_name {
                 "BeginAsyncSpanEvent" => {
-                    on_async_event(&obj, |span_desc, span_id, parent_span_id, depth, ts| {
-                        let name = span_desc.get::<Arc<String>>("name")?;
-                        let filename = span_desc.get::<Arc<String>>("file")?;
-                        let target = span_desc.get::<Arc<String>>("target")?;
+                    on_async_event(obj, |span_desc, span_id, parent_span_id, depth, ts| {
+                        let name = span_desc.get::<&str>("name")?;
+                        let filename = span_desc.get::<&str>("file")?;
+                        let target = span_desc.get::<&str>("target")?;
                         let line = span_desc.get::<u32>("line")?;
-                        let scope_desc = ScopeDesc::new(name, filename, target, line);
+                        let scope_desc = BorrowedScopeDesc::new(name, filename, target, line);
                         processor.on_begin_async_scope(
                             block_id,
                             scope_desc,
@@ -85,12 +84,12 @@ pub fn parse_async_block_payload<Proc: AsyncBlockProcessor>(
                     .with_context(|| "reading BeginAsyncSpanEvent")
                 }
                 "EndAsyncSpanEvent" => {
-                    on_async_event(&obj, |span_desc, span_id, parent_span_id, depth, ts| {
-                        let name = span_desc.get::<Arc<String>>("name")?;
-                        let filename = span_desc.get::<Arc<String>>("file")?;
-                        let target = span_desc.get::<Arc<String>>("target")?;
+                    on_async_event(obj, |span_desc, span_id, parent_span_id, depth, ts| {
+                        let name = span_desc.get::<&str>("name")?;
+                        let filename = span_desc.get::<&str>("file")?;
+                        let target = span_desc.get::<&str>("target")?;
                         let line = span_desc.get::<u32>("line")?;
-                        let scope_desc = ScopeDesc::new(name, filename, target, line);
+                        let scope_desc = BorrowedScopeDesc::new(name, filename, target, line);
                         processor.on_end_async_scope(
                             block_id,
                             scope_desc,
@@ -103,12 +102,12 @@ pub fn parse_async_block_payload<Proc: AsyncBlockProcessor>(
                     .with_context(|| "reading EndAsyncSpanEvent")
                 }
                 "BeginAsyncNamedSpanEvent" => on_async_named_event(
-                    &obj,
+                    obj,
                     |span_location, name, span_id, parent_span_id, depth, ts| {
-                        let filename = span_location.get::<Arc<String>>("file")?;
-                        let target = span_location.get::<Arc<String>>("target")?;
+                        let filename = span_location.get::<&str>("file")?;
+                        let target = span_location.get::<&str>("target")?;
                         let line = span_location.get::<u32>("line")?;
-                        let scope_desc = ScopeDesc::new(name, filename, target, line);
+                        let scope_desc = BorrowedScopeDesc::new(name, filename, target, line);
                         processor.on_begin_async_scope(
                             block_id,
                             scope_desc,
@@ -121,12 +120,12 @@ pub fn parse_async_block_payload<Proc: AsyncBlockProcessor>(
                 )
                 .with_context(|| "reading BeginAsyncNamedSpanEvent"),
                 "EndAsyncNamedSpanEvent" => on_async_named_event(
-                    &obj,
+                    obj,
                     |span_location, name, span_id, parent_span_id, depth, ts| {
-                        let filename = span_location.get::<Arc<String>>("file")?;
-                        let target = span_location.get::<Arc<String>>("target")?;
+                        let filename = span_location.get::<&str>("file")?;
+                        let target = span_location.get::<&str>("target")?;
                         let line = span_location.get::<u32>("line")?;
-                        let scope_desc = ScopeDesc::new(name, filename, target, line);
+                        let scope_desc = BorrowedScopeDesc::new(name, filename, target, line);
                         processor.on_end_async_scope(
                             block_id,
                             scope_desc,

--- a/rust/analytics/src/async_events_table.rs
+++ b/rust/analytics/src/async_events_table.rs
@@ -19,19 +19,22 @@ use crate::time::TimeRange;
 
 /// Represents a single async span event record.
 /// Optimized for high-frequency data - process info can be joined when needed.
+///
+/// `name`/`filename`/`target` borrow the per-block parse arena; the record is
+/// appended to Arrow (which copies the strings) within the parse callback.
 #[derive(Debug, Clone)]
-pub struct AsyncEventRecord {
+pub struct AsyncEventRecord<'a> {
     pub stream_id: Arc<String>,
     pub block_id: Arc<String>,
     pub time: i64,
-    pub event_type: Arc<String>,
+    pub event_type: &'static str,
     pub span_id: i64,
     pub parent_span_id: i64,
     pub depth: u32,
     pub hash: u32,
-    pub name: Arc<String>,
-    pub filename: Arc<String>,
-    pub target: Arc<String>,
+    pub name: &'a str,
+    pub filename: &'a str,
+    pub target: &'a str,
     pub line: u32,
 }
 
@@ -136,18 +139,18 @@ impl AsyncEventRecordBuilder {
         self.times.len() == 0
     }
 
-    pub fn append(&mut self, record: &AsyncEventRecord) -> Result<()> {
+    pub fn append(&mut self, record: &AsyncEventRecord<'_>) -> Result<()> {
         self.stream_ids.append_value(&*record.stream_id);
         self.block_ids.append_value(&*record.block_id);
         self.times.append_value(record.time);
-        self.event_types.append_value(&*record.event_type);
+        self.event_types.append_value(record.event_type);
         self.span_ids.append_value(record.span_id);
         self.parent_span_ids.append_value(record.parent_span_id);
         self.depths.append_value(record.depth);
         self.hashes.append_value(record.hash);
-        self.names.append_value(&*record.name);
-        self.filenames.append_value(&*record.filename);
-        self.targets.append_value(&*record.target);
+        self.names.append_value(record.name);
+        self.filenames.append_value(record.filename);
+        self.targets.append_value(record.target);
         self.lines.append_value(record.line);
         Ok(())
     }

--- a/rust/analytics/src/call_tree.rs
+++ b/rust/analytics/src/call_tree.rs
@@ -1,4 +1,5 @@
 use crate::metadata::{StreamMetadata, get_thread_name_from_stream_metadata};
+use crate::scope::BorrowedScopeDesc;
 use crate::scope::ScopeDesc;
 use crate::scope::ScopeHashMap;
 use crate::thread_block_processor::ThreadBlockProcessor;
@@ -114,10 +115,12 @@ impl CallTreeBuilder {
         }
     }
 
-    fn record_scope_desc(&mut self, scope_desc: ScopeDesc) {
+    fn record_scope_desc(&mut self, scope_desc: BorrowedScopeDesc<'_>) {
+        // Own the scope strings only on first encounter (once per distinct scope),
+        // not per event — the borrowed scope comes from the per-block arena.
         self.scopes
             .entry(scope_desc.hash)
-            .or_insert_with(|| scope_desc);
+            .or_insert_with(|| scope_desc.to_owned());
     }
 }
 
@@ -126,7 +129,7 @@ impl ThreadBlockProcessor for CallTreeBuilder {
         &mut self,
         _block_id: &str,
         event_id: i64,
-        scope: ScopeDesc,
+        scope: BorrowedScopeDesc<'_>,
         ts: i64,
     ) -> Result<bool> {
         if self.limit.is_some() && self.nb_spans >= self.limit.unwrap() {
@@ -157,7 +160,7 @@ impl ThreadBlockProcessor for CallTreeBuilder {
         &mut self,
         _block_id: &str,
         event_id: i64,
-        scope: ScopeDesc,
+        scope: BorrowedScopeDesc<'_>,
         ts: i64,
     ) -> Result<bool> {
         let time = self.convert_ticks.ticks_to_nanoseconds(ts);

--- a/rust/analytics/src/lakehouse/async_events_block_processor.rs
+++ b/rust/analytics/src/lakehouse/async_events_block_processor.rs
@@ -6,7 +6,7 @@ use crate::{
     async_block_processing::{AsyncBlockProcessor, parse_async_block_payload},
     async_events_table::{AsyncEventRecord, AsyncEventRecordBuilder},
     payload::fetch_block_payload,
-    scope::ScopeDesc,
+    scope::BorrowedScopeDesc,
     time::ConvertTicks,
 };
 use anyhow::{Context, Result};
@@ -15,10 +15,8 @@ use micromegas_telemetry::blob_storage::BlobStorage;
 use micromegas_tracing::prelude::*;
 use std::sync::Arc;
 
-lazy_static::lazy_static! {
-    static ref BEGIN_EVENT_TYPE: Arc<String> = Arc::new("begin".to_string());
-    static ref END_EVENT_TYPE: Arc<String> = Arc::new("end".to_string());
-}
+const BEGIN_EVENT_TYPE: &str = "begin";
+const END_EVENT_TYPE: &str = "end";
 
 /// A `BlockProcessor` implementation for processing async event blocks.
 #[derive(Debug)]
@@ -60,7 +58,7 @@ impl AsyncBlockProcessor for AsyncEventCollector {
     fn on_begin_async_scope(
         &mut self,
         _block_id: &str,
-        scope: ScopeDesc,
+        scope: BorrowedScopeDesc<'_>,
         ts: i64,
         span_id: i64,
         parent_span_id: i64,
@@ -71,7 +69,7 @@ impl AsyncBlockProcessor for AsyncEventCollector {
             stream_id: self.stream_id.clone(),
             block_id: self.block_id.clone(),
             time: time_ns,
-            event_type: BEGIN_EVENT_TYPE.clone(),
+            event_type: BEGIN_EVENT_TYPE,
             span_id,
             parent_span_id,
             depth,
@@ -88,7 +86,7 @@ impl AsyncBlockProcessor for AsyncEventCollector {
     fn on_end_async_scope(
         &mut self,
         _block_id: &str,
-        scope: ScopeDesc,
+        scope: BorrowedScopeDesc<'_>,
         ts: i64,
         span_id: i64,
         parent_span_id: i64,
@@ -99,7 +97,7 @@ impl AsyncBlockProcessor for AsyncEventCollector {
             stream_id: self.stream_id.clone(),
             block_id: self.block_id.clone(),
             time: time_ns,
-            event_type: END_EVENT_TYPE.clone(),
+            event_type: END_EVENT_TYPE,
             span_id,
             parent_span_id,
             depth,

--- a/rust/analytics/src/lakehouse/image_block_processor.rs
+++ b/rust/analytics/src/lakehouse/image_block_processor.rs
@@ -48,19 +48,15 @@ impl BlockProcessor for ImageBlockProcessor {
         let mut record_builder = ImagesRecordBuilder::new();
 
         parse_block(&src_block.stream, &payload, |val| {
-            if let Value::Object(obj) = &val
-                && obj.type_name.as_str() == "ImageEvent"
+            if let Value::Object(obj) = val
+                && obj.type_name == "ImageEvent"
             {
                 let ticks = obj.get::<i64>("time").with_context(|| "reading time")?;
-                let name = obj
-                    .get::<Arc<String>>("name")
-                    .with_context(|| "reading name")?;
+                let name = obj.get::<&str>("name").with_context(|| "reading name")?;
                 let format = obj
-                    .get::<Arc<String>>("format")
+                    .get::<&str>("format")
                     .with_context(|| "reading format")?;
-                let image_data = obj
-                    .get::<Arc<Vec<u8>>>("data")
-                    .with_context(|| "reading data")?;
+                let image_data = obj.get::<&[u8]>("data").with_context(|| "reading data")?;
                 let time_ns = convert_ticks.ticks_to_nanoseconds(ticks);
                 let payload_size = image_data.len() as i64;
                 record_builder.append(
@@ -70,10 +66,10 @@ impl BlockProcessor for ImageBlockProcessor {
                     &block_id_str,
                     insert_time_nanos,
                     time_ns,
-                    &name,
-                    &format,
+                    name,
+                    format,
                     payload_size,
-                    &image_data,
+                    image_data,
                 )?;
             }
             Ok(true)

--- a/rust/analytics/src/lakehouse/parse_block_table_function.rs
+++ b/rust/analytics/src/lakehouse/parse_block_table_function.rs
@@ -43,25 +43,25 @@ fn output_schema() -> SchemaRef {
 }
 
 /// Converts a `transit::Value` to a `jsonb::Value`.
-pub fn transit_value_to_jsonb(value: &TransitValue) -> JsonbValue<'_> {
+pub fn transit_value_to_jsonb(value: TransitValue<'_>) -> JsonbValue<'_> {
     match value {
-        TransitValue::String(s) => JsonbValue::String(Cow::Borrowed(s.as_str())),
+        TransitValue::String(s) => JsonbValue::String(Cow::Borrowed(s)),
         TransitValue::Object(obj) => {
             let mut map = BTreeMap::new();
             map.insert(
                 "__type".to_string(),
-                JsonbValue::String(Cow::Borrowed(obj.type_name.as_str())),
+                JsonbValue::String(Cow::Borrowed(obj.type_name)),
             );
-            for (name, val) in &obj.members {
-                map.insert(name.as_ref().clone(), transit_value_to_jsonb(val));
+            for &(name, val) in obj.members {
+                map.insert(name.to_string(), transit_value_to_jsonb(val));
             }
             JsonbValue::Object(map)
         }
-        TransitValue::U8(v) => JsonbValue::Number(jsonb::Number::UInt64(u64::from(*v))),
-        TransitValue::U32(v) => JsonbValue::Number(jsonb::Number::UInt64(u64::from(*v))),
-        TransitValue::U64(v) => JsonbValue::Number(jsonb::Number::UInt64(*v)),
-        TransitValue::I64(v) => JsonbValue::Number(jsonb::Number::Int64(*v)),
-        TransitValue::F64(v) => JsonbValue::Number(jsonb::Number::Float64(*v)),
+        TransitValue::U8(v) => JsonbValue::Number(jsonb::Number::UInt64(u64::from(v))),
+        TransitValue::U32(v) => JsonbValue::Number(jsonb::Number::UInt64(u64::from(v))),
+        TransitValue::U64(v) => JsonbValue::Number(jsonb::Number::UInt64(v)),
+        TransitValue::I64(v) => JsonbValue::Number(jsonb::Number::Int64(v)),
+        TransitValue::F64(v) => JsonbValue::Number(jsonb::Number::Float64(v)),
         TransitValue::None => JsonbValue::Null,
         TransitValue::Bytes(b) => {
             JsonbValue::String(Cow::Owned(format!("<binary {} bytes>", b.len())))
@@ -168,13 +168,13 @@ fn parse_block_objects(
     let mut nb_objects: usize = 0;
 
     parse_block(stream_metadata, payload, |value| {
-        if let TransitValue::Object(obj) = &value {
-            let jsonb_val = transit_value_to_jsonb(&value);
+        if let TransitValue::Object(obj) = value {
+            let jsonb_val = transit_value_to_jsonb(value);
             let mut buf = Vec::new();
             jsonb_val.write_to_vec(&mut buf);
 
             index_builder.append_value(object_offset + local_index);
-            name_builder.append_value(obj.type_name.as_ref());
+            name_builder.append_value(obj.type_name);
             value_builder.append_value(&buf);
             nb_objects += 1;
         } else {

--- a/rust/analytics/src/log_entries_table.rs
+++ b/rust/analytics/src/log_entries_table.rs
@@ -150,9 +150,9 @@ impl LogEntriesRecordBuilder {
         self.usernames.append_value(&row.process.username);
         self.computers.append_value(&row.process.computer);
         self.times.append_value(row.time);
-        self.targets.append_value(&*row.target);
+        self.targets.append_value(row.target);
         self.levels.append_value(row.level);
-        self.msgs.append_value(&*row.msg);
+        self.msgs.append_value(row.msg);
         self.properties.append_property_set(&row.properties)?;
         self.process_properties
             .append_value(&*row.process.properties);
@@ -163,9 +163,9 @@ impl LogEntriesRecordBuilder {
     pub fn append_entry_only(&mut self, row: &LogEntry) -> Result<()> {
         // Only append fields that truly vary per log entry
         self.times.append_value(row.time);
-        self.targets.append_value(&*row.target);
+        self.targets.append_value(row.target);
         self.levels.append_value(row.level);
-        self.msgs.append_value(&*row.msg);
+        self.msgs.append_value(row.msg);
         self.properties.append_property_set(&row.properties)?;
         Ok(())
     }

--- a/rust/analytics/src/log_entry.rs
+++ b/rust/analytics/src/log_entry.rs
@@ -11,46 +11,50 @@ use micromegas_transit::value::{Object, Value};
 use std::sync::Arc;
 
 /// A single log entry.
+///
+/// String fields borrow the per-block parse arena, so a `LogEntry` is valid only
+/// within the `parse_block` callback that produced it; it must be appended to
+/// Arrow (which copies the bytes) before the arena is dropped.
 #[derive(Debug)]
-pub struct LogEntry {
+pub struct LogEntry<'a> {
     pub process: Arc<ProcessMetadata>,
     pub stream_id: Arc<String>,
     pub block_id: Arc<String>,
     pub insert_time: i64,
     pub time: i64,
     pub level: i32,
-    pub target: Arc<String>,
-    pub msg: Arc<String>,
-    pub properties: PropertySet,
+    pub target: &'a str,
+    pub msg: &'a str,
+    pub properties: PropertySet<'a>,
 }
 
 /// Creates a `LogEntry` from a `Value`.
 #[span_fn]
-pub fn log_entry_from_value(
+pub fn log_entry_from_value<'a>(
     convert_ticks: &ConvertTicks,
     process: Arc<ProcessMetadata>,
     stream_id: Arc<String>,
     block_id: Arc<String>,
     block_insert_time_ns: i64,
-    val: &Value,
-) -> Result<Option<LogEntry>> {
+    val: Value<'a>,
+) -> Result<Option<LogEntry<'a>>> {
     if let Value::Object(obj) = val {
-        match obj.type_name.as_str() {
+        match obj.type_name {
             "LogStaticStrEvent" => {
                 let ticks = obj
                     .get::<i64>("time")
                     .with_context(|| "reading time from LogStaticStrEvent")?;
                 let desc = obj
-                    .get::<Arc<Object>>("desc")
+                    .get::<&Object>("desc")
                     .with_context(|| "reading desc from LogStaticStrEvent")?;
                 let level = desc
                     .get::<u32>("level")
                     .with_context(|| "reading level from LogStaticStrEvent")?;
                 let target = desc
-                    .get::<Arc<String>>("target")
+                    .get::<&str>("target")
                     .with_context(|| "reading target from LogStaticStrEvent")?;
                 let msg = desc
-                    .get::<Arc<String>>("fmt_str")
+                    .get::<&str>("fmt_str")
                     .with_context(|| "reading fmt_str from LogStaticStrEvent")?;
                 Ok(Some(LogEntry {
                     process,
@@ -69,16 +73,16 @@ pub fn log_entry_from_value(
                     .get::<i64>("time")
                     .with_context(|| "reading time from LogStringEvent")?;
                 let desc = obj
-                    .get::<Arc<Object>>("desc")
+                    .get::<&Object>("desc")
                     .with_context(|| "reading desc from LogStringEvent")?;
                 let level = desc
                     .get::<u32>("level")
                     .with_context(|| "reading level from LogStringEvent")?;
                 let target = desc
-                    .get::<Arc<String>>("target")
+                    .get::<&str>("target")
                     .with_context(|| "reading target from LogStringEvent")?;
                 let msg = obj
-                    .get::<Arc<String>>("msg")
+                    .get::<&str>("msg")
                     .with_context(|| "reading msg from LogStringEvent")?;
                 Ok(Some(LogEntry {
                     process,
@@ -95,16 +99,16 @@ pub fn log_entry_from_value(
             "LogStaticStrInteropEvent" | "LogStringInteropEventV2" | "LogStringInteropEventV3" => {
                 let ticks = obj
                     .get::<i64>("time")
-                    .with_context(|| format!("reading time from {}", obj.type_name.as_str()))?;
+                    .with_context(|| format!("reading time from {}", obj.type_name))?;
                 let level = obj
                     .get::<u32>("level")
-                    .with_context(|| format!("reading level from {}", obj.type_name.as_str()))?;
+                    .with_context(|| format!("reading level from {}", obj.type_name))?;
                 let target = obj
-                    .get::<Arc<String>>("target")
-                    .with_context(|| format!("reading target from {}", obj.type_name.as_str()))?;
+                    .get::<&str>("target")
+                    .with_context(|| format!("reading target from {}", obj.type_name))?;
                 let msg = obj
-                    .get::<Arc<String>>("msg")
-                    .with_context(|| format!("reading msg from {}", obj.type_name.as_str()))?;
+                    .get::<&str>("msg")
+                    .with_context(|| format!("reading msg from {}", obj.type_name))?;
                 Ok(Some(LogEntry {
                     process,
                     stream_id,
@@ -120,19 +124,19 @@ pub fn log_entry_from_value(
             "TaggedLogInteropEvent" => {
                 let ticks = obj
                     .get::<i64>("time")
-                    .with_context(|| format!("reading time from {}", obj.type_name.as_str()))?;
+                    .with_context(|| format!("reading time from {}", obj.type_name))?;
                 let level = obj
                     .get::<u32>("level")
-                    .with_context(|| format!("reading level from {}", obj.type_name.as_str()))?;
+                    .with_context(|| format!("reading level from {}", obj.type_name))?;
                 let target = obj
-                    .get::<Arc<String>>("target")
-                    .with_context(|| format!("reading target from {}", obj.type_name.as_str()))?;
+                    .get::<&str>("target")
+                    .with_context(|| format!("reading target from {}", obj.type_name))?;
                 let msg = obj
-                    .get::<Arc<String>>("msg")
-                    .with_context(|| format!("reading msg from {}", obj.type_name.as_str()))?;
-                let properties = obj.get::<Arc<Object>>("properties").with_context(|| {
-                    format!("reading properties from {}", obj.type_name.as_str())
-                })?;
+                    .get::<&str>("msg")
+                    .with_context(|| format!("reading msg from {}", obj.type_name))?;
+                let properties = obj
+                    .get::<&Object>("properties")
+                    .with_context(|| format!("reading properties from {}", obj.type_name))?;
                 let time = convert_ticks.ticks_to_nanoseconds(ticks);
                 Ok(Some(LogEntry {
                     process,
@@ -149,32 +153,32 @@ pub fn log_entry_from_value(
             "TaggedLogString" => {
                 let ticks = obj
                     .get::<i64>("time")
-                    .with_context(|| format!("reading time from {}", obj.type_name.as_str()))?;
+                    .with_context(|| format!("reading time from {}", obj.type_name))?;
                 let msg = obj
-                    .get::<Arc<String>>("msg")
-                    .with_context(|| format!("reading msg from {}", obj.type_name.as_str()))?;
+                    .get::<&str>("msg")
+                    .with_context(|| format!("reading msg from {}", obj.type_name))?;
                 let desc = obj
-                    .get::<Arc<Object>>("desc")
-                    .with_context(|| format!("reading desc from {}", obj.type_name.as_str()))?;
+                    .get::<&Object>("desc")
+                    .with_context(|| format!("reading desc from {}", obj.type_name))?;
                 let mut level = desc
                     .get::<u32>("level")
-                    .with_context(|| format!("reading level from {}", obj.type_name.as_str()))?;
+                    .with_context(|| format!("reading level from {}", obj.type_name))?;
                 let mut target = desc
-                    .get::<Arc<String>>("target")
-                    .with_context(|| format!("reading target from {}", obj.type_name.as_str()))?;
-                let properties = obj.get::<Arc<Object>>("properties").with_context(|| {
-                    format!("reading properties from {}", obj.type_name.as_str())
-                })?;
-                for (prop_name, prop_value) in &properties.members {
-                    match (prop_name.as_str(), prop_value) {
+                    .get::<&str>("target")
+                    .with_context(|| format!("reading target from {}", obj.type_name))?;
+                let properties = obj
+                    .get::<&Object>("properties")
+                    .with_context(|| format!("reading properties from {}", obj.type_name))?;
+                for &(prop_name, prop_value) in properties.members {
+                    match (prop_name, prop_value) {
                         ("target", Value::String(value_str)) => {
-                            target = value_str.clone();
+                            target = value_str;
                         }
                         ("level", Value::String(level_str)) => {
                             level = Level::parse(level_str).with_context(|| "parsing log level")?
                                 as u32;
                         }
-                        (&_, _) => {}
+                        (_, _) => {}
                     }
                 }
                 Ok(Some(LogEntry {
@@ -202,14 +206,17 @@ pub fn log_entry_from_value(
 
 /// Iterates over all log entries in a block.
 #[span_fn]
-pub async fn for_each_log_entry_in_block<Predicate: FnMut(LogEntry) -> Result<bool>>(
+pub async fn for_each_log_entry_in_block<Predicate>(
     blob_storage: Arc<BlobStorage>,
     convert_ticks: &ConvertTicks,
     process: Arc<ProcessMetadata>,
     stream: &StreamMetadata,
     block: &BlockMetadata,
     mut fun: Predicate,
-) -> Result<bool> {
+) -> Result<bool>
+where
+    Predicate: for<'a> FnMut(LogEntry<'a>) -> Result<bool>,
+{
     let payload = fetch_block_payload(
         blob_storage,
         stream.process_id,
@@ -227,7 +234,7 @@ pub async fn for_each_log_entry_in_block<Predicate: FnMut(LogEntry) -> Result<bo
             stream_id.clone(),
             block_id.clone(),
             block_insert_time_ns,
-            &val,
+            val,
         )
         .with_context(|| "log_entry_from_value")?
             && !fun(log_entry)?

--- a/rust/analytics/src/measure.rs
+++ b/rust/analytics/src/measure.rs
@@ -10,31 +10,36 @@ use micromegas_tracing::prelude::*;
 use micromegas_transit::value::{Object, Value};
 use std::sync::Arc;
 
+/// Unit substituted for integer "ticks" metrics once converted to seconds.
+const SECONDS_METRIC_UNIT: &str = "seconds";
+
 /// Represents a single metric measurement.
-pub struct Measure {
+///
+/// String fields borrow the per-block parse arena (see [`crate::log_entry::LogEntry`]).
+pub struct Measure<'a> {
     pub process: Arc<ProcessMetadata>,
     pub stream_id: Arc<String>,
     pub block_id: Arc<String>,
     pub insert_time: i64, // nanoseconds
     pub time: i64,        // nanoseconds
-    pub target: Arc<String>,
-    pub name: Arc<String>,
-    pub unit: Arc<String>,
+    pub target: &'a str,
+    pub name: &'a str,
+    pub unit: &'a str,
     pub value: f64,
-    pub properties: PropertySet,
+    pub properties: PropertySet<'a>,
 }
 
 /// Creates a `Measure` from a `Value`.
-pub fn measure_from_value(
+pub fn measure_from_value<'a>(
     process: Arc<ProcessMetadata>,
     stream_id: Arc<String>,
     block_id: Arc<String>,
     block_insert_time_ns: i64,
     convert_ticks: &ConvertTicks,
-    val: &Value,
-) -> Result<Option<Measure>> {
+    val: Value<'a>,
+) -> Result<Option<Measure<'a>>> {
     if let Value::Object(obj) = val {
-        match obj.type_name.as_str() {
+        match obj.type_name {
             "FloatMetricEvent" => {
                 let ticks = obj
                     .get::<i64>("time")
@@ -43,16 +48,16 @@ pub fn measure_from_value(
                     .get::<f64>("value")
                     .with_context(|| "reading value from FloatMetricEvent")?;
                 let desc = obj
-                    .get::<Arc<Object>>("desc")
+                    .get::<&Object>("desc")
                     .with_context(|| "reading desc from FloatMetricEvent")?;
                 let target = desc
-                    .get::<Arc<String>>("target")
+                    .get::<&str>("target")
                     .with_context(|| "reading target from FloatMetricEvent")?;
                 let name = desc
-                    .get::<Arc<String>>("name")
+                    .get::<&str>("name")
                     .with_context(|| "reading name from FloatMetricEvent")?;
                 let unit = desc
-                    .get::<Arc<String>>("unit")
+                    .get::<&str>("unit")
                     .with_context(|| "reading unit from FloatMetricEvent")?;
                 Ok(Some(Measure {
                     process,
@@ -76,21 +81,18 @@ pub fn measure_from_value(
                     .get::<u64>("value")
                     .with_context(|| "reading value from IntegerMetricEvent")?;
                 let desc = obj
-                    .get::<Arc<Object>>("desc")
+                    .get::<&Object>("desc")
                     .with_context(|| "reading desc from IntegerMetricEvent")?;
                 let target = desc
-                    .get::<Arc<String>>("target")
+                    .get::<&str>("target")
                     .with_context(|| "reading target from IntegerMetricEvent")?;
                 let name = desc
-                    .get::<Arc<String>>("name")
+                    .get::<&str>("name")
                     .with_context(|| "reading name from IntegerMetricEvent")?;
                 let unit = desc
-                    .get::<Arc<String>>("unit")
+                    .get::<&str>("unit")
                     .with_context(|| "reading unit from IntegerMetricEvent")?;
-                if *unit == "ticks" {
-                    lazy_static::lazy_static! {
-                        static ref SECONDS_METRIC_UNIT: Arc<String> = Arc::new( String::from("seconds"));
-                    }
+                if unit == "ticks" {
                     Ok(Some(Measure {
                         process,
                         stream_id,
@@ -99,7 +101,7 @@ pub fn measure_from_value(
                         time,
                         target,
                         name,
-                        unit: SECONDS_METRIC_UNIT.clone(),
+                        unit: SECONDS_METRIC_UNIT,
                         value: convert_ticks.delta_ticks_to_ms(value as i64) / 1000.0,
                         properties: PropertySet::empty(),
                     }))
@@ -127,39 +129,36 @@ pub fn measure_from_value(
                     .get::<u64>("value")
                     .with_context(|| "reading value from TaggedIntegerMetricEvent")?;
                 let desc = obj
-                    .get::<Arc<Object>>("desc")
+                    .get::<&Object>("desc")
                     .with_context(|| "reading desc from IntegerMetricEvent")?;
                 let mut target = desc
-                    .get::<Arc<String>>("target")
+                    .get::<&str>("target")
                     .with_context(|| "reading target from IntegerMetricEvent")?;
                 let mut name = desc
-                    .get::<Arc<String>>("name")
+                    .get::<&str>("name")
                     .with_context(|| "reading name from IntegerMetricEvent")?;
                 let mut unit = desc
-                    .get::<Arc<String>>("unit")
+                    .get::<&str>("unit")
                     .with_context(|| "reading unit from IntegerMetricEvent")?;
                 let properties = obj
-                    .get::<Arc<Object>>("properties")
+                    .get::<&Object>("properties")
                     .with_context(|| "reading properties from TaggedIntegerMetricEvent")?;
-                for (prop_name, prop_value) in &properties.members {
-                    match (prop_name.as_str(), prop_value) {
+                for &(prop_name, prop_value) in properties.members {
+                    match (prop_name, prop_value) {
                         ("target", Value::String(value_str)) => {
-                            target = value_str.clone();
+                            target = value_str;
                         }
                         ("name", Value::String(value_str)) => {
-                            name = value_str.clone();
+                            name = value_str;
                         }
                         ("unit", Value::String(value_str)) => {
-                            unit = value_str.clone();
+                            unit = value_str;
                         }
-                        (&_, _) => {}
+                        (_, _) => {}
                     }
                 }
 
-                if *unit == "ticks" {
-                    lazy_static::lazy_static! {
-                        static ref SECONDS_METRIC_UNIT: Arc<String> = Arc::new( String::from("seconds"));
-                    }
+                if unit == "ticks" {
                     Ok(Some(Measure {
                         process,
                         stream_id,
@@ -168,7 +167,7 @@ pub fn measure_from_value(
                         time,
                         target,
                         name,
-                        unit: SECONDS_METRIC_UNIT.clone(),
+                        unit: SECONDS_METRIC_UNIT,
                         value: convert_ticks.delta_ticks_to_ms(value as i64) / 1000.0,
                         properties: properties.into(),
                     }))
@@ -196,32 +195,32 @@ pub fn measure_from_value(
                     .get::<f64>("value")
                     .with_context(|| "reading value from TaggedFloatMetricEvent")?;
                 let desc = obj
-                    .get::<Arc<Object>>("desc")
+                    .get::<&Object>("desc")
                     .with_context(|| "reading desc from TaggedFloatMetricEvent")?;
                 let mut target = desc
-                    .get::<Arc<String>>("target")
+                    .get::<&str>("target")
                     .with_context(|| "reading target from TaggedFloatMetricEvent")?;
                 let mut name = desc
-                    .get::<Arc<String>>("name")
+                    .get::<&str>("name")
                     .with_context(|| "reading name from TaggedFloatMetricEvent")?;
                 let mut unit = desc
-                    .get::<Arc<String>>("unit")
+                    .get::<&str>("unit")
                     .with_context(|| "reading unit from TaggedFloatMetricEvent")?;
                 let properties = obj
-                    .get::<Arc<Object>>("properties")
+                    .get::<&Object>("properties")
                     .with_context(|| "reading properties from TaggedFloatMetricEvent")?;
-                for (prop_name, prop_value) in &properties.members {
-                    match (prop_name.as_str(), prop_value) {
+                for &(prop_name, prop_value) in properties.members {
+                    match (prop_name, prop_value) {
                         ("target", Value::String(value_str)) => {
-                            target = value_str.clone();
+                            target = value_str;
                         }
                         ("name", Value::String(value_str)) => {
-                            name = value_str.clone();
+                            name = value_str;
                         }
                         ("unit", Value::String(value_str)) => {
-                            unit = value_str.clone();
+                            unit = value_str;
                         }
-                        (&_, _) => {}
+                        (_, _) => {}
                     }
                 }
                 Ok(Some(Measure {
@@ -250,14 +249,17 @@ pub fn measure_from_value(
 
 /// Iterates over each metric measurement in a block.
 #[span_fn]
-pub async fn for_each_measure_in_block<Predicate: FnMut(Measure) -> Result<bool>>(
+pub async fn for_each_measure_in_block<Predicate>(
     blob_storage: Arc<BlobStorage>,
     convert_ticks: &ConvertTicks,
     process: Arc<ProcessMetadata>,
     stream: &StreamMetadata,
     block: &BlockMetadata,
     mut fun: Predicate,
-) -> Result<bool> {
+) -> Result<bool>
+where
+    Predicate: for<'a> FnMut(Measure<'a>) -> Result<bool>,
+{
     let payload = fetch_block_payload(
         blob_storage,
         stream.process_id,
@@ -275,7 +277,7 @@ pub async fn for_each_measure_in_block<Predicate: FnMut(Measure) -> Result<bool>
             block_id.clone(),
             block_insert_time_ns,
             convert_ticks,
-            &val,
+            val,
         )
         .with_context(|| "measure_from_value")?
             && !fun(measure)?

--- a/rust/analytics/src/metrics_table.rs
+++ b/rust/analytics/src/metrics_table.rs
@@ -155,9 +155,9 @@ impl MetricsRecordBuilder {
         self.usernames.append_value(&row.process.username);
         self.computers.append_value(&row.process.computer);
         self.times.append_value(row.time);
-        self.targets.append_value(&*row.target);
-        self.names.append_value(&*row.name);
-        self.units.append_value(&*row.unit);
+        self.targets.append_value(row.target);
+        self.names.append_value(row.name);
+        self.units.append_value(row.unit);
         self.values.append_value(row.value);
         self.properties.append_property_set(&row.properties)?;
         self.process_properties
@@ -169,9 +169,9 @@ impl MetricsRecordBuilder {
     pub fn append_entry_only(&mut self, row: &Measure) -> Result<()> {
         // Only append fields that truly vary per metrics entry
         self.times.append_value(row.time);
-        self.targets.append_value(&*row.target);
-        self.names.append_value(&*row.name);
-        self.units.append_value(&*row.unit);
+        self.targets.append_value(row.target);
+        self.names.append_value(row.name);
+        self.units.append_value(row.unit);
         self.values.append_value(row.value);
         self.properties.append_property_set(&row.properties)?;
         Ok(())

--- a/rust/analytics/src/net_block_processing.rs
+++ b/rust/analytics/src/net_block_processing.rs
@@ -11,23 +11,21 @@ use std::sync::Arc;
 ///
 /// Implementors receive one callback per decoded net event. Returning `Ok(true)`
 /// continues iteration; returning `Ok(false)` stops parsing the current block.
+///
+/// The string arguments borrow the per-block parse arena; an implementor that
+/// retains them across blocks (e.g. an open-span stack) must copy them out.
 pub trait NetBlockProcessor {
     fn on_connection_begin(
         &mut self,
         event_id: i64,
         time: i64,
-        connection_name: Arc<String>,
+        connection_name: &str,
         is_outgoing: bool,
     ) -> Result<bool>;
 
     fn on_connection_end(&mut self, event_id: i64, time: i64, bit_size: i64) -> Result<bool>;
 
-    fn on_object_begin(
-        &mut self,
-        event_id: i64,
-        time: i64,
-        object_name: Arc<String>,
-    ) -> Result<bool>;
+    fn on_object_begin(&mut self, event_id: i64, time: i64, object_name: &str) -> Result<bool>;
 
     fn on_object_end(&mut self, event_id: i64, time: i64, bit_size: i64) -> Result<bool>;
 
@@ -35,25 +33,20 @@ pub trait NetBlockProcessor {
         &mut self,
         event_id: i64,
         time: i64,
-        property_name: Arc<String>,
+        property_name: &str,
         bit_size: i64,
     ) -> Result<bool>;
 
-    fn on_rpc_begin(
-        &mut self,
-        event_id: i64,
-        time: i64,
-        function_name: Arc<String>,
-    ) -> Result<bool>;
+    fn on_rpc_begin(&mut self, event_id: i64, time: i64, function_name: &str) -> Result<bool>;
 
     fn on_rpc_end(&mut self, event_id: i64, time: i64, bit_size: i64) -> Result<bool>;
 }
 
-fn read_time(obj: &Object) -> Result<i64> {
+fn read_time(obj: &Object<'_>) -> Result<i64> {
     obj.get::<i64>("time")
 }
 
-fn read_bit_size(obj: &Object) -> Result<i64> {
+fn read_bit_size(obj: &Object<'_>) -> Result<i64> {
     Ok(obj.get::<u32>("bit_size")? as i64)
 }
 
@@ -68,11 +61,11 @@ pub fn parse_net_block_payload<Proc: NetBlockProcessor>(
     let mut event_id = object_offset;
     parse_block(stream, payload, |val| {
         let res = if let Value::Object(obj) = val {
-            match obj.type_name.as_str() {
+            match obj.type_name {
                 "NetConnectionBeginEvent" => {
-                    let time = read_time(&obj).with_context(|| "NetConnectionBeginEvent.time")?;
+                    let time = read_time(obj).with_context(|| "NetConnectionBeginEvent.time")?;
                     let connection_name = obj
-                        .get::<Arc<String>>("connection_name")
+                        .get::<&str>("connection_name")
                         .with_context(|| "NetConnectionBeginEvent.connection_name")?;
                     let is_outgoing = obj
                         .get::<u8>("is_outgoing")
@@ -81,44 +74,43 @@ pub fn parse_net_block_payload<Proc: NetBlockProcessor>(
                     processor.on_connection_begin(event_id, time, connection_name, is_outgoing)
                 }
                 "NetConnectionEndEvent" => {
-                    let time = read_time(&obj).with_context(|| "NetConnectionEndEvent.time")?;
+                    let time = read_time(obj).with_context(|| "NetConnectionEndEvent.time")?;
                     let bit_size =
-                        read_bit_size(&obj).with_context(|| "NetConnectionEndEvent.bit_size")?;
+                        read_bit_size(obj).with_context(|| "NetConnectionEndEvent.bit_size")?;
                     processor.on_connection_end(event_id, time, bit_size)
                 }
                 "NetObjectBeginEvent" => {
-                    let time = read_time(&obj).with_context(|| "NetObjectBeginEvent.time")?;
+                    let time = read_time(obj).with_context(|| "NetObjectBeginEvent.time")?;
                     let object_name = obj
-                        .get::<Arc<String>>("object_name")
+                        .get::<&str>("object_name")
                         .with_context(|| "NetObjectBeginEvent.object_name")?;
                     processor.on_object_begin(event_id, time, object_name)
                 }
                 "NetObjectEndEvent" => {
-                    let time = read_time(&obj).with_context(|| "NetObjectEndEvent.time")?;
+                    let time = read_time(obj).with_context(|| "NetObjectEndEvent.time")?;
                     let bit_size =
-                        read_bit_size(&obj).with_context(|| "NetObjectEndEvent.bit_size")?;
+                        read_bit_size(obj).with_context(|| "NetObjectEndEvent.bit_size")?;
                     processor.on_object_end(event_id, time, bit_size)
                 }
                 "NetPropertyEvent" => {
-                    let time = read_time(&obj).with_context(|| "NetPropertyEvent.time")?;
+                    let time = read_time(obj).with_context(|| "NetPropertyEvent.time")?;
                     let property_name = obj
-                        .get::<Arc<String>>("property_name")
+                        .get::<&str>("property_name")
                         .with_context(|| "NetPropertyEvent.property_name")?;
                     let bit_size =
-                        read_bit_size(&obj).with_context(|| "NetPropertyEvent.bit_size")?;
+                        read_bit_size(obj).with_context(|| "NetPropertyEvent.bit_size")?;
                     processor.on_property(event_id, time, property_name, bit_size)
                 }
                 "NetRPCBeginEvent" => {
-                    let time = read_time(&obj).with_context(|| "NetRPCBeginEvent.time")?;
+                    let time = read_time(obj).with_context(|| "NetRPCBeginEvent.time")?;
                     let function_name = obj
-                        .get::<Arc<String>>("function_name")
+                        .get::<&str>("function_name")
                         .with_context(|| "NetRPCBeginEvent.function_name")?;
                     processor.on_rpc_begin(event_id, time, function_name)
                 }
                 "NetRPCEndEvent" => {
-                    let time = read_time(&obj).with_context(|| "NetRPCEndEvent.time")?;
-                    let bit_size =
-                        read_bit_size(&obj).with_context(|| "NetRPCEndEvent.bit_size")?;
+                    let time = read_time(obj).with_context(|| "NetRPCEndEvent.time")?;
+                    let bit_size = read_bit_size(obj).with_context(|| "NetRPCEndEvent.bit_size")?;
                     processor.on_rpc_end(event_id, time, bit_size)
                 }
                 event_type => {

--- a/rust/analytics/src/net_span_tree.rs
+++ b/rust/analytics/src/net_span_tree.rs
@@ -171,10 +171,12 @@ impl<'a> NetBlockProcessor for NetSpanTreeBuilder<'a> {
         &mut self,
         event_id: i64,
         time: i64,
-        connection_name: Arc<String>,
+        connection_name: &str,
         is_outgoing: bool,
     ) -> Result<bool> {
         let begin_time_ns = self.convert_ticks.ticks_to_nanoseconds(time);
+        // Owned once at push: the open-span stack outlives the per-block arena.
+        let connection_name = Arc::new(connection_name.to_owned());
         self.stack.push(OpenSpan {
             span_id: event_id,
             parent_span_id: ROOT_PARENT_SPAN_ID,
@@ -194,12 +196,7 @@ impl<'a> NetBlockProcessor for NetSpanTreeBuilder<'a> {
         self.close_span(&KIND_CONNECTION, end_time_ns, bit_size)
     }
 
-    fn on_object_begin(
-        &mut self,
-        event_id: i64,
-        time: i64,
-        object_name: Arc<String>,
-    ) -> Result<bool> {
+    fn on_object_begin(&mut self, event_id: i64, time: i64, object_name: &str) -> Result<bool> {
         let begin_time_ns = self.convert_ticks.ticks_to_nanoseconds(time);
         let (parent_span_id, depth, _) = self.parent_of_new_child();
         let (connection_name, is_outgoing) = self.connection_context();
@@ -208,7 +205,7 @@ impl<'a> NetBlockProcessor for NetSpanTreeBuilder<'a> {
             parent_span_id,
             depth,
             kind: KIND_OBJECT.clone(),
-            name: object_name,
+            name: Arc::new(object_name.to_owned()),
             connection_name,
             is_outgoing,
             begin_time_ns,
@@ -226,7 +223,7 @@ impl<'a> NetBlockProcessor for NetSpanTreeBuilder<'a> {
         &mut self,
         event_id: i64,
         time: i64,
-        property_name: Arc<String>,
+        property_name: &str,
         bit_size: i64,
     ) -> Result<bool> {
         let event_time_ns = self.convert_ticks.ticks_to_nanoseconds(time);
@@ -240,7 +237,7 @@ impl<'a> NetBlockProcessor for NetSpanTreeBuilder<'a> {
             parent_span_id,
             depth,
             kind: KIND_PROPERTY.clone(),
-            name: property_name,
+            name: Arc::new(property_name.to_owned()),
             connection_name,
             is_outgoing,
             begin_bits,
@@ -256,12 +253,7 @@ impl<'a> NetBlockProcessor for NetSpanTreeBuilder<'a> {
         Ok(true)
     }
 
-    fn on_rpc_begin(
-        &mut self,
-        event_id: i64,
-        time: i64,
-        function_name: Arc<String>,
-    ) -> Result<bool> {
+    fn on_rpc_begin(&mut self, event_id: i64, time: i64, function_name: &str) -> Result<bool> {
         let begin_time_ns = self.convert_ticks.ticks_to_nanoseconds(time);
         let (parent_span_id, depth, _) = self.parent_of_new_child();
         let (connection_name, is_outgoing) = self.connection_context();
@@ -270,7 +262,7 @@ impl<'a> NetBlockProcessor for NetSpanTreeBuilder<'a> {
             parent_span_id,
             depth,
             kind: KIND_RPC.clone(),
-            name: function_name,
+            name: Arc::new(function_name.to_owned()),
             connection_name,
             is_outgoing,
             begin_time_ns,

--- a/rust/analytics/src/payload.rs
+++ b/rust/analytics/src/payload.rs
@@ -1,10 +1,18 @@
 use anyhow::{Context, Result};
+use bumpalo::Bump;
 use micromegas_telemetry::{blob_storage::BlobStorage, compression::decompress};
 use micromegas_tracing::{parsing::make_custom_readers, prelude::*};
-use micromegas_transit::{parse_object_buffer, read_dependencies, value::Value};
+use micromegas_transit::{CustomReaderMap, parse_object_buffer, read_dependencies, value::Value};
 use std::sync::Arc;
 
 use crate::metadata::StreamMetadata;
+
+thread_local! {
+    /// The custom-reader map is identical for every block, so build it once per
+    /// worker thread instead of rebuilding a `HashMap` of `Arc<dyn Fn>` on every
+    /// `parse_block` call.
+    static CUSTOM_READERS: CustomReaderMap = make_custom_readers();
+}
 
 /// Fetches the payload of a block from blob storage.
 #[span_fn]
@@ -30,32 +38,42 @@ pub async fn fetch_block_payload(
 }
 
 /// Parses a block of telemetry data, calling a function for each object in the block.
+///
+/// Each parsed `Value` borrows from a per-block bump arena (and the decompressed
+/// buffers) that live only for the duration of this call. The higher-ranked
+/// `FnMut(Value<'_>)` bound forbids the callback from retaining a `Value` beyond
+/// its invocation — anything that must outlive the block (e.g. an Arrow append)
+/// must copy out inside the callback.
 // parse_block calls fun for each object in the block until fun returns `false`
 #[span_fn]
 pub fn parse_block<F>(
     stream: &StreamMetadata,
     payload: &micromegas_telemetry::block_wire_format::BlockPayload,
-    fun: F,
+    mut fun: F,
 ) -> Result<bool>
 where
-    F: FnMut(Value) -> Result<bool>,
+    F: for<'a> FnMut(Value<'a>) -> Result<bool>,
 {
     let dep_udts = &stream.dependencies_metadata;
-    let custom_readers = make_custom_readers();
-    let dependencies = read_dependencies(
-        &custom_readers,
-        dep_udts,
-        &decompress(&payload.dependencies).with_context(|| "decompressing dependencies payload")?,
-    )
-    .with_context(|| "reading dependencies")?;
     let obj_udts = &stream.objects_metadata;
-    let continue_iterating = parse_object_buffer(
-        &custom_readers,
-        &dependencies,
-        obj_udts,
-        &decompress(&payload.objects).with_context(|| "decompressing objects payload")?,
-        fun,
-    )
-    .with_context(|| "parsing object buffer")?;
-    Ok(continue_iterating)
+    // Bind the decompressed buffers and the arena to locals so every parsed
+    // Value borrows from storage that outlives the parse below.
+    let deps_buf =
+        decompress(&payload.dependencies).with_context(|| "decompressing dependencies payload")?;
+    let objs_buf = decompress(&payload.objects).with_context(|| "decompressing objects payload")?;
+    let bump = Bump::new();
+    CUSTOM_READERS.with(|custom_readers| {
+        let dependencies = read_dependencies(&bump, custom_readers, dep_udts, &deps_buf)
+            .with_context(|| "reading dependencies")?;
+        let continue_iterating = parse_object_buffer(
+            &bump,
+            custom_readers,
+            &dependencies,
+            obj_udts,
+            &objs_buf,
+            &mut fun,
+        )
+        .with_context(|| "parsing object buffer")?;
+        Ok(continue_iterating)
+    })
 }

--- a/rust/analytics/src/properties/property_set.rs
+++ b/rust/analytics/src/properties/property_set.rs
@@ -1,51 +1,54 @@
 use anyhow::Result;
-use micromegas_telemetry::property::Property;
 use micromegas_transit::value::{Object, Value};
-use std::sync::Arc;
 
-/// A set of properties, backed by a `transit` object.
-#[derive(Debug, Clone)]
-pub struct PropertySet {
-    obj: Arc<Object>,
+/// A set of properties, backed by an arena-allocated `transit` object.
+///
+/// Borrows the parse arena, so it is valid only within a single `parse_block`
+/// call; consumers must serialize/copy it out before the arena is dropped.
+#[derive(Debug, Clone, Copy)]
+pub struct PropertySet<'a> {
+    obj: &'a Object<'a>,
 }
 
-impl PropertySet {
-    pub fn new(obj: Arc<Object>) -> Self {
+impl<'a> PropertySet<'a> {
+    pub fn new(obj: &'a Object<'a>) -> Self {
         Self { obj }
     }
 
-    pub fn empty() -> Self {
-        lazy_static::lazy_static! {
-            static ref TYPE_NAME: Arc<String> = Arc::new("EmptyPropertySet".into());
-            static ref EMPTY_SET: PropertySet = PropertySet::new( Arc::new( Object{ type_name: TYPE_NAME.clone(), members: vec![] }) );
-        }
-        EMPTY_SET.clone()
+    pub fn empty() -> PropertySet<'static> {
+        static EMPTY: Object<'static> = Object {
+            type_name: "EmptyPropertySet",
+            members: &[],
+        };
+        PropertySet { obj: &EMPTY }
     }
 
-    /// Iterates over the properties in the set.
-    pub fn for_each_property<Fun: FnMut(Property) -> Result<()>>(
+    /// Iterates over the string-valued properties in the set as `(key, value)` pairs.
+    pub fn for_each_property<Fun: FnMut(&'a str, &'a str) -> Result<()>>(
         &self,
         mut fun: Fun,
     ) -> Result<()> {
-        for (key, value) in &self.obj.members {
+        for &(key, value) in self.obj.members {
             if let Value::String(value_str) = value {
-                fun(Property::new(key.clone(), value_str.clone()))?;
+                fun(key, value_str)?;
             }
         }
         Ok(())
     }
 
-    /// Get a reference to the underlying `Arc<Object>` for pointer-based operations.
+    /// Stable identity pointer to the underlying arena object.
     ///
-    /// This is used by custom dictionary builders for efficient deduplication
-    /// based on Arc pointer addresses rather than content hashing.
-    pub fn as_arc_object(&self) -> &Arc<Object> {
-        &self.obj
+    /// Used by the dictionary builder for pointer-based deduplication: within a
+    /// single block, every event referencing the same property-set dependency
+    /// shares one arena `Object`, so identical sets compare equal by address.
+    /// The pointer is only ever compared, never dereferenced.
+    pub fn object_ptr(&self) -> *const () {
+        self.obj as *const Object as *const ()
     }
 }
 
-impl From<Arc<Object>> for PropertySet {
-    fn from(value: Arc<Object>) -> Self {
+impl<'a> From<&'a Object<'a>> for PropertySet<'a> {
+    fn from(value: &'a Object<'a>) -> Self {
         Self::new(value)
     }
 }

--- a/rust/analytics/src/properties/property_set_jsonb_dictionary_builder.rs
+++ b/rust/analytics/src/properties/property_set_jsonb_dictionary_builder.rs
@@ -32,6 +32,16 @@ unsafe impl Sync for ObjectPointer {}
 /// - Pointer-based deduplication: O(1) pointer comparison vs O(n) content hash
 /// - Serialization only when needed: Only serialize PropertySet on first encounter
 /// - Memory efficiency: Shared PropertySet references, single JSONB copy per unique set
+///
+/// # Invariant (must not outlive a single parse arena)
+///
+/// The pointer keys are only unique while every appended `PropertySet` borrows the
+/// same parse arena. A dropped arena's address can be recycled by the next block's
+/// arena, so a builder instance must be fed exactly one block / one arena: construct
+/// it fresh in each block processor and `finish()` it before the arena is dropped.
+/// Reusing one builder across arenas would let a recycled address alias a stale
+/// entry and emit the wrong JSONB. `append_property_set` debug-asserts this
+/// invariant so any future cross-arena reuse fails loudly in debug/test builds.
 pub struct PropertySetJsonbDictionaryBuilder {
     /// Maps `Arc<Object>` pointer to dictionary index (avoids content hashing)
     pointer_to_index: HashMap<ObjectPointer, i32>,
@@ -60,7 +70,20 @@ impl PropertySetJsonbDictionaryBuilder {
 
         match self.pointer_to_index.get(&ptr) {
             Some(&index) => {
-                // Cache hit: reuse existing dictionary index (no serialization)
+                // Cache hit: reuse existing dictionary index (no serialization).
+                // Invariant: an equal pointer must mean equal content. This holds only
+                // while all appended sets come from the same parse arena; if a builder
+                // is ever reused across arenas, a recycled address could alias a stale
+                // entry here. Verify in debug builds so that misuse fails loudly instead
+                // of silently emitting the wrong JSONB. Compiled out of release builds.
+                #[cfg(debug_assertions)]
+                {
+                    let expected = serialize_property_set_to_jsonb(property_set)?;
+                    debug_assert_eq!(
+                        expected, self.jsonb_values[index as usize],
+                        "pointer-dedup collision: arena address reused across blocks"
+                    );
+                }
                 self.keys.push(Some(index));
             }
             None => {

--- a/rust/analytics/src/properties/property_set_jsonb_dictionary_builder.rs
+++ b/rust/analytics/src/properties/property_set_jsonb_dictionary_builder.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use datafusion::arrow::array::{BinaryArray, DictionaryArray, Int32Array};
 use datafusion::arrow::datatypes::Int32Type;
 use datafusion::common::DataFusionError;
-use micromegas_transit::value::Object;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -13,19 +12,15 @@ use std::sync::Arc;
 /// This is safe because:
 /// 1. We only use the pointer for identity comparison (equality/hashing)
 /// 2. We never dereference the pointer
-/// 3. We keep the actual Arc<Object> alive in _property_refs
+/// 3. The parse arena keeps the underlying objects alive for the whole block,
+///    so addresses stay stable and unique while comparisons happen; after the
+///    block is parsed the pointers are never touched again.
 /// 4. The cache is scoped to single block processing (no cross-thread sharing)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct ObjectPointer(*const Object);
+struct ObjectPointer(*const ());
 
 unsafe impl Send for ObjectPointer {}
 unsafe impl Sync for ObjectPointer {}
-
-impl ObjectPointer {
-    fn new(arc_obj: &Arc<Object>) -> Self {
-        Self(Arc::as_ptr(arc_obj))
-    }
-}
 
 /// Custom dictionary builder for PropertySet → JSONB encoding with pointer-based deduplication.
 ///
@@ -44,8 +39,6 @@ pub struct PropertySetJsonbDictionaryBuilder {
     jsonb_values: Vec<Vec<u8>>,
     /// Dictionary keys (indices) for each appended entry
     keys: Vec<Option<i32>>,
-    /// Keep PropertySet references alive for pointer safety
-    _property_refs: Vec<Arc<Object>>,
 }
 
 impl PropertySetJsonbDictionaryBuilder {
@@ -55,7 +48,6 @@ impl PropertySetJsonbDictionaryBuilder {
             pointer_to_index: HashMap::with_capacity(capacity),
             jsonb_values: Vec::with_capacity(capacity),
             keys: Vec::with_capacity(capacity),
-            _property_refs: Vec::with_capacity(capacity),
         }
     }
 
@@ -63,9 +55,8 @@ impl PropertySetJsonbDictionaryBuilder {
     ///
     /// For cache hits: reuses existing dictionary index (no serialization)
     /// For cache misses: serializes once and stores in dictionary
-    pub fn append_property_set(&mut self, property_set: &PropertySet) -> Result<()> {
-        let arc_obj = property_set.as_arc_object();
-        let ptr = ObjectPointer::new(arc_obj);
+    pub fn append_property_set(&mut self, property_set: &PropertySet<'_>) -> Result<()> {
+        let ptr = ObjectPointer(property_set.object_ptr());
 
         match self.pointer_to_index.get(&ptr) {
             Some(&index) => {
@@ -80,8 +71,6 @@ impl PropertySetJsonbDictionaryBuilder {
                 self.jsonb_values.push(jsonb_bytes);
                 self.pointer_to_index.insert(ptr, new_index);
                 self.keys.push(Some(new_index));
-                // Keep Arc reference alive to ensure pointer validity
-                self._property_refs.push(Arc::clone(arc_obj));
             }
         }
         Ok(())

--- a/rust/analytics/src/scope.rs
+++ b/rust/analytics/src/scope.rs
@@ -28,6 +28,44 @@ impl ScopeDesc {
     }
 }
 
+/// A borrowed scope description handed to block processors per event.
+///
+/// Borrows the parse arena, so it costs no allocation to construct; the owning
+/// [`ScopeDesc`] is materialized only when a scope is first inserted into a
+/// long-lived [`ScopeHashMap`] (once per distinct scope, not per event).
+#[derive(Debug, Clone, Copy)]
+pub struct BorrowedScopeDesc<'a> {
+    pub name: &'a str,
+    pub filename: &'a str,
+    pub target: &'a str,
+    pub line: u32,
+    pub hash: u32,
+}
+
+impl<'a> BorrowedScopeDesc<'a> {
+    pub fn new(name: &'a str, filename: &'a str, target: &'a str, line: u32) -> Self {
+        let hash = compute_scope_hash(name, filename, target, line);
+        Self {
+            name,
+            filename,
+            target,
+            line,
+            hash,
+        }
+    }
+
+    /// Materializes an owned `ScopeDesc` (allocates the strings).
+    pub fn to_owned(self) -> ScopeDesc {
+        ScopeDesc {
+            name: Arc::new(self.name.to_owned()),
+            filename: Arc::new(self.filename.to_owned()),
+            target: Arc::new(self.target.to_owned()),
+            line: self.line,
+            hash: self.hash,
+        }
+    }
+}
+
 /// Computes the hash of a scope.
 pub fn compute_scope_hash(name: &str, filename: &str, target: &str, line: u32) -> u32 {
     let hash_name = xxh32(name.as_bytes(), 0);

--- a/rust/analytics/src/thread_block_processor.rs
+++ b/rust/analytics/src/thread_block_processor.rs
@@ -1,6 +1,6 @@
 use crate::metadata::StreamMetadata;
 use crate::payload::{fetch_block_payload, parse_block};
-use crate::scope::ScopeDesc;
+use crate::scope::BorrowedScopeDesc;
 use anyhow::{Context, Result};
 use micromegas_telemetry::blob_storage::BlobStorage;
 use micromegas_tracing::prelude::*;
@@ -14,34 +14,34 @@ pub trait ThreadBlockProcessor {
         &mut self,
         block_id: &str,
         event_id: i64,
-        scope: ScopeDesc,
+        scope: BorrowedScopeDesc<'_>,
         ts: i64,
     ) -> Result<bool>;
     fn on_end_thread_scope(
         &mut self,
         block_id: &str,
         event_id: i64,
-        scope: ScopeDesc,
+        scope: BorrowedScopeDesc<'_>,
         ts: i64,
     ) -> Result<bool>;
 }
 
-fn on_thread_event<F>(obj: &Object, mut fun: F) -> Result<bool>
+fn on_thread_event<'a, F>(obj: &Object<'a>, mut fun: F) -> Result<bool>
 where
-    F: FnMut(Arc<Object>, i64) -> Result<bool>,
+    F: FnMut(&'a Object<'a>, i64) -> Result<bool>,
 {
     let tick = obj.get::<i64>("time")?;
-    let scope = obj.get::<Arc<Object>>("thread_span_desc")?;
+    let scope = obj.get::<&Object>("thread_span_desc")?;
     fun(scope, tick)
 }
 
-fn on_thread_named_event<F>(obj: &Object, mut fun: F) -> Result<bool>
+fn on_thread_named_event<'a, F>(obj: &Object<'a>, mut fun: F) -> Result<bool>
 where
-    F: FnMut(Arc<Object>, Arc<String>, i64) -> Result<bool>,
+    F: FnMut(&'a Object<'a>, &'a str, i64) -> Result<bool>,
 {
     let tick = obj.get::<i64>("time")?;
-    let scope = obj.get::<Arc<Object>>("thread_span_location")?;
-    let name = obj.get::<Arc<String>>("name")?;
+    let scope = obj.get::<&Object>("thread_span_location")?;
+    let name = obj.get::<&str>("name")?;
     fun(scope, name, tick)
 }
 
@@ -57,38 +57,38 @@ pub fn parse_thread_block_payload<Proc: ThreadBlockProcessor>(
     let mut event_id = object_offset;
     parse_block(stream, payload, |val| {
         let res = if let Value::Object(obj) = val {
-            match obj.type_name.as_str() {
-                "BeginThreadSpanEvent" => on_thread_event(&obj, |scope, ts| {
-                    let name = scope.get::<Arc<String>>("name")?;
-                    let filename = scope.get::<Arc<String>>("file")?;
-                    let target = scope.get::<Arc<String>>("target")?;
+            match obj.type_name {
+                "BeginThreadSpanEvent" => on_thread_event(obj, |scope, ts| {
+                    let name = scope.get::<&str>("name")?;
+                    let filename = scope.get::<&str>("file")?;
+                    let target = scope.get::<&str>("target")?;
                     let line = scope.get::<u32>("line")?;
-                    let scope_desc = ScopeDesc::new(name, filename, target, line);
+                    let scope_desc = BorrowedScopeDesc::new(name, filename, target, line);
                     processor.on_begin_thread_scope(block_id, event_id, scope_desc, ts)
                 })
                 .with_context(|| "reading BeginThreadSpanEvent"),
-                "EndThreadSpanEvent" => on_thread_event(&obj, |scope, ts| {
-                    let name = scope.get::<Arc<String>>("name")?;
-                    let filename = scope.get::<Arc<String>>("file")?;
-                    let target = scope.get::<Arc<String>>("target")?;
+                "EndThreadSpanEvent" => on_thread_event(obj, |scope, ts| {
+                    let name = scope.get::<&str>("name")?;
+                    let filename = scope.get::<&str>("file")?;
+                    let target = scope.get::<&str>("target")?;
                     let line = scope.get::<u32>("line")?;
-                    let scope_desc = ScopeDesc::new(name, filename, target, line);
+                    let scope_desc = BorrowedScopeDesc::new(name, filename, target, line);
                     processor.on_end_thread_scope(block_id, event_id, scope_desc, ts)
                 })
                 .with_context(|| "reading EndThreadSpanEvent"),
-                "BeginThreadNamedSpanEvent" => on_thread_named_event(&obj, |scope, name, ts| {
-                    let filename = scope.get::<Arc<String>>("file")?;
-                    let target = scope.get::<Arc<String>>("target")?;
+                "BeginThreadNamedSpanEvent" => on_thread_named_event(obj, |scope, name, ts| {
+                    let filename = scope.get::<&str>("file")?;
+                    let target = scope.get::<&str>("target")?;
                     let line = scope.get::<u32>("line")?;
-                    let scope_desc = ScopeDesc::new(name, filename, target, line);
+                    let scope_desc = BorrowedScopeDesc::new(name, filename, target, line);
                     processor.on_begin_thread_scope(block_id, event_id, scope_desc, ts)
                 })
                 .with_context(|| "reading BeginThreadNamedSpanEvent"),
-                "EndThreadNamedSpanEvent" => on_thread_named_event(&obj, |scope, name, ts| {
-                    let filename = scope.get::<Arc<String>>("file")?;
-                    let target = scope.get::<Arc<String>>("target")?;
+                "EndThreadNamedSpanEvent" => on_thread_named_event(obj, |scope, name, ts| {
+                    let filename = scope.get::<&str>("file")?;
+                    let target = scope.get::<&str>("target")?;
                     let line = scope.get::<u32>("line")?;
-                    let scope_desc = ScopeDesc::new(name, filename, target, line);
+                    let scope_desc = BorrowedScopeDesc::new(name, filename, target, line);
                     processor.on_end_thread_scope(block_id, event_id, scope_desc, ts)
                 })
                 .with_context(|| "reading EndThreadNamedSpanEvent"),

--- a/rust/analytics/tests/async_events_tests.rs
+++ b/rust/analytics/tests/async_events_tests.rs
@@ -3,7 +3,7 @@ use micromegas_analytics::{
     async_block_processing::AsyncBlockProcessor,
     async_events_table::{AsyncEventRecord, AsyncEventRecordBuilder, async_events_table_schema},
     lakehouse::{async_events_view::AsyncEventsView, view::View, view_factory::ViewFactory},
-    scope::ScopeDesc,
+    scope::{BorrowedScopeDesc, ScopeDesc},
 };
 use std::sync::Arc;
 
@@ -40,7 +40,7 @@ impl AsyncBlockProcessor for TestAsyncProcessor {
     fn on_begin_async_scope(
         &mut self,
         block_id: &str,
-        scope: ScopeDesc,
+        scope: BorrowedScopeDesc<'_>,
         ts: i64,
         span_id: i64,
         parent_span_id: i64,
@@ -63,7 +63,7 @@ impl AsyncBlockProcessor for TestAsyncProcessor {
     fn on_end_async_scope(
         &mut self,
         block_id: &str,
-        scope: ScopeDesc,
+        scope: BorrowedScopeDesc<'_>,
         ts: i64,
         span_id: i64,
         parent_span_id: i64,
@@ -117,14 +117,14 @@ fn test_async_event_record_builder() {
         stream_id: Arc::new("stream1".to_string()),
         block_id: Arc::new("block1".to_string()),
         time: 2000000000,
-        event_type: Arc::new("begin".to_string()),
+        event_type: "begin",
         span_id: 1,
         parent_span_id: 0,
         depth: 0,
         hash: 0,
-        name: Arc::new("test_function".to_string()),
-        filename: Arc::new("test.rs".to_string()),
-        target: Arc::new("test_target".to_string()),
+        name: "test_function",
+        filename: "test.rs",
+        target: "test_target",
         line: 42,
     };
 
@@ -132,14 +132,14 @@ fn test_async_event_record_builder() {
         stream_id: Arc::new("stream1".to_string()),
         block_id: Arc::new("block1".to_string()),
         time: 3000000000,
-        event_type: Arc::new("end".to_string()),
+        event_type: "end",
         span_id: 1,
         parent_span_id: 0,
         depth: 0,
         hash: 0,
-        name: Arc::new("test_function".to_string()),
-        filename: Arc::new("test.rs".to_string()),
-        target: Arc::new("test_target".to_string()),
+        name: "test_function",
+        filename: "test.rs",
+        target: "test_target",
         line: 42,
     };
 
@@ -205,12 +205,7 @@ fn test_async_block_processor_trait() {
     processor
         .on_begin_async_scope(
             "block123",
-            ScopeDesc::new(
-                Arc::new("test_function".to_string()),
-                Arc::new("test.rs".to_string()),
-                Arc::new("test_target".to_string()),
-                42,
-            ),
+            BorrowedScopeDesc::new("test_function", "test.rs", "test_target", 42),
             1000,
             1,
             0,
@@ -222,12 +217,7 @@ fn test_async_block_processor_trait() {
     processor
         .on_end_async_scope(
             "block123",
-            ScopeDesc::new(
-                Arc::new("test_function".to_string()),
-                Arc::new("test.rs".to_string()),
-                Arc::new("test_target".to_string()),
-                42,
-            ),
+            BorrowedScopeDesc::new("test_function", "test.rs", "test_target", 42),
             2000,
             1,
             0,
@@ -313,22 +303,21 @@ fn test_async_events_high_frequency_performance() {
 
     // Generate many records to test performance
     for i in 0..1000 {
+        let name = format!("async_fn_{}", i % 5);
+        let filename = format!("src/lib_{}.rs", i % 3);
+        let target = format!("module_{}", i % 7);
         let record = AsyncEventRecord {
             stream_id: Arc::new(format!("stream_{}", i % 10)),
             block_id: Arc::new(format!("block_{}", i / 100)),
             time: 1000000000 + i,
-            event_type: Arc::new(if i % 2 == 0 {
-                "begin".to_string()
-            } else {
-                "end".to_string()
-            }),
+            event_type: if i % 2 == 0 { "begin" } else { "end" },
             span_id: i / 2,
             parent_span_id: if i > 0 { i / 4 } else { 0 },
             depth: (i % 5) as u32, // Test different depth levels
             hash: 0,
-            name: Arc::new(format!("async_fn_{}", i % 5)),
-            filename: Arc::new(format!("src/lib_{}.rs", i % 3)),
-            target: Arc::new(format!("module_{}", i % 7)),
+            name: &name,
+            filename: &filename,
+            target: &target,
             line: (i % 1000) as u32 + 1,
         };
         builder
@@ -363,14 +352,14 @@ fn test_async_events_cross_stream_scenarios() {
             stream_id: Arc::new("stream_001".to_string()),
             block_id: Arc::new("block_a".to_string()),
             time: 1000,
-            event_type: Arc::new("begin".to_string()),
+            event_type: "begin",
             span_id: 100,
             parent_span_id: 0,
             depth: 0,
             hash: 0,
-            name: Arc::new("async_task".to_string()),
-            filename: Arc::new("worker.rs".to_string()),
-            target: Arc::new("worker".to_string()),
+            name: "async_task",
+            filename: "worker.rs",
+            target: "worker",
             line: 42,
         },
         // Subtask starts on stream 2 (work stealing)
@@ -378,14 +367,14 @@ fn test_async_events_cross_stream_scenarios() {
             stream_id: Arc::new("stream_002".to_string()),
             block_id: Arc::new("block_b".to_string()),
             time: 1100,
-            event_type: Arc::new("begin".to_string()),
+            event_type: "begin",
             span_id: 101,
             parent_span_id: 100,
             depth: 1,
             hash: 0,
-            name: Arc::new("subtask".to_string()),
-            filename: Arc::new("worker.rs".to_string()),
-            target: Arc::new("worker".to_string()),
+            name: "subtask",
+            filename: "worker.rs",
+            target: "worker",
             line: 55,
         },
         // Subtask ends on stream 2
@@ -393,14 +382,14 @@ fn test_async_events_cross_stream_scenarios() {
             stream_id: Arc::new("stream_002".to_string()),
             block_id: Arc::new("block_c".to_string()),
             time: 1200,
-            event_type: Arc::new("end".to_string()),
+            event_type: "end",
             span_id: 101,
             parent_span_id: 100,
             depth: 1,
             hash: 0,
-            name: Arc::new("subtask".to_string()),
-            filename: Arc::new("worker.rs".to_string()),
-            target: Arc::new("worker".to_string()),
+            name: "subtask",
+            filename: "worker.rs",
+            target: "worker",
             line: 55,
         },
         // Main task continues on stream 1
@@ -408,14 +397,14 @@ fn test_async_events_cross_stream_scenarios() {
             stream_id: Arc::new("stream_001".to_string()),
             block_id: Arc::new("block_d".to_string()),
             time: 1300,
-            event_type: Arc::new("end".to_string()),
+            event_type: "end",
             span_id: 100,
             parent_span_id: 0,
             depth: 0,
             hash: 0,
-            name: Arc::new("async_task".to_string()),
-            filename: Arc::new("worker.rs".to_string()),
-            target: Arc::new("worker".to_string()),
+            name: "async_task",
+            filename: "worker.rs",
+            target: "worker",
             line: 42,
         },
     ];

--- a/rust/analytics/tests/call_tree_tests.rs
+++ b/rust/analytics/tests/call_tree_tests.rs
@@ -1,20 +1,14 @@
 use micromegas_analytics::call_tree::CallTreeBuilder;
-use micromegas_analytics::scope::ScopeDesc;
+use micromegas_analytics::scope::BorrowedScopeDesc;
 use micromegas_analytics::thread_block_processor::ThreadBlockProcessor;
 use micromegas_analytics::time::ConvertTicks;
-use std::sync::Arc;
 
 fn make_convert_ticks() -> ConvertTicks {
     ConvertTicks::from_meta_data(0, 0, 1_000_000_000).expect("ConvertTicks::from_meta_data")
 }
 
-fn scope(name: &str) -> ScopeDesc {
-    ScopeDesc::new(
-        Arc::new(name.to_string()),
-        Arc::new(String::new()),
-        Arc::new(String::new()),
-        0,
-    )
+fn scope(name: &str) -> BorrowedScopeDesc<'_> {
+    BorrowedScopeDesc::new(name, "", "", 0)
 }
 
 #[test]

--- a/rust/analytics/tests/image_tests.rs
+++ b/rust/analytics/tests/image_tests.rs
@@ -47,29 +47,25 @@ fn test_image_block_round_trip() {
 
     let mut events_parsed = 0;
     parse_block(&stream_metadata, &received_block.payload, |val| {
-        if let Value::Object(obj) = &val {
-            assert_eq!(
-                obj.type_name.as_str(),
-                "ImageEvent",
-                "unexpected object type"
-            );
+        if let Value::Object(obj) = val {
+            assert_eq!(obj.type_name, "ImageEvent", "unexpected object type");
             assert_eq!(
                 obj.get::<i64>("time").expect("reading time"),
                 42,
                 "time mismatch"
             );
             assert_eq!(
-                &*obj.get::<Arc<String>>("name").expect("reading name"),
+                obj.get::<&str>("name").expect("reading name"),
                 "heatmap",
                 "name mismatch"
             );
             assert_eq!(
-                &*obj.get::<Arc<String>>("format").expect("reading format"),
+                obj.get::<&str>("format").expect("reading format"),
                 "png",
                 "format mismatch"
             );
-            let parsed_data = obj.get::<Arc<Vec<u8>>>("data").expect("reading data");
-            assert_eq!(*parsed_data, image_data, "image data mismatch");
+            let parsed_data = obj.get::<&[u8]>("data").expect("reading data");
+            assert_eq!(parsed_data, image_data.as_slice(), "image data mismatch");
             events_parsed += 1;
         }
         Ok(true)

--- a/rust/analytics/tests/log_tests.rs
+++ b/rust/analytics/tests/log_tests.rs
@@ -72,11 +72,11 @@ fn test_log_encode_static() {
 
     parse_block(&stream_metadata, &received_block.payload, |val| {
         if let Value::Object(obj) = val {
-            assert_eq!(obj.type_name.as_str(), "LogStaticStrInteropEvent");
+            assert_eq!(obj.type_name, "LogStaticStrInteropEvent");
             assert_eq!(obj.get::<i64>("time").unwrap(), 1);
             assert_eq!(obj.get::<u32>("level").unwrap(), 2);
-            assert_eq!(&*obj.get::<Arc<String>>("target").unwrap(), "target_name");
-            assert_eq!(&*obj.get::<Arc<String>>("msg").unwrap(), "my message");
+            assert_eq!(obj.get::<&str>("target").unwrap(), "target_name");
+            assert_eq!(obj.get::<&str>("msg").unwrap(), "my message");
         } else {
             panic!("log entry not an object");
         }
@@ -128,12 +128,12 @@ fn test_log_encode_dynamic() {
 
     parse_block(&stream_metadata, &received_block.payload, |val| {
         if let Value::Object(obj) = val {
-            assert_eq!(obj.type_name.as_str(), "LogStringEventV2");
+            assert_eq!(obj.type_name, "LogStringEventV2");
             assert_eq!(obj.get::<i64>("time").unwrap(), 1);
-            let desc = obj.get::<Arc<Object>>("desc").unwrap();
+            let desc = obj.get::<&Object>("desc").unwrap();
             assert_eq!(desc.get::<u32>("level").unwrap(), 4);
-            assert_eq!(&*desc.get::<Arc<String>>("target").unwrap(), "target_name");
-            assert_eq!(&*obj.get::<Arc<String>>("msg").unwrap(), "my message");
+            assert_eq!(desc.get::<&str>("target").unwrap(), "target_name");
+            assert_eq!(obj.get::<&str>("msg").unwrap(), "my message");
         } else {
             panic!("log entry not an object");
         }
@@ -195,7 +195,7 @@ fn test_parse_log_interops() {
             stream_id.to_string().into(),
             received_block.block_id.to_string().into(),
             0,
-            &val,
+            val,
         )
         .unwrap()
         .is_some()
@@ -268,7 +268,7 @@ fn test_tagged_log_entries() {
             stream_id.to_string().into(),
             received_block.block_id.to_string().into(),
             0,
-            &val,
+            val,
         )
         .unwrap()
         .unwrap();

--- a/rust/analytics/tests/metrics_test.rs
+++ b/rust/analytics/tests/metrics_test.rs
@@ -177,7 +177,9 @@ fn test_tagged_measures() {
     let stream_info = make_stream_info(&stream);
     let stream_metadata = StreamMetadata::from_stream_info(&stream_info).unwrap();
     let convert_ticks = ConvertTicks::from_meta_data(0, 0, 1).unwrap();
-    let mut measures = vec![];
+    // Measures borrow the per-block arena, so we assert inside the callback rather
+    // than collecting them (the higher-ranked closure forbids escaping the arena).
+    let mut nb_measures = 0;
     parse_block(&stream_metadata, &received_block.payload, |val| {
         let measure = measure_from_value(
             process_info.clone(),
@@ -185,18 +187,18 @@ fn test_tagged_measures() {
             received_block.block_id.to_string().into(),
             0,
             &convert_ticks,
-            &val,
+            val,
         )
         .unwrap()
         .unwrap();
-        assert_eq!(measure.name.as_str(), "override_name");
-        assert_eq!(measure.unit.as_str(), "override_unit");
-        assert_eq!(measure.target.as_str(), "override_target");
-        measures.push(measure);
+        assert_eq!(measure.name, "override_name");
+        assert_eq!(measure.unit, "override_unit");
+        assert_eq!(measure.target, "override_target");
+        nb_measures += 1;
         Ok(true)
     })
     .unwrap();
-    assert_eq!(measures.len(), 2);
+    assert_eq!(nb_measures, 2);
 
     let guard = init_in_memory_tracing();
     imetric!("tagged_int", "count", 100);

--- a/rust/analytics/tests/net_spans_test.rs
+++ b/rust/analytics/tests/net_spans_test.rs
@@ -16,8 +16,8 @@ fn make_builder_ctx() -> (NetSpanRecordBuilder, Arc<String>, Arc<String>, Conver
     )
 }
 
-fn s(value: &str) -> Arc<String> {
-    Arc::new(String::from(value))
+fn s(value: &str) -> &str {
+    value
 }
 
 fn collect_rows(builder: NetSpanRecordBuilder) -> Vec<NetRow> {

--- a/rust/analytics/tests/parse_alloc_test.rs
+++ b/rust/analytics/tests/parse_alloc_test.rs
@@ -1,0 +1,165 @@
+//! Allocation-profile regression guard for the transit block parse path.
+//!
+//! Wraps the system allocator with a counter that is only armed around a single
+//! `parse_block` call, so we can report allocations-per-object and bytes-per-object
+//! for the hot parse paths. This is the headline metric for the bumpalo-arena work:
+//! it should drop sharply once `Value<'a>` is arena-allocated.
+//!
+//! Run with: `cargo test -p micromegas-analytics --test parse_alloc_test -- --nocapture`
+
+use micromegas_analytics::metadata::StreamMetadata;
+use micromegas_analytics::payload::parse_block;
+use micromegas_telemetry::block_wire_format::{Block, BlockPayload};
+use micromegas_telemetry_sink::{stream_block::StreamBlock, stream_info::make_stream_info};
+use micromegas_tracing::dispatch::make_process_info;
+use micromegas_tracing::event::TracingBlock;
+use micromegas_tracing::logs::{LogBlock, LogStaticStrInteropEvent, LogStream};
+use micromegas_tracing::prelude::*;
+use micromegas_tracing::spans::{
+    BeginThreadNamedSpanEvent, SpanLocation, ThreadBlock, ThreadStream,
+};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+static COUNTING: AtomicBool = AtomicBool::new(false);
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static BYTES: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+// SAFETY: forwards every call to the System allocator; the atomics only observe.
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let p = unsafe { System.alloc(layout) };
+        if COUNTING.load(Ordering::Relaxed) && !p.is_null() {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        p
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            BYTES.fetch_add(new_size, Ordering::Relaxed);
+        }
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: Counting = Counting;
+
+const N: usize = 4096;
+const BUF: usize = 16 * 1024 * 1024;
+
+fn build_span_block() -> (StreamMetadata, BlockPayload) {
+    let process_id = uuid::Uuid::new_v4();
+    let process_info = make_process_info(process_id, Some(uuid::Uuid::new_v4()), HashMap::new());
+    let mut stream = ThreadStream::new(BUF, process_id, &[], HashMap::new());
+    let stream_id = stream.stream_id();
+    static LOC: SpanLocation = SpanLocation {
+        lod: Verbosity::Med,
+        target: "target",
+        module_path: "module_path",
+        file: "file",
+        line: 123,
+    };
+    for i in 0..N {
+        stream.get_events_mut().push(BeginThreadNamedSpanEvent {
+            thread_span_location: &LOC,
+            name: "my_function".into(),
+            time: i as i64,
+        });
+    }
+    let mut block = stream.replace_block(Arc::new(ThreadBlock::new(BUF, process_id, stream_id, 0)));
+    Arc::get_mut(&mut block).unwrap().close();
+    let encoded = block.encode_bin(&process_info).unwrap();
+    let received: Block = ciborium::from_reader(&encoded[..]).unwrap();
+    let meta = StreamMetadata::from_stream_info(&make_stream_info(&stream)).unwrap();
+    (meta, received.payload)
+}
+
+fn build_log_block() -> (StreamMetadata, BlockPayload) {
+    let process_id = uuid::Uuid::new_v4();
+    let process_info = make_process_info(process_id, Some(uuid::Uuid::new_v4()), HashMap::new());
+    let mut stream = LogStream::new(BUF, process_id, &[], HashMap::new());
+    let stream_id = stream.stream_id();
+    for i in 0..N {
+        stream.get_events_mut().push(LogStaticStrInteropEvent {
+            time: i as i64,
+            level: 2,
+            target: "target_name".into(),
+            msg: "my log message".into(),
+        });
+    }
+    let mut block = stream.replace_block(Arc::new(LogBlock::new(BUF, process_id, stream_id, 0)));
+    Arc::get_mut(&mut block).unwrap().close();
+    let encoded = block.encode_bin(&process_info).unwrap();
+    let meta = StreamMetadata::from_stream_info(&make_stream_info(&stream)).unwrap();
+    (meta, received_payload(encoded))
+}
+
+fn received_payload(encoded: Vec<u8>) -> BlockPayload {
+    let received: Block = ciborium::from_reader(&encoded[..]).unwrap();
+    received.payload
+}
+
+/// Counts allocations during exactly one `parse_block` call.
+fn measure(meta: &StreamMetadata, payload: &BlockPayload) -> (usize, usize, u64) {
+    // Warm up once (caches, lazy statics) outside the counted region.
+    parse_block(meta, payload, |_| Ok(true)).unwrap();
+    ALLOCS.store(0, Ordering::SeqCst);
+    BYTES.store(0, Ordering::SeqCst);
+    COUNTING.store(true, Ordering::SeqCst);
+    let mut count = 0u64;
+    parse_block(meta, payload, |v| {
+        std::hint::black_box(&v);
+        count += 1;
+        Ok(true)
+    })
+    .unwrap();
+    COUNTING.store(false, Ordering::SeqCst);
+    (
+        ALLOCS.load(Ordering::SeqCst),
+        BYTES.load(Ordering::SeqCst),
+        count,
+    )
+}
+
+fn report(label: &str, meta: &StreamMetadata, payload: &BlockPayload) -> f64 {
+    let (allocs, bytes, count) = measure(meta, payload);
+    let per_obj = allocs as f64 / count as f64;
+    println!(
+        "parse_block[{label}]: N={count} allocs={allocs} bytes={bytes} allocs/obj={per_obj:.3} bytes/obj={:.1}",
+        bytes as f64 / count as f64
+    );
+    per_obj
+}
+
+#[test]
+fn parse_block_allocation_profile() {
+    let span = build_span_block();
+    let logs = build_log_block();
+    let span_per_obj = report("thread_spans", &span.0, &span.1);
+    let log_per_obj = report("log_static", &logs.0, &logs.1);
+
+    // Regression guard. With the bump arena, per-object heap allocation is
+    // eliminated: only fixed per-block costs (readers map, deps map, decompress
+    // buffers, arena chunks) remain, amortized to ~0.01 allocs/object at N=4096.
+    // The 0.5 ceiling catches any return of per-object allocation (which would be
+    // ~3-4) while leaving generous headroom for platform/allocator variance.
+    // (Pre-arena baseline was ~3.0 for spans, ~4.0 for logs.)
+    assert!(
+        span_per_obj < 0.5,
+        "thread_spans allocs/object regressed: {span_per_obj:.3} (expected ~0.01)"
+    );
+    assert!(
+        log_per_obj < 0.5,
+        "log_static allocs/object regressed: {log_per_obj:.3} (expected ~0.01)"
+    );
+}

--- a/rust/analytics/tests/parse_block_tests.rs
+++ b/rust/analytics/tests/parse_block_tests.rs
@@ -1,21 +1,21 @@
 use jsonb::Value as JsonbValue;
 use micromegas_transit::value::{Object, Value as TransitValue};
-use std::{borrow::Cow, sync::Arc};
+use std::borrow::Cow;
 
 // Re-export the conversion function for testing
 use micromegas_analytics::lakehouse::parse_block_table_function::transit_value_to_jsonb;
 
 #[test]
 fn test_transit_string_to_jsonb() {
-    let val = TransitValue::String(Arc::new("hello".to_string()));
-    let jsonb = transit_value_to_jsonb(&val);
+    let val = TransitValue::String("hello");
+    let jsonb = transit_value_to_jsonb(val);
     assert!(matches!(jsonb, JsonbValue::String(s) if s == "hello"));
 }
 
 #[test]
 fn test_transit_u8_to_jsonb() {
     let val = TransitValue::U8(42);
-    let jsonb = transit_value_to_jsonb(&val);
+    let jsonb = transit_value_to_jsonb(val);
     assert!(matches!(
         jsonb,
         JsonbValue::Number(jsonb::Number::UInt64(42))
@@ -25,7 +25,7 @@ fn test_transit_u8_to_jsonb() {
 #[test]
 fn test_transit_u32_to_jsonb() {
     let val = TransitValue::U32(100_000);
-    let jsonb = transit_value_to_jsonb(&val);
+    let jsonb = transit_value_to_jsonb(val);
     assert!(matches!(
         jsonb,
         JsonbValue::Number(jsonb::Number::UInt64(100_000))
@@ -35,7 +35,7 @@ fn test_transit_u32_to_jsonb() {
 #[test]
 fn test_transit_u64_to_jsonb() {
     let val = TransitValue::U64(999_999_999);
-    let jsonb = transit_value_to_jsonb(&val);
+    let jsonb = transit_value_to_jsonb(val);
     assert!(matches!(
         jsonb,
         JsonbValue::Number(jsonb::Number::UInt64(999_999_999))
@@ -45,7 +45,7 @@ fn test_transit_u64_to_jsonb() {
 #[test]
 fn test_transit_i64_to_jsonb() {
     let val = TransitValue::I64(-42);
-    let jsonb = transit_value_to_jsonb(&val);
+    let jsonb = transit_value_to_jsonb(val);
     assert!(matches!(
         jsonb,
         JsonbValue::Number(jsonb::Number::Int64(-42))
@@ -55,7 +55,7 @@ fn test_transit_i64_to_jsonb() {
 #[test]
 fn test_transit_f64_to_jsonb() {
     let val = TransitValue::F64(std::f64::consts::PI);
-    let jsonb = transit_value_to_jsonb(&val);
+    let jsonb = transit_value_to_jsonb(val);
     match jsonb {
         JsonbValue::Number(jsonb::Number::Float64(v)) => {
             assert!((v - std::f64::consts::PI).abs() < f64::EPSILON);
@@ -67,24 +67,22 @@ fn test_transit_f64_to_jsonb() {
 #[test]
 fn test_transit_none_to_jsonb() {
     let val = TransitValue::None;
-    let jsonb = transit_value_to_jsonb(&val);
+    let jsonb = transit_value_to_jsonb(val);
     assert!(matches!(jsonb, JsonbValue::Null));
 }
 
 #[test]
 fn test_transit_object_to_jsonb() {
+    let members = [
+        ("msg", TransitValue::String("hello")),
+        ("level", TransitValue::U8(3)),
+    ];
     let obj = Object {
-        type_name: Arc::new("TestEvent".to_string()),
-        members: vec![
-            (
-                Arc::new("msg".to_string()),
-                TransitValue::String(Arc::new("hello".to_string())),
-            ),
-            (Arc::new("level".to_string()), TransitValue::U8(3)),
-        ],
+        type_name: "TestEvent",
+        members: &members,
     };
-    let val = TransitValue::Object(Arc::new(obj));
-    let jsonb = transit_value_to_jsonb(&val);
+    let val = TransitValue::Object(&obj);
+    let jsonb = transit_value_to_jsonb(val);
     match jsonb {
         JsonbValue::Object(map) => {
             assert_eq!(
@@ -103,19 +101,18 @@ fn test_transit_object_to_jsonb() {
 
 #[test]
 fn test_transit_nested_object_to_jsonb() {
+    let inner_members = [("x", TransitValue::I64(99))];
     let inner = Object {
-        type_name: Arc::new("Inner".to_string()),
-        members: vec![(Arc::new("x".to_string()), TransitValue::I64(99))],
+        type_name: "Inner",
+        members: &inner_members,
     };
+    let outer_members = [("child", TransitValue::Object(&inner))];
     let outer = Object {
-        type_name: Arc::new("Outer".to_string()),
-        members: vec![(
-            Arc::new("child".to_string()),
-            TransitValue::Object(Arc::new(inner)),
-        )],
+        type_name: "Outer",
+        members: &outer_members,
     };
-    let val = TransitValue::Object(Arc::new(outer));
-    let jsonb = transit_value_to_jsonb(&val);
+    let val = TransitValue::Object(&outer);
+    let jsonb = transit_value_to_jsonb(val);
     match jsonb {
         JsonbValue::Object(map) => {
             assert_eq!(
@@ -142,19 +139,17 @@ fn test_transit_nested_object_to_jsonb() {
 
 #[test]
 fn test_transit_value_roundtrip_to_jsonb_bytes() {
+    let members = [
+        ("msg", TransitValue::String("test")),
+        ("count", TransitValue::U64(42)),
+        ("empty", TransitValue::None),
+    ];
     let obj = Object {
-        type_name: Arc::new("LogEvent".to_string()),
-        members: vec![
-            (
-                Arc::new("msg".to_string()),
-                TransitValue::String(Arc::new("test".to_string())),
-            ),
-            (Arc::new("count".to_string()), TransitValue::U64(42)),
-            (Arc::new("empty".to_string()), TransitValue::None),
-        ],
+        type_name: "LogEvent",
+        members: &members,
     };
-    let val = TransitValue::Object(Arc::new(obj));
-    let jsonb = transit_value_to_jsonb(&val);
+    let val = TransitValue::Object(&obj);
+    let jsonb = transit_value_to_jsonb(val);
     let mut buf = Vec::new();
     jsonb.write_to_vec(&mut buf);
     // Verify we get non-empty JSONB bytes

--- a/rust/analytics/tests/property_set_jsonb_dictionary_builder_tests.rs
+++ b/rust/analytics/tests/property_set_jsonb_dictionary_builder_tests.rs
@@ -1,26 +1,22 @@
 use anyhow::Result;
+use bumpalo::Bump;
 use datafusion::arrow::array::Array;
 use micromegas_analytics::properties::property_set::PropertySet;
 use micromegas_analytics::properties::property_set_jsonb_dictionary_builder::PropertySetJsonbDictionaryBuilder;
 use micromegas_transit::value::{Object, Value};
-use std::sync::Arc;
 
-fn create_test_property_set(props: Vec<(&str, &str)>) -> PropertySet {
-    let members = props
-        .into_iter()
-        .map(|(k, v)| {
-            (
-                Arc::new(k.to_string()),
-                Value::String(Arc::new(v.to_string())),
-            )
-        })
+/// Allocates a `PropertySet` in `bump`, mirroring how the parser produces them.
+/// Each call allocates a distinct arena object, so two calls with identical
+/// content still get distinct identity pointers (matching real per-block dedup).
+fn create_test_property_set<'a>(bump: &'a Bump, props: &[(&str, &str)]) -> PropertySet<'a> {
+    let members: Vec<(&'a str, Value<'a>)> = props
+        .iter()
+        .map(|(k, v)| (&*bump.alloc_str(k), Value::String(bump.alloc_str(v))))
         .collect();
-
-    let obj = Arc::new(Object {
-        type_name: Arc::new("TestPropertySet".to_string()),
-        members,
+    let obj: &Object = bump.alloc(Object {
+        type_name: "TestPropertySet",
+        members: bump.alloc_slice_copy(&members),
     });
-
     PropertySet::new(obj)
 }
 
@@ -33,8 +29,9 @@ fn test_empty_builder() {
 
 #[test]
 fn test_single_property_set() -> Result<()> {
+    let bump = Bump::new();
     let mut builder = PropertySetJsonbDictionaryBuilder::new(1);
-    let props = create_test_property_set(vec![("key1", "value1")]);
+    let props = create_test_property_set(&bump, &[("key1", "value1")]);
 
     builder.append_property_set(&props)?;
 
@@ -47,10 +44,11 @@ fn test_single_property_set() -> Result<()> {
 
 #[test]
 fn test_duplicate_property_sets() -> Result<()> {
+    let bump = Bump::new();
     let mut builder = PropertySetJsonbDictionaryBuilder::new(3);
-    let props1 = create_test_property_set(vec![("key1", "value1")]);
-    let props2 = create_test_property_set(vec![("key2", "value2")]);
-    let props1_again = props1.clone(); // Same Arc<Object> pointer
+    let props1 = create_test_property_set(&bump, &[("key1", "value1")]);
+    let props2 = create_test_property_set(&bump, &[("key2", "value2")]);
+    let props1_again = props1; // Same arena object pointer (PropertySet is Copy)
 
     builder.append_property_set(&props1)?;
     builder.append_property_set(&props2)?;
@@ -71,8 +69,9 @@ fn test_duplicate_property_sets() -> Result<()> {
 
 #[test]
 fn test_null_values() -> Result<()> {
+    let bump = Bump::new();
     let mut builder = PropertySetJsonbDictionaryBuilder::new(2);
-    let props = create_test_property_set(vec![("key1", "value1")]);
+    let props = create_test_property_set(&bump, &[("key1", "value1")]);
 
     builder.append_null();
     builder.append_property_set(&props)?;
@@ -90,11 +89,12 @@ fn test_null_values() -> Result<()> {
 
 #[test]
 fn test_pointer_based_deduplication() -> Result<()> {
+    let bump = Bump::new();
     let mut builder = PropertySetJsonbDictionaryBuilder::new(4);
 
-    // Create two PropertySets with same content but different Arc<Object> instances
-    let props1 = create_test_property_set(vec![("key1", "value1")]);
-    let props2 = create_test_property_set(vec![("key1", "value1")]); // Same content, different Arc
+    // Create two PropertySets with same content but distinct arena objects
+    let props1 = create_test_property_set(&bump, &[("key1", "value1")]);
+    let props2 = create_test_property_set(&bump, &[("key1", "value1")]); // Same content, different object
 
     builder.append_property_set(&props1)?;
     builder.append_property_set(&props2)?;

--- a/rust/datafusion-wasm/Cargo.lock
+++ b/rust/datafusion-wasm/Cargo.lock
@@ -2461,6 +2461,7 @@ name = "micromegas-tracing"
 version = "0.27.0"
 dependencies = [
  "anyhow",
+ "bumpalo",
  "chrono",
  "getrandom 0.3.4",
  "internment",
@@ -2493,6 +2494,7 @@ name = "micromegas-transit"
 version = "0.27.0"
 dependencies = [
  "anyhow",
+ "bumpalo",
  "lazy_static",
  "log",
  "micromegas-derive-transit",

--- a/rust/tracing/Cargo.toml
+++ b/rust/tracing/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Native-only: transit + platform deps
+bumpalo.workspace = true
 internment.workspace = true
 memoffset.workspace = true
 micromegas-transit.workspace = true

--- a/rust/tracing/src/lib.rs
+++ b/rust/tracing/src/lib.rs
@@ -152,10 +152,6 @@ pub mod test_utils;
 #[cfg(feature = "tokio")]
 pub mod runtime;
 
-#[cfg_attr(target_arch = "wasm32", allow(unused_imports))]
-#[macro_use]
-extern crate lazy_static;
-
 #[macro_use]
 mod macros;
 

--- a/rust/tracing/src/parsing.rs
+++ b/rust/tracing/src/parsing.rs
@@ -1,79 +1,86 @@
 //! Manual parsing of dynamically sized events
 use anyhow::{Context, Result};
+use bumpalo::Bump;
 use micromegas_transit::{
-    CustomReaderMap, InProcSerialize, LegacyDynString, UserDefinedType, advance_window,
-    parse_pod_instance, read_advance_string, read_consume_pod,
+    CustomReaderMap, UserDefinedType, advance_window, parse_pod_instance, read_advance_string_in,
+    read_consume_pod,
     value::{Object, Value},
 };
 use std::{collections::HashMap, sync::Arc};
 
 use crate::property_set::PROPERTY_SET_DEP_TYPE_NAME;
 
-lazy_static::lazy_static! {
-    static ref DATA: Arc<String> = Arc::new("data".into());
-    static ref DESC: Arc<String> = Arc::new("desc".into());
-    static ref FORMAT: Arc<String> = Arc::new("format".into());
-    static ref LEVEL: Arc<String> = Arc::new("level".into());
-    static ref MSG: Arc<String> = Arc::new("msg".into());
-    static ref NAME: Arc<String> = Arc::new("name".into());
-    static ref PROPERTIES: Arc<String> = Arc::new("properties".into());
-    static ref TARGET: Arc<String> = Arc::new("target".into());
-    static ref TIME: Arc<String> = Arc::new("time".into());
-}
+// Member names: 'static string literals reborrow into the parse arena lifetime for free.
+const DATA: &str = "data";
+const DESC: &str = "desc";
+const FORMAT: &str = "format";
+const ID: &str = "id";
+const LEVEL: &str = "level";
+const MSG: &str = "msg";
+const NAME: &str = "name";
+const PROPERTIES: &str = "properties";
+const TARGET: &str = "target";
+const TIME: &str = "time";
+const VALUE: &str = "value";
 
-fn parse_log_string_event(
-    udt: &UserDefinedType,
-    _udts: &[UserDefinedType],
-    dependencies: &HashMap<u64, Value>,
-    mut object_window: &[u8],
-) -> Result<Value> {
+const PROPERTY_SET_TYPE_NAME: &str = "property_set";
+
+fn parse_log_string_event<'a>(
+    bump: &'a Bump,
+    udt: &'a UserDefinedType,
+    _udts: &'a [UserDefinedType],
+    dependencies: &HashMap<u64, Value<'a>>,
+    mut object_window: &'a [u8],
+) -> Result<Value<'a>> {
     let desc_id: u64 = read_consume_pod(&mut object_window);
     let time: i64 = read_consume_pod(&mut object_window);
-    let msg = String::from_utf8(object_window.to_vec()).with_context(|| "parsing legacy string")?;
-    let desc = dependencies
+    // legacy format: the remaining bytes are the (utf8) message
+    let msg = std::str::from_utf8(object_window).with_context(|| "parsing legacy string")?;
+    let desc = *dependencies
         .get(&desc_id)
         .with_context(|| format!("desc member {desc_id} of LogStringEvent not found"))?;
-    let members = vec![
-        (TIME.clone(), Value::I64(time)),
-        (MSG.clone(), Value::String(Arc::new(msg))),
-        (DESC.clone(), desc.clone()),
-    ];
-    Ok(Value::Object(Arc::new(Object {
-        type_name: udt.name.clone(),
+    let members = bump.alloc_slice_copy(&[
+        (TIME, Value::I64(time)),
+        (MSG, Value::String(msg)),
+        (DESC, desc),
+    ]);
+    Ok(Value::Object(bump.alloc(Object {
+        type_name: udt.name.as_str(),
         members,
     })))
 }
 
-fn parse_log_string_event_v2(
-    udt: &UserDefinedType,
-    _udts: &[UserDefinedType],
-    dependencies: &HashMap<u64, Value>,
-    mut object_window: &[u8],
-) -> Result<Value> {
+fn parse_log_string_event_v2<'a>(
+    bump: &'a Bump,
+    udt: &'a UserDefinedType,
+    _udts: &'a [UserDefinedType],
+    dependencies: &HashMap<u64, Value<'a>>,
+    mut object_window: &'a [u8],
+) -> Result<Value<'a>> {
     let desc_id: u64 = read_consume_pod(&mut object_window);
     let time: i64 = read_consume_pod(&mut object_window);
-    let msg = read_advance_string(&mut object_window).with_context(|| "parsing string")?;
-    let desc: Value = dependencies
+    let msg = read_advance_string_in(bump, &mut object_window).with_context(|| "parsing string")?;
+    let desc = *dependencies
         .get(&desc_id)
-        .with_context(|| format!("desc member {desc_id} of LogStringEvent not found"))?
-        .clone();
-    let members = vec![
-        (TIME.clone(), Value::I64(time)),
-        (MSG.clone(), Value::String(Arc::new(msg))),
-        (DESC.clone(), desc),
-    ];
-    Ok(Value::Object(Arc::new(Object {
-        type_name: udt.name.clone(),
+        .with_context(|| format!("desc member {desc_id} of LogStringEvent not found"))?;
+    let members = bump.alloc_slice_copy(&[
+        (TIME, Value::I64(time)),
+        (MSG, Value::String(msg)),
+        (DESC, desc),
+    ]);
+    Ok(Value::Object(bump.alloc(Object {
+        type_name: udt.name.as_str(),
         members,
     })))
 }
 
-fn parse_log_string_interop_event_v3(
-    udt: &UserDefinedType,
-    udts: &[UserDefinedType],
-    dependencies: &HashMap<u64, Value>,
-    mut object_window: &[u8],
-) -> Result<Value> {
+fn parse_log_string_interop_event_v3<'a>(
+    bump: &'a Bump,
+    udt: &'a UserDefinedType,
+    udts: &'a [UserDefinedType],
+    dependencies: &HashMap<u64, Value<'a>>,
+    mut object_window: &'a [u8],
+) -> Result<Value<'a>> {
     let string_ref_metadata = udts
         .iter()
         .find(|t| *t.name == "StaticStringRef")
@@ -83,6 +90,7 @@ fn parse_log_string_interop_event_v3(
     let time: i64 = read_consume_pod(&mut object_window);
     let level: u8 = read_consume_pod(&mut object_window);
     let target = parse_pod_instance(
+        bump,
         string_ref_metadata,
         udts,
         dependencies,
@@ -90,25 +98,26 @@ fn parse_log_string_interop_event_v3(
     )
     .with_context(|| "parse_pod_instance")?;
     object_window = advance_window(object_window, string_ref_metadata.size);
-    let msg = read_advance_string(&mut object_window)?;
-    let members = vec![
-        (TIME.clone(), Value::I64(time)),
-        (LEVEL.clone(), Value::U8(level)),
-        (TARGET.clone(), target),
-        (MSG.clone(), Value::String(Arc::new(msg))),
-    ];
-    Ok(Value::Object(Arc::new(Object {
-        type_name: udt.name.clone(),
+    let msg = read_advance_string_in(bump, &mut object_window)?;
+    let members = bump.alloc_slice_copy(&[
+        (TIME, Value::I64(time)),
+        (LEVEL, Value::U8(level)),
+        (TARGET, target),
+        (MSG, Value::String(msg)),
+    ]);
+    Ok(Value::Object(bump.alloc(Object {
+        type_name: udt.name.as_str(),
         members,
     })))
 }
 
-fn parse_tagged_log_interop_event(
-    udt: &UserDefinedType,
-    udts: &[UserDefinedType],
-    dependencies: &HashMap<u64, Value>,
-    mut object_window: &[u8],
-) -> Result<Value> {
+fn parse_tagged_log_interop_event<'a>(
+    bump: &'a Bump,
+    udt: &'a UserDefinedType,
+    udts: &'a [UserDefinedType],
+    dependencies: &HashMap<u64, Value<'a>>,
+    mut object_window: &'a [u8],
+) -> Result<Value<'a>> {
     let string_ref_metadata = udts
         .iter()
         .find(|t| *t.name == "StaticStringRef")
@@ -118,6 +127,7 @@ fn parse_tagged_log_interop_event(
     let time: i64 = read_consume_pod(&mut object_window);
     let level: u8 = read_consume_pod(&mut object_window);
     let target = parse_pod_instance(
+        bump,
         string_ref_metadata,
         udts,
         dependencies,
@@ -126,158 +136,165 @@ fn parse_tagged_log_interop_event(
     .with_context(|| "parse_pod_instance")?;
     object_window = advance_window(object_window, string_ref_metadata.size);
     let properties_id: u64 = read_consume_pod(&mut object_window);
-    let properties = dependencies
+    let properties = *dependencies
         .get(&properties_id)
-        .with_context(|| "fetching properties in parse_tagged_log_interop_event")?
-        .clone();
-    let msg = read_advance_string(&mut object_window)?;
-    let members = vec![
-        (TIME.clone(), Value::I64(time)),
-        (LEVEL.clone(), Value::U8(level)),
-        (TARGET.clone(), target),
-        (PROPERTIES.clone(), properties),
-        (MSG.clone(), Value::String(Arc::new(msg))),
-    ];
-    Ok(Value::Object(Arc::new(Object {
-        type_name: udt.name.clone(),
+        .with_context(|| "fetching properties in parse_tagged_log_interop_event")?;
+    let msg = read_advance_string_in(bump, &mut object_window)?;
+    let members = bump.alloc_slice_copy(&[
+        (TIME, Value::I64(time)),
+        (LEVEL, Value::U8(level)),
+        (TARGET, target),
+        (PROPERTIES, properties),
+        (MSG, Value::String(msg)),
+    ]);
+    Ok(Value::Object(bump.alloc(Object {
+        type_name: udt.name.as_str(),
         members,
     })))
 }
 
-fn parse_tagged_log_string(
-    udt: &UserDefinedType,
-    _udts: &[UserDefinedType],
-    dependencies: &HashMap<u64, Value>,
-    mut object_window: &[u8],
-) -> Result<Value> {
+fn parse_tagged_log_string<'a>(
+    bump: &'a Bump,
+    udt: &'a UserDefinedType,
+    _udts: &'a [UserDefinedType],
+    dependencies: &HashMap<u64, Value<'a>>,
+    mut object_window: &'a [u8],
+) -> Result<Value<'a>> {
     let desc_id: u64 = read_consume_pod(&mut object_window);
-    let desc = dependencies
+    let desc = *dependencies
         .get(&desc_id)
-        .with_context(|| "fetching desc in parse_tagged_log_string")?
-        .clone();
+        .with_context(|| "fetching desc in parse_tagged_log_string")?;
     let properties_id: u64 = read_consume_pod(&mut object_window);
-    let properties = dependencies
+    let properties = *dependencies
         .get(&properties_id)
-        .with_context(|| "fetching property set in parse_tagged_log_string")?
-        .clone();
+        .with_context(|| "fetching property set in parse_tagged_log_string")?;
     let time: i64 = read_consume_pod(&mut object_window);
-    let msg = read_advance_string(&mut object_window)?;
+    let msg = read_advance_string_in(bump, &mut object_window)?;
 
-    let members = vec![
-        (TIME.clone(), Value::I64(time)),
-        (DESC.clone(), desc),
-        (PROPERTIES.clone(), properties),
-        (MSG.clone(), Value::String(Arc::new(msg))),
-    ];
-    Ok(Value::Object(Arc::new(Object {
-        type_name: udt.name.clone(),
+    let members = bump.alloc_slice_copy(&[
+        (TIME, Value::I64(time)),
+        (DESC, desc),
+        (PROPERTIES, properties),
+        (MSG, Value::String(msg)),
+    ]);
+    Ok(Value::Object(bump.alloc(Object {
+        type_name: udt.name.as_str(),
         members,
     })))
 }
 
-fn parse_log_string_interop_event(
-    udt: &UserDefinedType,
-    udts: &[UserDefinedType],
-    dependencies: &HashMap<u64, Value>,
-    mut object_window: &[u8],
-) -> Result<Value> {
+fn parse_log_string_interop_event<'a>(
+    bump: &'a Bump,
+    udt: &'a UserDefinedType,
+    udts: &'a [UserDefinedType],
+    dependencies: &HashMap<u64, Value<'a>>,
+    mut object_window: &'a [u8],
+) -> Result<Value<'a>> {
     let stringid_metadata = udts
         .iter()
         .find(|t| *t.name == "StringId")
         .with_context(|| "Can't parse log string interop event with no metadata for StringId")?;
-    unsafe {
-        let time: i64 = read_consume_pod(&mut object_window);
-        let level: u32 = read_consume_pod(&mut object_window);
-        let target = parse_pod_instance(
-            stringid_metadata,
-            udts,
-            dependencies,
-            &object_window[0..stringid_metadata.size],
-        )
-        .with_context(|| "parse_pod_instance")?;
-        object_window = advance_window(object_window, stringid_metadata.size);
-        let msg = <LegacyDynString as InProcSerialize>::read_value(object_window);
-        let members = vec![
-            (TIME.clone(), Value::I64(time)),
-            (LEVEL.clone(), Value::U32(level)),
-            (TARGET.clone(), target),
-            (MSG.clone(), Value::String(Arc::new(msg.0))),
-        ];
-        Ok(Value::Object(Arc::new(Object {
-            type_name: udt.name.clone(),
-            members,
-        })))
-    }
+    let time: i64 = read_consume_pod(&mut object_window);
+    let level: u32 = read_consume_pod(&mut object_window);
+    let target = parse_pod_instance(
+        bump,
+        stringid_metadata,
+        udts,
+        dependencies,
+        &object_window[0..stringid_metadata.size],
+    )
+    .with_context(|| "parse_pod_instance")?;
+    object_window = advance_window(object_window, stringid_metadata.size);
+    // legacy dyn string: the remaining bytes are the (utf8) message
+    let msg =
+        std::str::from_utf8(object_window).with_context(|| "parsing legacy interop string")?;
+    let members = bump.alloc_slice_copy(&[
+        (TIME, Value::I64(time)),
+        (LEVEL, Value::U32(level)),
+        (TARGET, target),
+        (MSG, Value::String(msg)),
+    ]);
+    Ok(Value::Object(bump.alloc(Object {
+        type_name: udt.name.as_str(),
+        members,
+    })))
 }
 
-fn parse_property_set(
-    _udt: &UserDefinedType,
-    udts: &[UserDefinedType],
-    dependencies: &HashMap<u64, Value>,
-    mut window: &[u8],
-) -> Result<Value> {
+fn parse_property_set<'a>(
+    bump: &'a Bump,
+    _udt: &'a UserDefinedType,
+    udts: &'a [UserDefinedType],
+    dependencies: &HashMap<u64, Value<'a>>,
+    mut window: &'a [u8],
+) -> Result<Value<'a>> {
     let property_layout = udts
         .iter()
         .find(|t| *t.name == "Property")
         .with_context(|| "could not find Property layout")?;
 
     let object_id: u64 = read_consume_pod(&mut window);
-    let nb_properties: u32 = read_consume_pod(&mut window);
-    let mut members = vec![];
+    let nb_properties = read_consume_pod::<u32>(&mut window) as usize;
+    let property_size = property_layout.size;
+    // Reject a corrupt count before reserving arena capacity: a real block holds
+    // at most window.len()/property_size properties, so a bogus large count must
+    // not trigger a huge (process-aborting) bump reservation.
+    if property_size == 0 || nb_properties > window.len() / property_size {
+        anyhow::bail!(
+            "invalid property_set: nb_properties={nb_properties} exceeds {}-byte window",
+            window.len()
+        );
+    }
+    let mut members = bumpalo::collections::Vec::with_capacity_in(nb_properties, bump);
     for i in 0..nb_properties {
-        let property_size = property_layout.size;
-        let begin = i as usize * property_size;
+        let begin = i * property_size;
         let property_window = &window[begin..begin + property_size];
         if let Value::Object(obj) =
-            parse_pod_instance(property_layout, udts, dependencies, property_window)?
+            parse_pod_instance(bump, property_layout, udts, dependencies, property_window)?
         {
             members.push((
-                obj.get::<Arc<String>>("name")?,
-                Value::String(obj.get::<Arc<String>>("value")?),
+                obj.get::<&str>("name")?,
+                Value::String(obj.get::<&str>("value")?),
             ));
         } else {
             anyhow::bail!("invalid property in propertyset");
         }
     }
 
-    lazy_static! {
-        static ref PROPERTY_SET_TYPE_NAME: Arc<String> = Arc::new("property_set".into());
-        static ref ID: Arc<String> = Arc::new("id".into());
-        static ref VALUE: Arc<String> = Arc::new("value".into());
-    }
-
-    let set = Arc::new(Object {
-        type_name: PROPERTY_SET_TYPE_NAME.clone(),
-        members,
+    let set: &Object = bump.alloc(Object {
+        type_name: PROPERTY_SET_TYPE_NAME,
+        members: members.into_bump_slice(),
     });
-    Ok(Value::Object(Arc::new(Object {
-        type_name: PROPERTY_SET_DEP_TYPE_NAME.clone(),
-        members: vec![
-            (ID.clone(), Value::U64(object_id)),
-            (VALUE.clone(), Value::Object(set)),
-        ],
+    let outer = bump.alloc_slice_copy(&[(ID, Value::U64(object_id)), (VALUE, Value::Object(set))]);
+    Ok(Value::Object(bump.alloc(Object {
+        type_name: PROPERTY_SET_DEP_TYPE_NAME.as_str(),
+        members: outer,
     })))
 }
 
-fn parse_image_event(
-    udt: &UserDefinedType,
-    _udts: &[UserDefinedType],
-    _dependencies: &HashMap<u64, Value>,
-    mut object_window: &[u8],
-) -> Result<Value> {
+fn parse_image_event<'a>(
+    bump: &'a Bump,
+    udt: &'a UserDefinedType,
+    _udts: &'a [UserDefinedType],
+    _dependencies: &HashMap<u64, Value<'a>>,
+    mut object_window: &'a [u8],
+) -> Result<Value<'a>> {
     let time: i64 = read_consume_pod(&mut object_window);
-    let name = read_advance_string(&mut object_window).with_context(|| "parsing image name")?;
-    let format = read_advance_string(&mut object_window).with_context(|| "parsing image format")?;
+    let name =
+        read_advance_string_in(bump, &mut object_window).with_context(|| "parsing image name")?;
+    let format =
+        read_advance_string_in(bump, &mut object_window).with_context(|| "parsing image format")?;
     let len: u32 = read_consume_pod(&mut object_window);
-    let data = Arc::new(object_window[..len as usize].to_vec());
-    let members = vec![
-        (TIME.clone(), Value::I64(time)),
-        (NAME.clone(), Value::String(Arc::new(name))),
-        (FORMAT.clone(), Value::String(Arc::new(format))),
-        (DATA.clone(), Value::Bytes(data)),
-    ];
-    Ok(Value::Object(Arc::new(Object {
-        type_name: udt.name.clone(),
+    // zero-copy: the blob borrows the (whole-block) source buffer; the consumer
+    // copies it into Arrow inside the parse_block callback.
+    let data: &[u8] = &object_window[..len as usize];
+    let members = bump.alloc_slice_copy(&[
+        (TIME, Value::I64(time)),
+        (NAME, Value::String(name)),
+        (FORMAT, Value::String(format)),
+        (DATA, Value::Bytes(data)),
+    ]);
+    Ok(Value::Object(bump.alloc(Object {
+        type_name: udt.name.as_str(),
         members,
     })))
 }

--- a/rust/transit/Cargo.toml
+++ b/rust/transit/Cargo.toml
@@ -13,6 +13,7 @@ authors.workspace = true
 micromegas-derive-transit = { path = "derive", version = "^0.27" }
 
 anyhow.workspace = true
+bumpalo.workspace = true
 lazy_static.workspace = true
 serde.workspace = true
 uuid.workspace = true

--- a/rust/transit/src/dyn_string.rs
+++ b/rust/transit/src/dyn_string.rs
@@ -3,6 +3,8 @@ use crate::{
     write_any,
 };
 use anyhow::Result;
+use bumpalo::Bump;
+use std::borrow::Cow;
 
 #[derive(Debug)]
 pub struct LegacyDynString(pub String);
@@ -79,6 +81,40 @@ pub fn read_advance_string(window: &mut &[u8]) -> Result<String> {
                 Ok(String::from_utf16_lossy(&*wide_slice))
             }
             StringCodec::Utf8 => Ok(String::from_utf8_lossy(string_buffer).to_string()),
+        }
+    }
+}
+
+/// Parse a string from the buffer, moving the buffer pointer forward.
+///
+/// Borrows the source buffer (`'a`) where possible: a valid-UTF-8 string is
+/// returned as a zero-copy slice of the buffer. Only the transcoded cases
+/// (UTF-16 wide, or lossy replacement of invalid bytes) allocate into the arena.
+pub fn read_advance_string_in<'a>(bump: &'a Bump, window: &mut &'a [u8]) -> Result<&'a str> {
+    let codec = StringCodec::try_from(read_consume_pod::<u8>(window))?;
+    let string_len_bytes: u32 = read_consume_pod(window);
+    let string_buffer = &window[0..(string_len_bytes as usize)];
+    *window = advance_window(window, string_len_bytes as usize);
+    match codec {
+        // Treat ANSI (windows-1252/latin1) as utf8, matching read_advance_string.
+        StringCodec::Ansi | StringCodec::Utf8 => match String::from_utf8_lossy(string_buffer) {
+            // Valid UTF-8: borrow the source buffer directly (zero-copy).
+            Cow::Borrowed(s) => Ok(s),
+            // Invalid bytes were replaced: the transcoded result lives in the arena.
+            Cow::Owned(s) => Ok(bump.alloc_str(&s)),
+        },
+        StringCodec::Wide => {
+            if !string_len_bytes.is_multiple_of(2) {
+                anyhow::bail!("wrong utf-16 buffer size");
+            }
+            // Decode UTF-16 LE without assuming the source bytes are 2-byte aligned.
+            let units = string_buffer
+                .chunks_exact(2)
+                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]));
+            let s: String = char::decode_utf16(units)
+                .map(|r| r.unwrap_or(char::REPLACEMENT_CHARACTER))
+                .collect();
+            Ok(bump.alloc_str(&s))
         }
     }
 }

--- a/rust/transit/src/parser.rs
+++ b/rust/transit/src/parser.rs
@@ -1,19 +1,33 @@
 use crate::{
-    UserDefinedType, advance_window, read_advance_string, read_any, read_consume_pod,
+    UserDefinedType, advance_window, read_advance_string_in, read_any, read_consume_pod,
     value::{Object, Value},
 };
 use anyhow::{Context, Result, bail};
+use bumpalo::Bump;
 use std::{collections::HashMap, sync::Arc};
 
-pub type CustomReader =
-    Arc<dyn Fn(&UserDefinedType, &[UserDefinedType], &HashMap<u64, Value>, &[u8]) -> Result<Value>>;
+/// A reader for a custom (dynamically-sized) transit type.
+///
+/// Two higher-ranked lifetimes keep the returned `Value<'a>` (which borrows the
+/// arena and source buffer) independent of the `&'dep` borrow of the dependency
+/// map, so the caller can insert the result back into the map afterwards.
+pub type CustomReader = Arc<
+    dyn for<'a, 'dep> Fn(
+        &'a Bump,
+        &'a UserDefinedType,
+        &'a [UserDefinedType],
+        &'dep HashMap<u64, Value<'a>>,
+        &'a [u8],
+    ) -> Result<Value<'a>>,
+>;
 pub type CustomReaderMap = HashMap<String, CustomReader>;
 
-pub fn read_dependencies(
+pub fn read_dependencies<'a>(
+    bump: &'a Bump,
     custom_readers: &CustomReaderMap,
-    udts: &[UserDefinedType],
-    buffer: &[u8],
-) -> Result<HashMap<u64, Value>> {
+    udts: &'a [UserDefinedType],
+    buffer: &'a [u8],
+) -> Result<HashMap<u64, Value<'a>>> {
     let mut hash = HashMap::new();
     let mut offset = 0;
     while offset < buffer.len() {
@@ -29,49 +43,44 @@ pub fn read_dependencies(
         let object_size = match udt.size {
             0 => {
                 //dynamic size
-                unsafe {
-                    let size_ptr = buffer.as_ptr().add(offset);
-                    let obj_size = read_any::<u32>(size_ptr);
-                    offset += std::mem::size_of::<u32>();
-                    obj_size as usize
-                }
+                let obj_size = unsafe { read_any::<u32>(buffer.as_ptr().add(offset)) };
+                offset += std::mem::size_of::<u32>();
+                obj_size as usize
             }
             static_size => static_size,
         };
 
         match udt.name.as_str() {
-            "StaticString" => unsafe {
-                let id_ptr = buffer.as_ptr().add(offset);
-                let string_id = read_any::<u64>(id_ptr);
+            "StaticString" => {
+                // zero-copy: the string borrows the (whole-block) source buffer.
+                let string_id = unsafe { read_any::<u64>(buffer.as_ptr().add(offset)) };
                 let nb_utf8_bytes = object_size - std::mem::size_of::<usize>();
-                let utf8_ptr = buffer.as_ptr().add(offset + std::mem::size_of::<usize>());
-                let slice = std::ptr::slice_from_raw_parts(utf8_ptr, nb_utf8_bytes);
-                let string =
-                    String::from(std::str::from_utf8(&*slice).with_context(|| "str::from_utf8")?);
-                let insert_res = hash.insert(string_id, Value::String(Arc::new(string)));
+                let str_start = offset + std::mem::size_of::<usize>();
+                let s = std::str::from_utf8(&buffer[str_start..str_start + nb_utf8_bytes])
+                    .with_context(|| "str::from_utf8")?;
+                let insert_res = hash.insert(string_id, Value::String(s));
                 assert!(insert_res.is_none());
-            },
+            }
             "StaticStringDependency" => {
                 let mut window = advance_window(buffer, offset);
                 let string_id: u64 = read_consume_pod(&mut window);
-                let string = read_advance_string(&mut window).with_context(|| "parsing string")?;
-
-                let insert_res = hash.insert(string_id, Value::String(Arc::new(string)));
+                let s =
+                    read_advance_string_in(bump, &mut window).with_context(|| "parsing string")?;
+                let insert_res = hash.insert(string_id, Value::String(s));
                 assert!(insert_res.is_none());
             }
             type_name => {
                 if let Some(reader) = custom_readers.get(type_name) {
                     let window = advance_window(buffer, offset);
-                    if let Value::Object(obj) = (*reader)(udt, udts, &hash, window)
+                    if let Value::Object(obj) = (*reader)(bump, udt, udts, &hash, window)
                         .with_context(|| "parsing custom dependency")?
                     {
                         let id: u64 = obj
                             .get("id")
                             .with_context(|| "reading id of custom dependency")?;
-                        let value = obj
+                        let value = *obj
                             .get_ref("value")
-                            .with_context(|| "reading value of custom dependency")?
-                            .clone();
+                            .with_context(|| "reading value of custom dependency")?;
                         let insert_res = hash.insert(id, value);
                         assert!(insert_res.is_none());
                     } else {
@@ -81,9 +90,14 @@ pub fn read_dependencies(
                     if udt.size == 0 {
                         anyhow::bail!("invalid user-defined type {:?}", udt);
                     }
-                    let instance =
-                        parse_pod_instance(udt, udts, &hash, &buffer[offset..offset + udt.size])
-                            .with_context(|| "parse_pod_instance")?;
+                    let instance = parse_pod_instance(
+                        bump,
+                        udt,
+                        udts,
+                        &hash,
+                        &buffer[offset..offset + udt.size],
+                    )
+                    .with_context(|| "parse_pod_instance")?;
                     if let Value::Object(obj) = instance {
                         let insert_res = hash.insert(obj.get::<u64>("id")?, Value::Object(obj));
                         assert!(insert_res.is_none());
@@ -97,34 +111,35 @@ pub fn read_dependencies(
     Ok(hash)
 }
 
-fn parse_custom_instance(
+fn parse_custom_instance<'a>(
+    bump: &'a Bump,
     custom_readers: &CustomReaderMap,
-    udt: &UserDefinedType,
-    udts: &[UserDefinedType],
-    dependencies: &HashMap<u64, Value>,
-    object_window: &[u8],
-) -> Result<Value> {
+    udt: &'a UserDefinedType,
+    udts: &'a [UserDefinedType],
+    dependencies: &HashMap<u64, Value<'a>>,
+    object_window: &'a [u8],
+) -> Result<Value<'a>> {
     if let Some(reader) = custom_readers.get(&*udt.name) {
-        (*reader)(udt, udts, dependencies, object_window)
+        (*reader)(bump, udt, udts, dependencies, object_window)
     } else {
         log::warn!("unknown custom object {}", &udt.name);
-        Ok(Value::Object(Arc::new(Object {
-            type_name: udt.name.clone(),
-            members: vec![],
+        Ok(Value::Object(bump.alloc(Object {
+            type_name: udt.name.as_str(),
+            members: &[],
         })))
     }
 }
 
-pub fn parse_pod_instance(
-    udt: &UserDefinedType,
-    udts: &[UserDefinedType],
-    dependencies: &HashMap<u64, Value>,
-    object_window: &[u8],
-) -> Result<Value> {
-    let mut members: Vec<(Arc<String>, Value)> = vec![];
+pub fn parse_pod_instance<'a>(
+    bump: &'a Bump,
+    udt: &'a UserDefinedType,
+    udts: &'a [UserDefinedType],
+    dependencies: &HashMap<u64, Value<'a>>,
+    object_window: &'a [u8],
+) -> Result<Value<'a>> {
+    let mut members = bumpalo::collections::Vec::with_capacity_in(udt.members.len(), bump);
     for member_meta in &udt.members {
-        let name = member_meta.name.clone();
-        let type_name = member_meta.type_name.clone();
+        let name: &'a str = member_meta.name.as_str();
         let value = if member_meta.is_reference {
             if member_meta.size < std::mem::size_of::<u64>() {
                 bail!(
@@ -134,12 +149,12 @@ pub fn parse_pod_instance(
             }
             let key = unsafe { read_any::<u64>(object_window.as_ptr().add(member_meta.offset)) };
             if let Some(v) = dependencies.get(&key) {
-                v.clone()
+                *v
             } else {
                 bail!("dependency not found: member={member_meta:?} key={key}");
             }
         } else {
-            match type_name.as_str() {
+            match member_meta.type_name.as_str() {
                 "u8" | "uint8" => {
                     assert_eq!(std::mem::size_of::<u8>(), member_meta.size);
                     unsafe {
@@ -187,6 +202,7 @@ pub fn parse_pod_instance(
                     {
                         let member_udt = &udts[index];
                         parse_pod_instance(
+                            bump,
                             member_udt,
                             udts,
                             dependencies,
@@ -205,29 +221,30 @@ pub fn parse_pod_instance(
 
     if udt.is_reference {
         // reference objects need a member called 'id' which is the key to the dependency
-        if let Some(id_index) = members.iter().position(|m| *m.0 == "id") {
-            return Ok(members[id_index].1.clone());
+        if let Some(id_index) = members.iter().position(|m| m.0 == "id") {
+            return Ok(members[id_index].1);
         }
         bail!("reference object has no 'id' member");
     }
 
-    Ok(Value::Object(Arc::new(Object {
-        type_name: udt.name.clone(),
-        members,
+    Ok(Value::Object(bump.alloc(Object {
+        type_name: udt.name.as_str(),
+        members: members.into_bump_slice(),
     })))
 }
 
 // parse_object_buffer calls fun for each object in the buffer until fun returns
 // `false`
-pub fn parse_object_buffer<F>(
+pub fn parse_object_buffer<'a, F>(
+    bump: &'a Bump,
     custom_readers: &CustomReaderMap,
-    dependencies: &HashMap<u64, Value>,
-    udts: &[UserDefinedType],
-    buffer: &[u8],
+    dependencies: &HashMap<u64, Value<'a>>,
+    udts: &'a [UserDefinedType],
+    buffer: &'a [u8],
     mut fun: F,
 ) -> Result<bool>
 where
-    F: FnMut(Value) -> Result<bool>,
+    F: FnMut(Value<'a>) -> Result<bool>,
 {
     let mut offset = 0;
     while offset < buffer.len() {
@@ -240,17 +257,15 @@ where
         let (object_size, is_size_dynamic) = match udt.size {
             0 => {
                 //dynamic size
-                unsafe {
-                    let size_ptr = buffer.as_ptr().add(offset);
-                    let obj_size = read_any::<u32>(size_ptr);
-                    offset += std::mem::size_of::<u32>();
-                    (obj_size as usize, true)
-                }
+                let obj_size = unsafe { read_any::<u32>(buffer.as_ptr().add(offset)) };
+                offset += std::mem::size_of::<u32>();
+                (obj_size as usize, true)
             }
             static_size => (static_size, false),
         };
         let instance = if is_size_dynamic {
             parse_custom_instance(
+                bump,
                 custom_readers,
                 udt,
                 udts,
@@ -259,8 +274,14 @@ where
             )
             .with_context(|| "parse_custom_instance")?
         } else {
-            parse_pod_instance(udt, udts, dependencies, &buffer[offset..offset + udt.size])
-                .with_context(|| "parse_pod_instance")?
+            parse_pod_instance(
+                bump,
+                udt,
+                udts,
+                dependencies,
+                &buffer[offset..offset + udt.size],
+            )
+            .with_context(|| "parse_pod_instance")?
         };
         if !fun(instance)? {
             return Ok(false);

--- a/rust/transit/src/value.rs
+++ b/rust/transit/src/value.rs
@@ -1,28 +1,32 @@
 use anyhow::{Result, bail};
-use std::sync::Arc;
 
-#[derive(Debug, Clone)]
-pub struct Object {
-    pub type_name: Arc<String>,
-    pub members: Vec<(Arc<String>, Value)>,
+/// A parsed object: a type name and a slice of named members.
+///
+/// All fields borrow from the parse arena (or the source buffer / stream
+/// metadata), so `Object` is `Copy` and carries no `Drop` glue. This is what
+/// lets it be bump-allocated safely.
+#[derive(Debug, Clone, Copy)]
+pub struct Object<'a> {
+    pub type_name: &'a str,
+    pub members: &'a [(&'a str, Value<'a>)],
 }
 
-impl Object {
+impl<'a> Object<'a> {
     pub fn get<T>(&self, member_name: &str) -> Result<T>
     where
-        T: TransitValue,
+        T: TransitValue<'a>,
     {
-        for m in &self.members {
-            if *m.0 == member_name {
-                return T::get(&m.1);
+        for m in self.members {
+            if m.0 == member_name {
+                return T::get(m.1);
             }
         }
         bail!("member {} not found in {:?}", member_name, self);
     }
 
-    pub fn get_ref(&self, member_name: &str) -> Result<&Value> {
-        for m in &self.members {
-            if *m.0 == member_name {
+    pub fn get_ref(&self, member_name: &str) -> Result<&'a Value<'a>> {
+        for m in self.members {
+            if m.0 == member_name {
                 return Ok(&m.1);
             }
         }
@@ -30,27 +34,25 @@ impl Object {
     }
 }
 
-pub trait TransitValue {
-    fn get(value: &Value) -> Result<Self>
-    where
-        Self: Sized;
+pub trait TransitValue<'a>: Sized {
+    fn get(value: Value<'a>) -> Result<Self>;
 }
 
-impl TransitValue for u8 {
-    fn get(value: &Value) -> Result<Self> {
+impl<'a> TransitValue<'a> for u8 {
+    fn get(value: Value<'a>) -> Result<Self> {
         if let Value::U8(val) = value {
-            Ok(*val)
+            Ok(val)
         } else {
             bail!("bad type cast u8 for value {:?}", value);
         }
     }
 }
 
-impl TransitValue for u32 {
-    fn get(value: &Value) -> Result<Self> {
+impl<'a> TransitValue<'a> for u32 {
+    fn get(value: Value<'a>) -> Result<Self> {
         match value {
-            Value::U32(val) => Ok(*val),
-            Value::U8(val) => Ok(Self::from(*val)),
+            Value::U32(val) => Ok(val),
+            Value::U8(val) => Ok(Self::from(val)),
             _ => {
                 bail!("bad type cast u32 for value {:?}", value);
             }
@@ -58,11 +60,11 @@ impl TransitValue for u32 {
     }
 }
 
-impl TransitValue for u64 {
-    fn get(value: &Value) -> Result<Self> {
+impl<'a> TransitValue<'a> for u64 {
+    fn get(value: Value<'a>) -> Result<Self> {
         match value {
-            Value::I64(val) => Ok(*val as Self),
-            Value::U64(val) => Ok(*val),
+            Value::I64(val) => Ok(val as Self),
+            Value::U64(val) => Ok(val),
             _ => {
                 bail!("bad type cast u64 for value {:?}", value)
             }
@@ -70,12 +72,12 @@ impl TransitValue for u64 {
     }
 }
 
-impl TransitValue for i64 {
+impl<'a> TransitValue<'a> for i64 {
     #[allow(clippy::cast_possible_wrap)]
-    fn get(value: &Value) -> Result<Self> {
+    fn get(value: Value<'a>) -> Result<Self> {
         match value {
-            Value::I64(val) => Ok(*val),
-            Value::U64(val) => Ok(*val as Self),
+            Value::I64(val) => Ok(val),
+            Value::U64(val) => Ok(val as Self),
             _ => {
                 bail!("bad type cast i64 for value {:?}", value)
             }
@@ -83,65 +85,79 @@ impl TransitValue for i64 {
     }
 }
 
-impl TransitValue for f64 {
-    fn get(value: &Value) -> Result<Self> {
+impl<'a> TransitValue<'a> for f64 {
+    fn get(value: Value<'a>) -> Result<Self> {
         if let Value::F64(val) = value {
-            Ok(*val)
+            Ok(val)
         } else {
             bail!("bad type cast f64 for value {:?}", value);
         }
     }
 }
 
-impl TransitValue for Arc<String> {
-    fn get(value: &Value) -> Result<Self> {
+impl<'a> TransitValue<'a> for &'a str {
+    fn get(value: Value<'a>) -> Result<Self> {
         if let Value::String(val) = value {
-            Ok(val.clone())
+            Ok(val)
         } else {
-            bail!("bad type cast String for value {:?}", value);
+            bail!("bad type cast str for value {:?}", value);
         }
     }
 }
 
-impl TransitValue for Arc<Object> {
-    fn get(value: &Value) -> Result<Self> {
+impl<'a> TransitValue<'a> for &'a Object<'a> {
+    fn get(value: Value<'a>) -> Result<Self> {
         if let Value::Object(val) = value {
-            Ok(val.clone())
+            Ok(val)
         } else {
-            bail!("bad type cast String for value {:?}", value);
+            bail!("bad type cast Object for value {:?}", value);
         }
     }
 }
 
-impl TransitValue for Arc<Vec<u8>> {
-    fn get(value: &Value) -> Result<Self> {
+impl<'a> TransitValue<'a> for &'a [u8] {
+    fn get(value: Value<'a>) -> Result<Self> {
         if let Value::Bytes(val) = value {
-            Ok(val.clone())
+            Ok(val)
         } else {
-            bail!("bad type cast Vec<u8> for value {:?}", value);
+            bail!("bad type cast bytes for value {:?}", value);
         }
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum Value {
-    Bytes(Arc<Vec<u8>>),
+/// A schemaless runtime value parsed from a transit buffer.
+///
+/// Every variant is a primitive or a shared borrow, so `Value` is `Copy` and
+/// `Drop`-free; it can be stored in a bump arena and discarded by resetting the
+/// arena rather than by running destructors.
+#[derive(Debug, Clone, Copy)]
+pub enum Value<'a> {
+    Bytes(&'a [u8]),
     F64(f64),
     I64(i64),
     None,
-    Object(Arc<Object>),
-    String(Arc<String>),
+    Object(&'a Object<'a>),
+    String(&'a str),
     U8(u8),
     U32(u32),
     U64(u64),
 }
 
-impl Value {
-    pub fn as_str(&self) -> Option<&str> {
-        if let Value::String(s) = &self {
-            Some(s.as_str())
+impl<'a> Value<'a> {
+    pub fn as_str(&self) -> Option<&'a str> {
+        if let Value::String(s) = self {
+            Some(*s)
         } else {
             None
         }
     }
 }
+
+// Compile-time guarantee that the arena-allocated representation stays `Copy`
+// (hence `Drop`-free): bump allocation never runs destructors, so a `Drop` type
+// here would leak.
+const _: fn() = || {
+    fn assert_copy<T: Copy>() {}
+    assert_copy::<Value<'static>>();
+    assert_copy::<Object<'static>>();
+};


### PR DESCRIPTION
Replace the Arc-based transit `Value` model with a zero-copy, bump-arena representation, eliminating nearly all per-object heap allocation in the block parse path (logs, metrics, spans). Parsing is ~3x faster and does hundreds of times fewer heap allocations per object.

## Motivation

`parse_block` is on every read path: the lakehouse materializes raw telemetry blocks into Parquet by parsing them through transit. The old `Value`/`Object` model allocated heavily per object — a `Vec` of members, an `Arc<Object>` wrapper, and per-member `Arc<String>` clones — so a block of N events did O(N) small allocations plus atomic refcount traffic, all discarded immediately after the row was written to Arrow.

## Approach

`Value`/`Object` become `Copy`, `Drop`-free borrows parameterized by a lifetime:

    enum Value<'a>  { Bytes(&'a [u8]), Object(&'a Object<'a>), String(&'a str), I64(i64), ... }
    struct Object<'a> { type_name: &'a str, members: &'a [(&'a str, Value<'a>)] }

All parsed data lives in a single bumpalo arena per block, or is borrowed directly from the decompressed buffer / stream metadata:

- POD events parse their members into an arena slice; member and type names borrow the long-lived stream metadata (no allocation).
- Interned `StaticString` dependencies and image blobs borrow the source buffer directly (zero-copy).
- Dynamic UTF-8 strings borrow the source buffer too; only transcoded (UTF-16 / lossy) strings are copied into the arena.
- `parse_block` takes a higher-ranked `for<'a> FnMut(Value<'a>)` callback, so a `Value` cannot escape the arena — consumers copy what they keep into Arrow inside the callback (Arrow owns its own buffers).

The arena is dropped wholesale when the block finishes: O(1) cleanup instead of O(N) frees, and no atomic refcounting on the hot path.

Cross-block consumers (the call-tree and net-span builders) retain data beyond a single block, so they copy strings to owned at the retention boundary — once per distinct scope, not per event.

## Results

Criterion, release build, 4096 objects/block (per object, full `parse_block` including decompression):

| view         | before | after  | speedup |
|--------------|--------|--------|---------|
| thread_spans | 361 ns | 125 ns | 2.9x    |
| measures     | 252 ns |  82 ns | 3.1x    |
| log_static   | 511 ns | 167 ns | 3.1x    |

Heap allocations per object (counting global allocator):

| view         | before | after | reduction |
|--------------|--------|-------|-----------|
| thread_spans | 3.01   | 0.008 | ~370x     |
| log_static   | 4.01   | 0.007 | ~570x     |

Per-object heap allocation is effectively gone; the few remaining allocations per block are fixed costs (decompression buffers, the dependency map, arena chunk growth). Peak memory per block is marginally higher, since the arena holds the block's whole parsed form at once.

## Notable details

- The custom-reader map is built once per worker thread (`thread_local!`) instead of being rebuilt on every `parse_block`.
- `parse_property_set` rejects a corrupt property count before reserving arena capacity, so a malformed block cannot trigger a huge, process- aborting reservation.
- Fixed a latent UTF-16 alignment UB: wide strings are now decoded via `u16::from_le_bytes` instead of an unaligned `u16` pointer cast.

## Breaking change

`micromegas-transit`'s `Value`, `Object`, and `TransitValue` gain a lifetime parameter — a breaking API change for that crate (major bump).

## Tests / benchmarks

- New `rust/analytics/benches/parse_block.rs` (criterion, ns/object).
- New `rust/analytics/tests/parse_alloc_test.rs` — an allocation-count regression guard (asserts < 0.5 allocs/object).
- Existing parse-path tests updated for the borrowed API; all passing.

    cargo bench -p micromegas-analytics --bench parse_block
    cargo test  -p micromegas-analytics --test parse_alloc_test -- --nocapture