### PR TITLE
object-cache: allow a list of key prefixes, fail closed by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file documents the historical progress of the Micromegas project. For curre
 * **Caching:**
   * Add a standalone range-aware S3 read cache (`micromegas-object-cache-srv`) backed by local SSD (Foyer RAM+disk): new `micromegas-object-cache` crate (cache engine + client `ObjectStore` layer) and `object-cache-srv` HTTP binary, wired into `BlobStorage`; clients fall back to the direct store on miss/error. Adds an `object-cache.Dockerfile`, MinIO-backed local test scripts, and admin docs (#1122)
   * Store `FoyerBackend` cache values as `Bytes` instead of `Vec<u8>` to avoid full-block copies on every RAM-tier read hit and fill (#1195)
+  * Accept a list of allowed key prefixes in `object-cache-srv` (comma-separated `MICROMEGAS_OBJECT_CACHE_PREFIX` or repeated `--prefix`) so it can serve both `blobs/` and `views/`; the server now fails closed with no prefixes configured, requiring an explicit `--allow-all-prefixes` dev opt-out (#1204)
 * **OTLP:**
   * Populate the `processes.username` column from `process.owner` (falling back through `process.user.name`, `process.real_user.name`, then `user.name`) and fold the resolved owner into the `process_id` derivation so processes that differ only by owning user get distinct ids; re-derivation stays under the existing `NS_OTEL_PROCESS_V1` namespace
 * **Security:**

--- a/docker/README.md
+++ b/docker/README.md
@@ -206,9 +206,10 @@ docker run -d --name analytics-web \
 | `MICROMEGAS_OBJECT_CACHE_RAM_MB` | No | In-memory cache size (default `512`) |
 | `MICROMEGAS_OBJECT_CACHE_DISK_GB` | No | On-disk cache size (default `50`) |
 | `MICROMEGAS_OBJECT_CACHE_BLOCK_SIZE` | No | Cache block size in bytes (default `1048576`) |
-| `MICROMEGAS_OBJECT_CACHE_PREFIX` | No | Restrict access to a single key prefix |
+| `MICROMEGAS_OBJECT_CACHE_PREFIX` | Yes** | Allowed key prefixes, comma-separated (e.g. `blobs,views`); only matching keys are served |
 
 *Required unless running with `--disable-auth` (development mode only)
+**Required unless running with `--allow-all-prefixes` (development mode only)
 
 ### Analytics Web App
 | Variable | Required | Description |

--- a/local_test_env/ai_scripts/start_services.py
+++ b/local_test_env/ai_scripts/start_services.py
@@ -119,15 +119,23 @@ def start_object_cache(target_dir):
     listen = "127.0.0.1:8082"
     cache_url = f"http://{listen}"
 
+    # The cache serves exactly two datasets: lake blocks under `blobs/` and
+    # lakehouse partitions under `views/`, both carrying the lake-root prefix
+    # inside each request key. Allow just those two (server fails closed on an
+    # empty list), keeping local dev's containment aligned with production.
+    roots = ["blobs", "views"]
+    if prefix:
+        roots = [f"{prefix}/{r}" for r in roots]
+    allowed_prefixes = ",".join(roots)
+
     env = os.environ.copy()
     env["MICROMEGAS_OBJECT_CACHE_ORIGIN_URI"] = origin
-    if prefix:
-        env["MICROMEGAS_OBJECT_CACHE_PREFIX"] = prefix
+    env["MICROMEGAS_OBJECT_CACHE_PREFIX"] = allowed_prefixes
     env["MICROMEGAS_OBJECT_CACHE_DISK_PATH"] = disk_path
     env["MICROMEGAS_API_KEYS"] = json.dumps([{"name": "local-dev", "key": api_key}])
 
     print("🗄️  Starting Object Cache Server...")
-    print(f"   origin={origin} prefix={prefix or '(none)'} disk={disk_path}")
+    print(f"   origin={origin} prefixes={allowed_prefixes} disk={disk_path}")
     with open("/tmp/object_cache.log", "w") as log_file:
         cache_process = subprocess.Popen(
             [str(target_dir / "micromegas-object-cache-srv"), "--listen", listen],

--- a/mkdocs/docs/admin/object-cache.md
+++ b/mkdocs/docs/admin/object-cache.md
@@ -41,7 +41,7 @@ docker run -d -p 8080:8080 \
 | `MICROMEGAS_OBJECT_CACHE_DISK_GB` | No | On-disk cache tier size (default `50`) |
 | `MICROMEGAS_OBJECT_CACHE_BLOCK_SIZE` | No | Cache block size in bytes (default `1048576`); must be > 0 |
 | `MICROMEGAS_OBJECT_CACHE_NAMESPACE` | No | Cache namespace (default: derived from the origin URI) |
-| `MICROMEGAS_OBJECT_CACHE_PREFIX` | No | Restrict served keys to this prefix |
+| `MICROMEGAS_OBJECT_CACHE_PREFIX` | Yes | Allowed key prefixes, comma-separated (e.g. `blobs,views`); only keys equal to or under a prefix are served. Required unless `--allow-all-prefixes` is set (development only) |
 | `MICROMEGAS_SHUTDOWN_GRACE_PERIOD_SECONDS` | No | Drain timeout on `SIGTERM` (default `25`) |
 
 Authenticating *against the origin* (e.g. AWS credentials) uses the same environment variables as every other Micromegas service's `MICROMEGAS_OBJECT_STORE_URI` — standard `object_store` crate variables such as `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT`, `AWS_REGION`, `AWS_ALLOW_HTTP`.

--- a/rust/object-cache-srv/README.md
+++ b/rust/object-cache-srv/README.md
@@ -48,7 +48,8 @@ All flags can be set via the listed environment variables.
 | `--disk-gb`                     | `MICROMEGAS_OBJECT_CACHE_DISK_GB`    | `50`           | Disk cache size, in GB.                                           |
 | `--block-size`                  | `MICROMEGAS_OBJECT_CACHE_BLOCK_SIZE` | `1048576`      | Cache block size, in bytes (must be > 0).                         |
 | `--namespace`                   | `MICROMEGAS_OBJECT_CACHE_NAMESPACE`  | _(derived)_    | Cache namespace. Defaults to the origin URI with the scheme stripped. |
-| `--allowed-prefix`              | `MICROMEGAS_OBJECT_CACHE_PREFIX`     | _(none)_       | If set, only keys under this prefix are served.                  |
+| `--prefix`                      | `MICROMEGAS_OBJECT_CACHE_PREFIX`     | _(required)_   | Allowed key prefixes. Repeat the flag or comma-separate the env var (e.g. `blobs,views`). Only keys equal to a prefix or under `{prefix}/` are served. The server refuses to start unless at least one is set or `--allow-all-prefixes` is passed. |
+| `--allow-all-prefixes`          |                                      | `false`        | Serve the entire bucket, bypassing prefix containment (development only). |
 | `--api-keys`                    | `MICROMEGAS_API_KEYS`                | _(none)_       | Key ring for request authentication.                             |
 | `--disable-auth`                |                                      | `false`        | Disable authentication (development only).                        |
 | `--shutdown-grace-period-seconds` | `MICROMEGAS_SHUTDOWN_GRACE_PERIOD_SECONDS` | `25`  | Graceful-shutdown grace period on `SIGTERM`.                     |

--- a/rust/object-cache-srv/src/app_state.rs
+++ b/rust/object-cache-srv/src/app_state.rs
@@ -3,5 +3,8 @@ use micromegas_object_cache::range_cache::RangeCache;
 #[derive(Clone)]
 pub(crate) struct AppState {
     pub(crate) cache: RangeCache,
-    pub(crate) allowed_prefix: String,
+    /// Prefixes a request key may fall under. Empty = allow every key; this is
+    /// only reachable via `--allow-all-prefixes`, since the server refuses to
+    /// start with an empty list otherwise.
+    pub(crate) allowed_prefixes: Vec<String>,
 }

--- a/rust/object-cache-srv/src/cli.rs
+++ b/rust/object-cache-srv/src/cli.rs
@@ -34,8 +34,21 @@ pub(crate) struct Cli {
     #[clap(long, env = "MICROMEGAS_OBJECT_CACHE_NAMESPACE", default_value = "")]
     pub(crate) namespace: String,
 
-    #[clap(long, env = "MICROMEGAS_OBJECT_CACHE_PREFIX", default_value = "")]
-    pub(crate) allowed_prefix: String,
+    /// Allowed key prefixes (repeat `--prefix`, or comma-separate the env var,
+    /// e.g. `blobs,views`). A key is served only if it equals a prefix or lies
+    /// under `{prefix}/`. Empty by default: the server refuses to start unless
+    /// at least one prefix is set or `--allow-all-prefixes` is passed.
+    #[clap(
+        long = "prefix",
+        env = "MICROMEGAS_OBJECT_CACHE_PREFIX",
+        value_delimiter = ','
+    )]
+    pub(crate) allowed_prefixes: Vec<String>,
+
+    /// Serve the entire bucket, bypassing prefix containment (development mode
+    /// only). Mirrors `--disable-auth`: an explicit opt-out, never the default.
+    #[clap(long)]
+    pub(crate) allow_all_prefixes: bool,
 
     #[clap(long, env = "MICROMEGAS_API_KEYS", default_value = "")]
     pub(crate) api_keys: String,

--- a/rust/object-cache-srv/src/handlers.rs
+++ b/rust/object-cache-srv/src/handlers.rs
@@ -1,5 +1,5 @@
 use crate::app_state::AppState;
-use crate::validation::{is_not_found, parse_range_header, validate_key};
+use crate::validation::{is_not_found, parse_range_header};
 use axum::{
     body::Body,
     extract::{Path, State},
@@ -8,6 +8,7 @@ use axum::{
 };
 use bytes::{BufMut, Bytes, BytesMut};
 use micromegas_object_cache::range_cache::RangeError;
+use micromegas_object_cache::validation::validate_key;
 use micromegas_tracing::prelude::*;
 use serde::Deserialize;
 

--- a/rust/object-cache-srv/src/handlers.rs
+++ b/rust/object-cache-srv/src/handlers.rs
@@ -25,7 +25,7 @@ pub(crate) async fn head_handler(
     Path(key): Path<String>,
     State(state): State<AppState>,
 ) -> Result<Response, StatusCode> {
-    if let Err(e) = validate_key(&key, &state.allowed_prefix) {
+    if let Err(e) = validate_key(&key, &state.allowed_prefixes) {
         warn!("rejected key {key}: {e}");
         return Err(StatusCode::BAD_REQUEST);
     }
@@ -54,7 +54,7 @@ pub(crate) async fn get_range_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Response, StatusCode> {
-    if let Err(e) = validate_key(&key, &state.allowed_prefix) {
+    if let Err(e) = validate_key(&key, &state.allowed_prefixes) {
         warn!("rejected key {key}: {e}");
         return Err(StatusCode::BAD_REQUEST);
     }
@@ -183,7 +183,7 @@ pub(crate) async fn post_ranges_handler(
     State(state): State<AppState>,
     body: Bytes,
 ) -> Result<Response, StatusCode> {
-    if let Err(e) = validate_key(&key, &state.allowed_prefix) {
+    if let Err(e) = validate_key(&key, &state.allowed_prefixes) {
         warn!("rejected key {key}: {e}");
         return Err(StatusCode::BAD_REQUEST);
     }

--- a/rust/object-cache-srv/src/object_cache_srv.rs
+++ b/rust/object-cache-srv/src/object_cache_srv.rs
@@ -86,9 +86,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cache = RangeCache::new(origin_store, Arc::new(foyer), args.block_size, ns);
 
+    // Resolve the prefix allowlist. Fail-closed like auth: an empty list is a
+    // fatal config error unless `--allow-all-prefixes` is given (dev opt-out).
+    // Reject blank entries (e.g. a trailing comma in the env var) — a blank
+    // prefix would admit every key and silently defeat containment.
+    let allowed_prefixes = if args.allow_all_prefixes {
+        warn!("Object cache: serving ALL prefixes (--allow-all-prefixes)");
+        Vec::new()
+    } else {
+        let prefixes: Vec<String> = args
+            .allowed_prefixes
+            .iter()
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty())
+            .collect();
+        if prefixes.is_empty() {
+            return Err(
+                "No allowed prefixes configured. Set MICROMEGAS_OBJECT_CACHE_PREFIX \
+                 (comma-separated, e.g. `blobs,views`) or pass --prefix, \
+                 or use --allow-all-prefixes for development"
+                    .into(),
+            );
+        }
+        info!("Object cache: allowed prefixes {prefixes:?}");
+        prefixes
+    };
+
     let state = AppState {
         cache,
-        allowed_prefix: args.allowed_prefix.clone(),
+        allowed_prefixes,
     };
 
     let auth_provider: Option<Arc<dyn AuthProvider>> = if args.disable_auth {

--- a/rust/object-cache-srv/src/validation.rs
+++ b/rust/object-cache-srv/src/validation.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, anyhow, bail};
 
-pub(crate) fn validate_key(key: &str, allowed_prefix: &str) -> Result<()> {
+pub(crate) fn validate_key(key: &str, allowed_prefixes: &[String]) -> Result<()> {
     if key.is_empty() {
         bail!("empty key");
     }
@@ -10,11 +10,19 @@ pub(crate) fn validate_key(key: &str, allowed_prefix: &str) -> Result<()> {
     if key.split('/').any(|seg| seg == "..") {
         bail!("key must not contain ..");
     }
-    if !allowed_prefix.is_empty()
-        && key != allowed_prefix
-        && !key.starts_with(&format!("{allowed_prefix}/"))
-    {
-        bail!("key {key} is outside allowed prefix {allowed_prefix}");
+    // An empty list means allow-all. This is only reachable via
+    // `--allow-all-prefixes`; the server refuses to start with an empty list
+    // otherwise (see object_cache_srv.rs), so this is never a fail-open default.
+    if allowed_prefixes.is_empty() {
+        return Ok(());
+    }
+    // Admit the key if it matches any prefix on the equal-or-`{p}/`-boundary
+    // rule, so `blobs` admits `blobs` and `blobs/x` but not `blobs-secret/y`.
+    let allowed = allowed_prefixes
+        .iter()
+        .any(|p| key == p || key.starts_with(&format!("{p}/")));
+    if !allowed {
+        bail!("key {key} is outside allowed prefixes {allowed_prefixes:?}");
     }
     Ok(())
 }
@@ -57,5 +65,56 @@ pub(crate) fn is_not_found(e: &anyhow::Error) -> bool {
         matches!(os_err, object_store::Error::NotFound { .. })
     } else {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_key;
+
+    fn prefixes(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn rejects_structurally_invalid_keys() {
+        let allowed = prefixes(&["blobs"]);
+        assert!(validate_key("", &allowed).is_err());
+        assert!(validate_key("/blobs/x", &allowed).is_err());
+        assert!(validate_key("blobs/../secret", &allowed).is_err());
+        // Traversal is rejected even in allow-all mode.
+        assert!(validate_key("a/../b", &[]).is_err());
+    }
+
+    #[test]
+    fn admits_key_under_any_configured_prefix() {
+        let allowed = prefixes(&["blobs", "views"]);
+        assert!(validate_key("blobs/p/s/b", &allowed).is_ok());
+        assert!(validate_key("views/v/x.parquet", &allowed).is_ok());
+        // A key equal to a prefix is admitted.
+        assert!(validate_key("blobs", &allowed).is_ok());
+        assert!(validate_key("views", &allowed).is_ok());
+    }
+
+    #[test]
+    fn rejects_key_outside_all_prefixes() {
+        let allowed = prefixes(&["blobs", "views"]);
+        assert!(validate_key("secret/x", &allowed).is_err());
+        assert!(validate_key("blob/x", &allowed).is_err());
+    }
+
+    #[test]
+    fn enforces_segment_boundary_per_prefix() {
+        let allowed = prefixes(&["blobs"]);
+        // `blobs-secret` shares a textual prefix but not a path boundary.
+        assert!(validate_key("blobs-secret/y", &allowed).is_err());
+        assert!(validate_key("blobsx", &allowed).is_err());
+    }
+
+    #[test]
+    fn empty_list_allows_all_valid_keys() {
+        // Reachable only via --allow-all-prefixes; still enforces structure.
+        assert!(validate_key("anything/goes/here", &[]).is_ok());
+        assert!(validate_key("secret/x", &[]).is_ok());
     }
 }

--- a/rust/object-cache-srv/src/validation.rs
+++ b/rust/object-cache-srv/src/validation.rs
@@ -1,32 +1,5 @@
 use anyhow::{Context, Result, anyhow, bail};
 
-pub(crate) fn validate_key(key: &str, allowed_prefixes: &[String]) -> Result<()> {
-    if key.is_empty() {
-        bail!("empty key");
-    }
-    if key.starts_with('/') {
-        bail!("key must not start with /");
-    }
-    if key.split('/').any(|seg| seg == "..") {
-        bail!("key must not contain ..");
-    }
-    // An empty list means allow-all. This is only reachable via
-    // `--allow-all-prefixes`; the server refuses to start with an empty list
-    // otherwise (see object_cache_srv.rs), so this is never a fail-open default.
-    if allowed_prefixes.is_empty() {
-        return Ok(());
-    }
-    // Admit the key if it matches any prefix on the equal-or-`{p}/`-boundary
-    // rule, so `blobs` admits `blobs` and `blobs/x` but not `blobs-secret/y`.
-    let allowed = allowed_prefixes
-        .iter()
-        .any(|p| key == p || key.starts_with(&format!("{p}/")));
-    if !allowed {
-        bail!("key {key} is outside allowed prefixes {allowed_prefixes:?}");
-    }
-    Ok(())
-}
-
 pub(crate) fn parse_range_header(
     header_value: &str,
     file_size: u64,
@@ -65,56 +38,5 @@ pub(crate) fn is_not_found(e: &anyhow::Error) -> bool {
         matches!(os_err, object_store::Error::NotFound { .. })
     } else {
         false
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::validate_key;
-
-    fn prefixes(list: &[&str]) -> Vec<String> {
-        list.iter().map(|s| s.to_string()).collect()
-    }
-
-    #[test]
-    fn rejects_structurally_invalid_keys() {
-        let allowed = prefixes(&["blobs"]);
-        assert!(validate_key("", &allowed).is_err());
-        assert!(validate_key("/blobs/x", &allowed).is_err());
-        assert!(validate_key("blobs/../secret", &allowed).is_err());
-        // Traversal is rejected even in allow-all mode.
-        assert!(validate_key("a/../b", &[]).is_err());
-    }
-
-    #[test]
-    fn admits_key_under_any_configured_prefix() {
-        let allowed = prefixes(&["blobs", "views"]);
-        assert!(validate_key("blobs/p/s/b", &allowed).is_ok());
-        assert!(validate_key("views/v/x.parquet", &allowed).is_ok());
-        // A key equal to a prefix is admitted.
-        assert!(validate_key("blobs", &allowed).is_ok());
-        assert!(validate_key("views", &allowed).is_ok());
-    }
-
-    #[test]
-    fn rejects_key_outside_all_prefixes() {
-        let allowed = prefixes(&["blobs", "views"]);
-        assert!(validate_key("secret/x", &allowed).is_err());
-        assert!(validate_key("blob/x", &allowed).is_err());
-    }
-
-    #[test]
-    fn enforces_segment_boundary_per_prefix() {
-        let allowed = prefixes(&["blobs"]);
-        // `blobs-secret` shares a textual prefix but not a path boundary.
-        assert!(validate_key("blobs-secret/y", &allowed).is_err());
-        assert!(validate_key("blobsx", &allowed).is_err());
-    }
-
-    #[test]
-    fn empty_list_allows_all_valid_keys() {
-        // Reachable only via --allow-all-prefixes; still enforces structure.
-        assert!(validate_key("anything/goes/here", &[]).is_ok());
-        assert!(validate_key("secret/x", &[]).is_ok());
     }
 }

--- a/rust/object-cache/src/lib.rs
+++ b/rust/object-cache/src/lib.rs
@@ -3,6 +3,7 @@ pub mod blocks;
 pub mod client;
 pub mod memory_backend;
 pub mod range_cache;
+pub mod validation;
 
 #[cfg(feature = "foyer")]
 pub mod foyer_backend;

--- a/rust/object-cache/src/validation.rs
+++ b/rust/object-cache/src/validation.rs
@@ -1,0 +1,32 @@
+use anyhow::{Result, bail};
+
+/// Validate a request key: reject structurally unsafe keys (empty, absolute, or
+/// containing `..` traversal segments) and enforce that it falls under one of
+/// the `allowed_prefixes`.
+///
+/// An empty `allowed_prefixes` list means allow-all (still enforcing structure).
+/// Callers that must fail closed are responsible for refusing to configure an
+/// empty list.
+pub fn validate_key(key: &str, allowed_prefixes: &[String]) -> Result<()> {
+    if key.is_empty() {
+        bail!("empty key");
+    }
+    if key.starts_with('/') {
+        bail!("key must not start with /");
+    }
+    if key.split('/').any(|seg| seg == "..") {
+        bail!("key must not contain ..");
+    }
+    if allowed_prefixes.is_empty() {
+        return Ok(());
+    }
+    // Admit the key if it matches any prefix on the equal-or-`{p}/`-boundary
+    // rule, so `blobs` admits `blobs` and `blobs/x` but not `blobs-secret/y`.
+    let allowed = allowed_prefixes
+        .iter()
+        .any(|p| key == p || key.starts_with(&format!("{p}/")));
+    if !allowed {
+        bail!("key {key} is outside allowed prefixes {allowed_prefixes:?}");
+    }
+    Ok(())
+}

--- a/rust/object-cache/tests/validation_tests.rs
+++ b/rust/object-cache/tests/validation_tests.rs
@@ -1,0 +1,47 @@
+use micromegas_object_cache::validation::validate_key;
+
+fn prefixes(list: &[&str]) -> Vec<String> {
+    list.iter().map(|s| s.to_string()).collect()
+}
+
+#[test]
+fn rejects_structurally_invalid_keys() {
+    let allowed = prefixes(&["blobs"]);
+    assert!(validate_key("", &allowed).is_err());
+    assert!(validate_key("/blobs/x", &allowed).is_err());
+    assert!(validate_key("blobs/../secret", &allowed).is_err());
+    // Traversal is rejected even in allow-all mode.
+    assert!(validate_key("a/../b", &[]).is_err());
+}
+
+#[test]
+fn admits_key_under_any_configured_prefix() {
+    let allowed = prefixes(&["blobs", "views"]);
+    assert!(validate_key("blobs/p/s/b", &allowed).is_ok());
+    assert!(validate_key("views/v/x.parquet", &allowed).is_ok());
+    // A key equal to a prefix is admitted.
+    assert!(validate_key("blobs", &allowed).is_ok());
+    assert!(validate_key("views", &allowed).is_ok());
+}
+
+#[test]
+fn rejects_key_outside_all_prefixes() {
+    let allowed = prefixes(&["blobs", "views"]);
+    assert!(validate_key("secret/x", &allowed).is_err());
+    assert!(validate_key("blob/x", &allowed).is_err());
+}
+
+#[test]
+fn enforces_segment_boundary_per_prefix() {
+    let allowed = prefixes(&["blobs"]);
+    // `blobs-secret` shares a textual prefix but not a path boundary.
+    assert!(validate_key("blobs-secret/y", &allowed).is_err());
+    assert!(validate_key("blobsx", &allowed).is_err());
+}
+
+#[test]
+fn empty_list_allows_all_valid_keys() {
+    // Reachable only via --allow-all-prefixes; still enforces structure.
+    assert!(validate_key("anything/goes/here", &[]).is_ok());
+    assert!(validate_key("secret/x", &[]).is_ok());
+}


### PR DESCRIPTION
## Summary
- Replace the single `MICROMEGAS_OBJECT_CACHE_PREFIX` with a list: comma-separated env var or repeated `--prefix`. A key is admitted if it matches any configured prefix on the equal-or-`{p}/`-boundary rule. This lets one cache serve both `blobs/` (telemetry block payloads) and `views/` (lakehouse partition parquet).
- The server now fails closed: it refuses to start with no prefixes configured. `--allow-all-prefixes` is an explicit dev opt-out mirroring `--disable-auth`.
- Blank entries (e.g. from trailing commas) are rejected so they can't silently re-open the whole bucket.
- Local dev script and docs updated to configure both dataset prefixes.

Closes #1204

## Test plan
- `cargo fmt --check` — passes
- `cargo clippy -p micromegas-object-cache-srv -- -D warnings` — passes
- `cargo test -p micromegas-object-cache-srv` — 5 tests pass, covering per-prefix boundary matching (`blobs-secret` rejected), equal-to-prefix admission, allow-all, empty-list-errors, and traversal rejection