### PR TITLE
blender-extension: install mold linker on ubuntu-latest

### DIFF
--- a/.github/workflows/blender-extension.yml
+++ b/.github/workflows/blender-extension.yml
@@ -32,6 +32,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # .cargo/config.toml forces -fuse-ld=mold for the native
+      # x86_64-unknown-linux-gnu target; the ubuntu-latest runner doesn't
+      # ship it by default (mirrors rust.yml's mold convention).
+      - name: Install mold linker
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y mold
+
       - name: Build native library
         working-directory: rust
         run: cargo build -p micromegas-capi --release


### PR DESCRIPTION
.cargo/config.toml forces -fuse-ld=mold for x86_64-unknown-linux-gnu, but the plain ubuntu-latest runner doesn't ship mold, breaking the native library build with "invalid linker name".