### PR TITLE
docs: document anyhow-vs-thiserror convention (#1251)

### DIFF
--- a/AI_GUIDELINES.md
+++ b/AI_GUIDELINES.md
@@ -5,6 +5,7 @@
 ### Rust
 - **Dependencies**: Always maintain alphabetical order within dependency blocks in Cargo.toml files
 - **Error Handling**: Use `expect()` with descriptive messages instead of `unwrap()`
+- **anyhow vs thiserror**: `anyhow` is the default for error propagation/reporting — use it unless the caller needs to branch on the error kind. Reach for `thiserror` (a typed error enum) only when a caller must match on which variant occurred to change behavior; the branching need justifies the typed error, not the location in the stack. The canonical example is retryability: where a path retries, model the retryable/terminal distinction as an explicit type (see `object-cache/src/range_cache/error.rs`, `otel-ingestion/src/error.rs`, `telemetry-sink/src/http_event_sink.rs`) rather than downcasting an `anyhow::Error` or matching on its message string. Don't convert the `anyhow` majority to `thiserror` — only the specific spots where callers branch on error kind.
 - **Testing**: Use `cargo test -- --nocapture` to see println! output during tests
 - **Formatting**: Always run `cargo fmt` before any commit to ensure consistent code formatting
 - **Format Strings**: Use inline format arguments `format!("value: {variable}")` instead of `format!("value: {}", variable)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Rust
 - Dependencies in alphabetical order in Cargo.toml files
 - Use `expect()` with descriptive messages instead of `unwrap()`
+- anyhow vs thiserror: see @AI_GUIDELINES.md — `anyhow` by default, `thiserror` only when a caller must branch on the error kind (e.g. retryability)
 - Run `cargo fmt` before any commit
 - Use inline format arguments: `format!("value: {variable}")`
 - Import proc macros through parent crate: `micromegas_tracing::prelude::*`


### PR DESCRIPTION
anyhow is the default for error propagation/reporting; thiserror is only for cases where the caller must branch on error kind (e.g. retryability). Audited existing downcast/string-match/retry sites and confirmed the codebase already follows this convention (RangeError, OtelError, IngestionClientError, RequestDecoratorError) - no code changes needed, only writing the rule down.