### PR TITLE
docs: add caching architecture page and per-service admin guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ This file documents the historical progress of the Micromegas project. For curre
   * Log add-on version and git commit hash on registration for easier triaging of field reports
   * Fix operator-history overflow gaps: drain the ring on every discrete input event via the recorder modal callback (per-keystroke cadence), lower the timer backstop from 1 s to 0.1 s, and set ring capacity to the correct Blender hard-cap of 32; adds `blender.action_gap` and `blender.action_captured` metrics (#1181)
   * Replace positional `bl_idname` string-diffing of the operator-history ring with per-entry object identity (`op.as_pointer()`) tracking, making new-entry detection exact and eliminating the false-gap WARN and duplicate action-log storm on repeating operator histories; gap detection reduces to a true full-ring turnover (#1181)
+* **Docs:**
+  * Add a caching architecture page describing the tiered L1/L2 object read path, and show the tiered read cache in the overview architecture diagram (#1238)
+  * Add per-service admin guides for the ingestion, FlightSQL, and maintenance-daemon services
+  * Refocus the object-cache admin guide on configuration, correcting the cache-warming and cache-client framing
+  * Fill README gaps (web app, maintenance daemon, C ABI/Blender, monolith, cache) and fix code-verified inaccuracies across the docs (schema/config references, removed UDFs, binary names)
 
 ## June 2026 - v0.26.0
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Micromegas consists of several key components:
 6.  **PostgreSQL Database:** Stores metadata about processes, streams, and data blocks, keeping the object storage indexable and fast to query.
 7.  **Object Storage (S3/GCS):** Stores all raw telemetry payloads and materialized query results in Parquet format.
 
-These roles can run as independent, horizontally-scalable services or bundled into a single `micromegas-monolith` process for local development and single-machine deployments. An optional shared read cache (`object-cache-srv`) can front the object store to cut egress cost and read latency across services.
+These roles can run as independent, horizontally-scalable services or bundled into a single `micromegas-monolith` process for local development and single-machine deployments. An optional shared read cache (`micromegas-object-cache-srv`) can front the object store to cut egress cost and read latency across services.
 
 ## Cost-Effectiveness
 

--- a/README.md
+++ b/README.md
@@ -36,17 +36,22 @@ Micromegas is an observability system designed to provide unified insights into 
 *   **☁️ Scalable & Cloud-Native:** The backend is designed to scale horizontally, capable of ingesting data from millions of concurrent processes using object storage (S3) and PostgreSQL.
 *   **💰 Cost-Efficient by Design:** Keep costs low with tail sampling and on-demand ETL. Raw data is stored cheaply and only processed when you need to query it.
 *   **🔍 Powerful SQL Interface:** Query your data using a powerful and familiar SQL interface, powered by [Apache DataFusion](https://datafusion.apache.org/) and accessible via [Apache Arrow FlightSQL](https://arrow.apache.org/blog/2022/02/16/introducing-arrow-flight-sql/).
+*   **📓 Interactive Notebooks:** A built-in web app for exploring data through composable notebook cells — queries, charts, flame graphs, maps, and logs — over the same SQL engine.
 *   **🔐 Enterprise Authentication:** Secure your data with OIDC authentication supporting both human users (browser-based login) and service accounts (OAuth 2.0 client credentials).
 
 ## How It Works
 
 Micromegas consists of several key components:
 
-1.  **Instrumentation Libraries:** Lightweight libraries for your applications (available in Rust and Unreal Engine) to send telemetry data. See [Optimism](https://github.com/madesroches/optimism) for an example Bevy project using Micromegas.
-2.  **Ingestion Service (`telemetry-ingestion-srv`):** A scalable service that receives telemetry data and writes it to blob storage.
+1.  **Instrumentation Libraries:** Lightweight libraries that send telemetry from your applications — native SDKs for Rust and Unreal Engine, a C ABI (`micromegas-capi`) for C/C++ and other FFI-capable languages, and a Blender add-on. See [Optimism](https://github.com/madesroches/optimism) for an example Bevy project using Micromegas.
+2.  **Ingestion Service (`telemetry-ingestion-srv`):** A scalable service that receives telemetry (native transit/CBOR and OTLP/HTTP) and writes it to blob storage.
 3.  **Analytics Service (`flight-sql-srv`):** A DataFusion-powered service that exposes a FlightSQL endpoint for running queries against your data.
-4.  **PostgreSQL Database:** Stores metadata about processes, streams, and data blocks, keeping the object storage indexable and fast to query.
-5.  **Object Storage (S3/GCS):** Stores all raw telemetry payloads and materialized query results in Parquet format.
+4.  **Analytics Web App (`analytics-web-srv`):** A browser UI for exploring data through interactive notebooks.
+5.  **Maintenance Daemon (`telemetry-admin`):** Runs the on-demand and continuous ETL that materializes raw blocks into Parquet views, so data is only processed when it's worth querying.
+6.  **PostgreSQL Database:** Stores metadata about processes, streams, and data blocks, keeping the object storage indexable and fast to query.
+7.  **Object Storage (S3/GCS):** Stores all raw telemetry payloads and materialized query results in Parquet format.
+
+These roles can run as independent, horizontally-scalable services or bundled into a single `micromegas-monolith` process for local development and single-machine deployments. An optional shared read cache (`object-cache-srv`) can front the object store to cut egress cost and read latency across services.
 
 ## Cost-Effectiveness
 

--- a/claude-plugin/skills/micromegas-query/SKILL.md
+++ b/claude-plugin/skills/micromegas-query/SKILL.md
@@ -3,14 +3,14 @@ name: micromegas-query
 description: Query micromegas observability data (logs, metrics, spans) using SQL. Use when the user wants to explore telemetry data, investigate errors, check performance, or analyze system behavior.
 argument-hint: "<SQL query or natural language question about observability data>"
 context: fork
-allowed-tools: Bash(source ~/.micromegas_env *), Bash(pip install micromegas), Bash(micromegas-query *), Bash(which micromegas-query), Bash(printenv MICROMEGAS_ANALYTICS_URI), Read, Glob, Grep, WebFetch(https://micromegas.info/*), WebFetch(https://datafusion.apache.org/*)
+allowed-tools: Bash(source ~/.micromegas_env), Bash(source ~/.micromegas_env *), Bash(pip install micromegas), Bash(micromegas-query *), Bash(which micromegas-query), Bash(printenv MICROMEGAS_ANALYTICS_URI), Read, Write, Edit, Glob, Grep, WebFetch(https://micromegas.info/*), WebFetch(https://datafusion.apache.org/*)
 ---
 
 The user's query or question: $ARGUMENTS
 
 ## MANDATORY RULES — read before writing ANY query
 
-1. **Every query MUST have `--begin` (and optionally `--end`).** No exceptions — not for DESCRIBE, not for SELECT DISTINCT, not for process lookups, not for exploratory queries. Default to `--begin 1h` when in doubt; narrow further when possible. The **only** exception: `--all` may be used for lightweight aggregate-only queries (`COUNT(*)`, `COUNT(DISTINCT ...)`, `MIN/MAX`) that return a single row or a small fixed number of rows. Never use `--all` with queries that return raw rows or unbounded GROUP BY result sets.
+1. **Every query MUST have `--begin` (and optionally `--end`).** No exceptions — not for `SELECT DISTINCT`, not for process lookups, not for exploratory queries. Default to `--begin 1h` when in doubt; narrow further when possible. The **only** exception: `--all` may be used for lightweight aggregate-only queries (`COUNT(*)`, `COUNT(DISTINCT ...)`, `MIN/MAX`) that return a single row or a small fixed number of rows. Never use `--all` with queries that return raw rows or unbounded GROUP BY result sets.
 2. **Every query MUST have a `LIMIT` clause** unless the user explicitly asks for all rows or the query is a pure aggregate (COUNT, SUM, etc.) guaranteed to return a small result set. Default to `LIMIT 20`. For GROUP BY queries, still add LIMIT (e.g. `LIMIT 50`).
 3. **Use `--begin`/`--end` CLI flags for time filtering, never `WHERE time >= ...` in SQL.** The CLI flags enable server-side partition pruning, making queries much faster.
 4. **Use `view_instance()` for single-process/stream queries.** Much better performance than filtering with WHERE.
@@ -44,11 +44,11 @@ export MICROMEGAS_OIDC_CLIENT_ID=<value from user>
 export MICROMEGAS_OIDC_AUDIENCE=<value from user>
 export MICROMEGAS_OIDC_SCOPE="openid email profile offline_access"
 ```
-Then append `source ~/.micromegas_env` to the user's shell profile (`~/.bashrc` or `~/.zshrc`) only if that source line is not already present. Source it in the current session.
+Then append `source ~/.micromegas_env` to the user's shell profile (`~/.bashrc` or `~/.zshrc`) only if that source line is not already present. The profile append is what matters: each command runs in a fresh shell, so sourcing the file in one command does **not** carry over to the next `micromegas-query` invocation — the profile line ensures every new shell picks up the config.
 
-Verify setup with:
+Verify setup with (source the env in the same command so it applies before the profile append takes effect in new shells):
 ```
-micromegas-query "SELECT 1" --begin 1h
+source ~/.micromegas_env && micromegas-query "SELECT 1" --begin 1h
 ```
 
 ## CLI syntax
@@ -60,7 +60,7 @@ micromegas-query [--file <path|->] ["<SQL>"] --begin <time> [--end <time>] [--fo
 - `--begin` is **always required** except when using `--all` for lightweight aggregate-only queries (see MANDATORY RULES).
 - `--file` accepts a `.sql` file path or `-` for stdin, as an alternative to the inline SQL positional argument. Using `--file` avoids awkward shell quoting when queries contain JSONPath expressions (e.g., `$[*].attributes[*]?(@.key=="Branch").value`).
 - Time formats: relative (`1h`, `30m`, `7d`) or RFC 3339
-- **ALWAYS use `--begin`/`--end` for time filtering, NEVER use `WHERE time >= ... AND time <= ...` in SQL.** The CLI flags enable server-side partition pruning, making queries much faster.
+- Use `--begin`/`--end` for time filtering, never `WHERE time >= ...` in SQL (see MANDATORY RULES).
 - Use `--format csv` or `--format json` when processing results programmatically (csv for flat data, json when properties/nested fields matter)
 - `--max-colwidth 0` for unlimited column width
 
@@ -71,6 +71,8 @@ Views are listed below. **Do not run DESCRIBE queries** — all schemas are docu
 **Ignore internal tables:** Tables prefixed with `__` and suffixed with `__partitions` (e.g. `__log_entries__partitions`) are internal partition tables — never query them directly.
 
 **Log levels:** 1=Fatal, 2=Error, 3=Warn, 4=Info, 5=Debug, 6=Trace
+
+**Type notes:** Types below are simplified for readability. `Dictionary(Utf8)` columns are dictionary-encoded (`Dictionary(Int16, Utf8)`) and behave like `Utf8` in SQL. `properties`/`process_properties` shown as `Binary` are actually `Dictionary(Int32, Binary)` — always read them via `property_get()` / the JSONB functions rather than treating them as raw bytes.
 
 ### `processes` — process metadata (global)
 
@@ -104,9 +106,12 @@ Views are listed below. **Do not run DESCRIBE queries** — all schemas are docu
 | tags | List(Utf8) |
 | properties | Binary (use `property_get()`) |
 | insert_time | Timestamp(ns, UTC) |
+| format | Utf8 |
 | last_update_time | Timestamp(ns, UTC) |
 
 ### `blocks` — block metadata with joined stream/process info (global)
+
+Common columns below. The view also exposes the full set of joined `streams.*` and `processes.*` fields (e.g. `streams.dependencies_metadata`, `streams.insert_time`, `streams.format`, `processes.start_time`, `processes.tsc_frequency`, `processes.realname`, `processes.distro`, `processes.cpu_brand`, `processes.parent_process_id`, …).
 
 | Column | Type |
 |--------|------|
@@ -221,7 +226,7 @@ High-frequency numeric metrics. Use `view_instance('measures', process_id)` for 
 - `process_spans(process_id, 'thread'|'async'|'both')` — all spans for a process with `stream_id` and `thread_name` columns. **Extremely dense** — always use tight `--begin`/`--end` and `LIMIT`.
 - `list_partitions()` — list available data partitions with metadata
 - `expand_histogram(h)` — expands a histogram into rows of `(bin_center, count)` for visualization
-- `jsonb_each(jsonb)` — expand JSONB object/array into rows of `(key, value)`
+- `jsonb_each(jsonb)` — expand JSONB object/array into rows of `(key, value)`. `value` is raw JSONB (Binary) — wrap it with `jsonb_as_string()`/`jsonb_as_f64()`/`jsonb_format_json()` to read it.
 
 ### Property functions
 - `property_get(properties, key)` — extract property values

--- a/mkdocs/docs/admin/authentication.md
+++ b/mkdocs/docs/admin/authentication.md
@@ -215,13 +215,13 @@ export MICROMEGAS_OIDC_CLIENT_SECRET="your-client-secret"  # Optional
 export MICROMEGAS_ANALYTICS_URI="grpc+tls://analytics.example.com:50051"
 
 # First use: Opens browser for authentication
-python3 -m micromegas.cli.query_processes --since 1h
+micromegas-query "SELECT process_id, exe, start_time FROM processes" --begin 1h
 
 # Subsequent uses: No browser interaction, uses cached tokens
-python3 -m micromegas.cli.query_process_log <process_id>
+micromegas-query "SELECT time, level, msg FROM log_entries WHERE process_id = '<process_id>'" --begin 1h
 
 # Logout (clear saved tokens)
-micromegas_logout
+micromegas-logout
 ```
 
 **Environment Variables:**
@@ -589,8 +589,8 @@ This prevents authorization code interception attacks even if the client secret 
 1. Check server logs: `tail -f /tmp/analytics.log | grep -i auth`
 2. Verify OIDC configuration matches between server and client
 3. Ensure Client ID and Issuer URL are correct
-4. Check token expiration: `cat ~/.micromegas/tokens.json | jq .expires_at`
-5. Clear tokens and re-authenticate: `micromegas_logout`
+4. Check token expiration: `cat ~/.micromegas/tokens.json | jq .token.expires_at`
+5. Clear tokens and re-authenticate: `micromegas-logout`
 
 ### Token Refresh Failures
 
@@ -598,10 +598,10 @@ This prevents authorization code interception attacks even if the client secret 
 
 **Solutions:**
 
-1. Check if refresh token is present: `cat ~/.micromegas/tokens.json | jq .refresh_token`
+1. Check if refresh token is present: `cat ~/.micromegas/tokens.json | jq .token.refresh_token`
 2. Verify client secret matches (if required by provider)
 3. Check token file permissions: `ls -la ~/.micromegas/tokens.json` (should be 600)
-4. Re-authenticate: `micromegas_logout` then retry
+4. Re-authenticate: `micromegas-logout` then retry
 
 ### Server Configuration Issues
 

--- a/mkdocs/docs/admin/flight-sql.md
+++ b/mkdocs/docs/admin/flight-sql.md
@@ -1,0 +1,76 @@
+# FlightSQL Server
+
+`flight-sql-srv` is the Apache Arrow FlightSQL service that answers SQL queries
+against the data lake. It runs a DataFusion engine over the partitions written by
+[ingestion](ingestion.md) and materialized by the [maintenance daemon](maintenance.md),
+and streams results back over gRPC.
+
+Clients — the [Python API](../query-guide/python-api.md), `micromegas-query`, the
+[Grafana plugin](../grafana/index.md), and the [analytics web app](web-app.md) —
+all connect here.
+
+## Running the binary
+
+```bash
+# from the rust/ directory
+cargo run --release --bin flight-sql-srv
+```
+
+The gRPC listener binds to `0.0.0.0:50051`. The Docker image
+(`flight-sql.Dockerfile`) exposes that port as its entrypoint.
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `MICROMEGAS_SQL_CONNECTION_STRING` | Yes | PostgreSQL connection for lake metadata |
+| `MICROMEGAS_OBJECT_STORE_URI` | Yes | Object store holding the partitions |
+| `MICROMEGAS_API_KEYS` | No | JSON array of API keys (see [Authentication](authentication.md)) |
+| `MICROMEGAS_OIDC_CONFIG` | No | OIDC configuration JSON |
+| `MICROMEGAS_ADMINS` | No | JSON array of admin user emails/subjects |
+| `MICROMEGAS_STATIC_TABLES_URL` | No | Location of static lookup tables to load at startup |
+| `MICROMEGAS_SHUTDOWN_GRACE_PERIOD_SECONDS` | No | Drain timeout on `SIGTERM` (default: `25`) |
+
+## CLI flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--disable-auth` | off | Disable authentication (development only) |
+| `--health-listen-addr` | none | Address for the HTTP health/readiness sidecar (e.g. `0.0.0.0:8082`) |
+| `--shutdown-grace-period-seconds` | `25` | Seconds to drain in-flight RPCs on `SIGTERM` |
+
+!!! note "Listen address is fixed"
+    Unlike ingestion, the split `flight-sql-srv` binary always binds
+    `0.0.0.0:50051`; there is no listen-address flag. Publish or remap the port
+    at the container / load-balancer layer.
+
+## Authentication
+
+If neither `MICROMEGAS_API_KEYS` nor `MICROMEGAS_OIDC_CONFIG` is set, the server
+refuses to start unless `--disable-auth` is passed. Admin users (via
+`MICROMEGAS_ADMINS`) gain access to administrative SQL functions — see
+[Admin SQL Functions](functions-reference.md). For provider configuration and
+precedence, see [Authentication](authentication.md).
+
+## Health and readiness
+
+The gRPC server does not itself serve HTTP. Pass `--health-listen-addr` to start
+a lightweight sidecar that serves `GET /health` (unconditional) and `GET /ready`
+(probes PostgreSQL and object storage):
+
+```bash
+flight-sql-srv --health-listen-addr 0.0.0.0:8082
+```
+
+Omit the flag and no sidecar starts. See
+[FlightSQL health sidecar](service-lifecycle.md#flightsql-health-sidecar) for
+details.
+
+## Scaling
+
+FlightSQL is stateless with respect to the lake — every instance reads the same
+partitions — so it scales horizontally behind a gRPC-aware load balancer. Queries
+are read-only against object storage and PostgreSQL; add instances to serve more
+concurrent queries. Heavy or slow-object-store deployments benefit from the
+[object cache](object-cache.md), which fronts the object store with a shared
+read-through cache.

--- a/mkdocs/docs/admin/functions-reference.md
+++ b/mkdocs/docs/admin/functions-reference.md
@@ -109,45 +109,6 @@ SELECT * FROM retire_partitions('log_entries', 'process-123', '2024-01-01T00:00:
 
 ## Scalar Functions (UDFs)
 
-### `delete_duplicate_processes()`
-
-**Description**: Deletes duplicate processes within the query time range. A duplicate is defined as multiple rows with the same `process_id`. This function keeps the row with the earliest `insert_time` and deletes all others.
-
-**Parameters**: None (time range is set via the Python client)
-
-**Returns**: String message (e.g., `"Deleted 42 duplicate processes"`)
-
-!!! warning "Destructive Operation"
-    This function permanently deletes data. The time range identifies duplicates, but ALL duplicate rows for matching IDs are deleted regardless of their insert_time.
-
----
-
-### `delete_duplicate_streams()`
-
-**Description**: Deletes duplicate streams within the query time range. A duplicate is defined as multiple rows with the same `stream_id`. This function keeps the row with the earliest `insert_time` and deletes all others.
-
-**Parameters**: None (time range is set via the Python client)
-
-**Returns**: String message (e.g., `"Deleted 15 duplicate streams"`)
-
-!!! warning "Destructive Operation"
-    This function permanently deletes data. The time range identifies duplicates, but ALL duplicate rows for matching IDs are deleted regardless of their insert_time.
-
----
-
-### `delete_duplicate_blocks()`
-
-**Description**: Deletes duplicate blocks within the query time range. A duplicate is defined as multiple rows with the same `block_id`. This function keeps the row with the earliest `insert_time` and deletes all others.
-
-**Parameters**: None (time range is set via the Python client)
-
-**Returns**: String message (e.g., `"Deleted 100 duplicate blocks"`)
-
-!!! warning "Destructive Operation"
-    This function permanently deletes data. The time range identifies duplicates, but ALL duplicate rows for matching IDs are deleted regardless of their insert_time.
-
----
-
 ### `retire_partition_by_metadata(view_set_name, view_instance_id, begin_insert_time, end_insert_time)`
 
 **Description**: Surgically retires a single partition by its metadata identifiers. This is the preferred method for retiring partitions as it works for both empty partitions (file_path=NULL) and non-empty partitions.

--- a/mkdocs/docs/admin/ingestion.md
+++ b/mkdocs/docs/admin/ingestion.md
@@ -1,0 +1,80 @@
+# Telemetry Ingestion Server
+
+`telemetry-ingestion-srv` is the HTTP service that accepts telemetry from instrumented
+processes. It writes event payloads to object storage and records the metadata
+(processes, streams, blocks) in PostgreSQL. Every acknowledged write is durable
+before the request returns — see [Service Lifecycle & Shutdown](service-lifecycle.md#data-durability).
+
+This is the only service that producers talk to. It does no query or
+materialization work; those belong to [FlightSQL](flight-sql.md) and the
+[maintenance daemon](maintenance.md).
+
+## Running the binary
+
+```bash
+# from the rust/ directory
+cargo run --release --bin telemetry-ingestion-srv -- \
+  --listen-endpoint-http 0.0.0.0:9000
+```
+
+The Docker image (`ingestion.Dockerfile`) exposes port `9000` and runs the same
+binary as its entrypoint.
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `MICROMEGAS_SQL_CONNECTION_STRING` | Yes | PostgreSQL connection for lake metadata |
+| `MICROMEGAS_OBJECT_STORE_URI` | Yes | Object store for payloads (`file:///path`, `s3://…`, `gs://…`) |
+| `MICROMEGAS_API_KEYS` | No | JSON array of API keys (see [Authentication](authentication.md)) |
+| `MICROMEGAS_OIDC_CONFIG` | No | OIDC configuration JSON |
+| `MICROMEGAS_SHUTDOWN_GRACE_PERIOD_SECONDS` | No | Drain timeout on `SIGTERM` (default: `25`) |
+
+## CLI flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--listen-endpoint-http` | `127.0.0.1:8081` | HTTP bind address |
+| `--disable-auth` | off | Disable authentication (development only) |
+| `--shutdown-grace-period-seconds` | `25` | Seconds to drain in-flight requests on `SIGTERM` |
+
+!!! warning "Bind address"
+    The binary defaults to `127.0.0.1:8081`, which only accepts local
+    connections. To accept traffic from other hosts (or from inside a
+    container), bind to `0.0.0.0` and the port you intend to publish, e.g.
+    `--listen-endpoint-http 0.0.0.0:9000`.
+
+## Authentication
+
+If neither `MICROMEGAS_API_KEYS` nor `MICROMEGAS_OIDC_CONFIG` is set, the server
+refuses to start unless `--disable-auth` is passed. This prevents accidentally
+running an open ingestion endpoint. For configuration details and provider
+precedence, see [Authentication](authentication.md).
+
+```bash
+# API keys for machine-to-machine producers
+export MICROMEGAS_API_KEYS='[{"name":"game-client","key":"…"}]'
+telemetry-ingestion-srv --listen-endpoint-http 0.0.0.0:9000
+```
+
+## Health and readiness
+
+The server exposes `GET /health` (unconditional) and `GET /ready` (probes
+PostgreSQL and object storage) on the same port as ingestion. Point load-balancer
+health checks at `/ready`. See
+[Readiness probes](service-lifecycle.md#readiness-probes) for ALB tuning.
+
+## Scaling
+
+Ingestion is stateless — every instance reads and writes the same lake — so it
+scales horizontally behind a load balancer. Add instances to raise write
+throughput; PostgreSQL and the object store are the shared backends. Writes are
+idempotent (blocks are stored at deterministic paths and recorded with
+`ON CONFLICT DO NOTHING`), so retried or duplicated requests never double-count.
+
+## Producer configuration
+
+Producers point at the ingestion endpoint with `MICROMEGAS_TELEMETRY_URL`. If the
+ingestion service falls behind or becomes briefly unreachable, the Rust telemetry
+sink buffers and retries; queue sizes, concurrency, and timeouts are tunable — see
+[Telemetry Sink Transport Tuning](telemetry-sink-tuning.md).

--- a/mkdocs/docs/admin/maintenance.md
+++ b/mkdocs/docs/admin/maintenance.md
@@ -1,0 +1,80 @@
+# Maintenance Daemon
+
+`telemetry-admin` runs the maintenance daemon that keeps the data lake healthy. It
+is a long-running service you deploy alongside [ingestion](ingestion.md) and
+[FlightSQL](flight-sql.md): it materializes views on a schedule and runs retention
+cleanup.
+
+Ad-hoc administration — inspecting partitions, retiring incompatible ones,
+removing duplicates — is done through SQL and the Python API, not by driving this
+binary. See [Admin SQL Functions](functions-reference.md).
+
+It reads the lake from the environment:
+
+| Variable | Required | Description |
+|---|---|---|
+| `MICROMEGAS_SQL_CONNECTION_STRING` | Yes | PostgreSQL connection for lake metadata |
+| `MICROMEGAS_OBJECT_STORE_URI` | Yes | Object store holding the partitions |
+
+## Running the daemon
+
+```bash
+# from the rust/ directory
+cargo run --release --bin telemetry-admin -- crond
+```
+
+The Docker image (`admin.Dockerfile`) runs `telemetry-admin` as its entrypoint;
+pass `crond` as the command.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--shutdown-grace-period-seconds` | `25` | Seconds to let in-flight tasks finish on `SIGTERM` |
+
+On `SIGTERM` the daemon stops scheduling new tasks and drains those already
+running, up to the grace period. See
+[Service Lifecycle & Shutdown](service-lifecycle.md). Interrupted materialization
+is safe to redo — a task that doesn't finish simply leaves its partition
+unwritten, and the next scheduled run redoes it.
+
+Run a **single** `crond` instance per lake. The scheduled tasks are not
+partitioned across instances, so multiple daemons would redundantly materialize
+the same partitions. Materialization is idempotent, so this is wasteful rather
+than corrupting — but there is no benefit to more than one.
+
+## What it does
+
+The daemon keeps materialized views current by running four scheduled tasks. Each
+task materializes a trailing window at its own granularity, so recent data lands
+in fine-grained partitions quickly while older data is consolidated into coarser
+ones:
+
+| Task | Period | Work |
+|---|---|---|
+| Every second | 1 s | Materialize the newest 1-second partitions. Skipped when the daemon is more than 10 s behind — the minute task backfills the gap. |
+| Every minute | 1 min | Materialize 1-minute partitions. |
+| Every hour | 1 h | Retention cleanup (see below), then materialize 1-hour partitions. |
+| Every day | 1 day | Materialize 1-day partitions. |
+
+### Retention
+
+The hourly task performs cleanup automatically:
+
+- **Deletes lake data older than 90 days** — blocks, streams, and processes past
+  the retention horizon are removed.
+- **Deletes expired temporary files** left behind by query execution.
+
+The 90-day retention is the daemon's built-in policy.
+
+## Ad-hoc administration
+
+Manual maintenance — backfilling a time range, retiring stale or
+schema-incompatible partitions, removing duplicate processes/streams/blocks — runs
+through the FlightSQL server, not this binary:
+
+- **SQL functions** such as `materialize_partitions()` (backfill a time range),
+  `retire_partitions()`, `retire_partition_by_metadata()`, and the
+  `delete_duplicate_*()` UDFs.
+- **Python helpers** such as `micromegas.admin.list_incompatible_partitions()` and
+  `micromegas.admin.retire_incompatible_partitions()`.
+
+Both are documented in [Admin SQL Functions](functions-reference.md).

--- a/mkdocs/docs/admin/maintenance.md
+++ b/mkdocs/docs/admin/maintenance.md
@@ -5,9 +5,9 @@ is a long-running service you deploy alongside [ingestion](ingestion.md) and
 [FlightSQL](flight-sql.md): it materializes views on a schedule and runs retention
 cleanup.
 
-Ad-hoc administration — inspecting partitions, retiring incompatible ones,
-removing duplicates — is done through SQL and the Python API, not by driving this
-binary. See [Admin SQL Functions](functions-reference.md).
+Ad-hoc administration — inspecting partitions, retiring incompatible ones — is
+done through SQL and the Python API, not by driving this binary. See
+[Admin SQL Functions](functions-reference.md).
 
 It reads the lake from the environment:
 
@@ -68,12 +68,11 @@ The 90-day retention is the daemon's built-in policy.
 ## Ad-hoc administration
 
 Manual maintenance — backfilling a time range, retiring stale or
-schema-incompatible partitions, removing duplicate processes/streams/blocks — runs
-through the FlightSQL server, not this binary:
+schema-incompatible partitions — runs through the FlightSQL server, not this
+binary:
 
 - **SQL functions** such as `materialize_partitions()` (backfill a time range),
-  `retire_partitions()`, `retire_partition_by_metadata()`, and the
-  `delete_duplicate_*()` UDFs.
+  `retire_partitions()`, and `retire_partition_by_metadata()`.
 - **Python helpers** such as `micromegas.admin.list_incompatible_partitions()` and
   `micromegas.admin.retire_incompatible_partitions()`.
 

--- a/mkdocs/docs/admin/monolith.md
+++ b/mkdocs/docs/admin/monolith.md
@@ -82,7 +82,7 @@ The prefix fallback means `MICROMEGAS_API_KEYS` works for ingestion when `MICROM
 ```bash
 export MICROMEGAS_OIDC_CONFIG='{"issuers":[{"issuer":"https://your-idp.example.com","audience":"your-client-id"}]}'
 export MICROMEGAS_STATE_SECRET="<random-secret>"
-export MICROMEGAS_AUTH_REDIRECT_URI="http://localhost:3000/api/auth/callback"
+export MICROMEGAS_AUTH_REDIRECT_URI="http://localhost:3000/auth/callback"
 micromegas-monolith --disable-ingestion-auth
 ```
 

--- a/mkdocs/docs/admin/object-cache.md
+++ b/mkdocs/docs/admin/object-cache.md
@@ -1,6 +1,6 @@
 # Object Cache Deployment
 
-`micromegas-object-cache-srv` is a shared HTTP range cache that sits in front of the data lake's object store. Split-mode services (FlightSQL, the maintenance daemon, ingestion) read overlapping byte ranges of the same Parquet/block files; routing those reads through one shared cache avoids re-fetching the same bytes from S3/GCS on every process, cutting egress cost and read latency.
+`micromegas-object-cache-srv` is a shared HTTP range cache that sits in front of the data lake's object store. Split-mode query services (FlightSQL and the maintenance daemon) read overlapping byte ranges of the same Parquet/block files; routing those reads through one shared cache avoids re-fetching the same bytes from S3/GCS on every process, cutting egress cost and read latency.
 
 It only caches **reads**. Writes, deletes, and listings always go straight to the origin store — see [What gets cached](#what-gets-cached) below.
 
@@ -135,7 +135,7 @@ See [Caching Architecture](../architecture/caching.md#cache-warming) for the des
 
 ## Client opt-in
 
-The cache is opt-in per client. Each split-mode service (ingestion, FlightSQL, the maintenance daemon) reads through it only when both of these are set in *its own* environment:
+The cache is opt-in per client. FlightSQL and the maintenance daemon use it only when both of these are set in *their own* environment:
 
 ```bash
 export MICROMEGAS_OBJECT_CACHE_URL=http://object-cache:8080
@@ -212,7 +212,7 @@ The cache emits metrics through the standard micromegas tracing sink (queryable 
 | `object_cache_prefetch_dropped` | cache server | Prefetch items load-shed because the queue was full. A sustained non-zero rate means prefetch volume exceeds `MICROMEGAS_OBJECT_CACHE_PREFETCH_QUEUE_CAPACITY` / worker throughput. |
 | `object_cache_prefetch_keys_warmed` / `object_cache_prefetch_fill_error` | cache server | Prefetch fills that completed successfully vs. failed (e.g. key not found at the origin). |
 | `range_cache_client_prefetch_error` | each client | Client-side prefetch calls that failed (transport error or non-2xx). Best-effort — callers do not retry. |
-| `object_warm_requested` | writer (ingestion) | A cache warm was scheduled for a freshly-written object (e.g. a new partition; see [Write-time warming](#write-time-warming)). |
+| `object_warm_requested` | maintenance daemon / JIT | A cache warm was scheduled for a freshly-written object (e.g. a new partition; see [Write-time warming](#write-time-warming)). |
 | `range_cache_prefetch_admission_unexpected_none` | cache server | Defensive counter in the SSD-only prefetch admission path: bumped if a force-insert unexpectedly reports no admission. Should never fire; a sustained non-zero rate points to an admission-path regression. |
 
 ### Latency

--- a/mkdocs/docs/admin/object-cache.md
+++ b/mkdocs/docs/admin/object-cache.md
@@ -180,9 +180,9 @@ Cached ranges never need invalidation because the lake is write-once; see [Cachi
 
 ## Authentication
 
-The cache authenticates with API keys only (no OIDC). Configure a key ring with `MICROMEGAS_API_KEYS` and give **each client its own named key**, so keys can be rotated or revoked per service. Only the two services that use the cache need a key — **FlightSQL and the maintenance daemon**; ingestion is not a client and should not be issued one.
+The cache authenticates with API keys only (no OIDC). Configure a key ring with `MICROMEGAS_API_KEYS` and give **each client its own named key**, so keys can be rotated or revoked per service. Issue keys only to the services that actually use the cache — currently **FlightSQL and the maintenance daemon**.
 
-Apply defense in depth: API keys are the application-layer check, but the cache is a purely internal service with no public role, so restrict it at the network layer too. Bind it to a private network and use a security group / firewall / Kubernetes `NetworkPolicy` so that **only FlightSQL and the maintenance daemon can reach its listen endpoint** — nothing else, ingestion or the public internet included, should be able to open a connection.
+Apply defense in depth: API keys are the application-layer check, but the cache is a purely internal service with no public role, so restrict it at the network layer too. Bind it to a private network and use a security group / firewall / Kubernetes `NetworkPolicy` so that **only the services that use the cache can reach its listen endpoint** — nothing else, the public internet included, should be able to open a connection.
 
 `--disable-auth` drops the API-key check and is for local development only — never on an endpoint reachable by anything but localhost.
 

--- a/mkdocs/docs/admin/object-cache.md
+++ b/mkdocs/docs/admin/object-cache.md
@@ -84,86 +84,54 @@ Authenticating *against the origin* (e.g. AWS credentials) uses the same environ
 
 ## Fetch scheduling & memory bounds
 
-Concurrent origin fetches share one global, priority-aware budget rather than a
-per-request cap:
+Origin fetches share one global, priority-aware budget rather than a per-request cap. The knobs
+that shape it are in the [environment variables](#environment-variables) table above; the ones
+worth tuning:
 
-- **Demand over prefetch.** Every origin GET is either `Demand` (a client's
-  `GET`/`POST /ranges` request) or `Prefetch` (background warming, #1198).
-  `MICROMEGAS_OBJECT_CACHE_DEMAND_RESERVED_FETCHES` of the total budget is
-  always available to demand reads; prefetch is capped at the remainder, so a
-  demand read is never stuck behind a large prefetch batch.
-- **Promotion.** If a demand read arrives for a block a prefetch call already
-  queued (but hasn't started fetching), that block is promoted to demand
-  priority and competes for reserved capacity immediately, instead of waiting
-  behind the rest of the prefetch batch.
-- **Coalescing.** Contiguous missing blocks are merged into one origin GET
-  (bounded by `MICROMEGAS_OBJECT_CACHE_MAX_COALESCED_GET_BYTES`) rather than
-  one GET per block.
-- **Cross-request memory budget.** `GET /obj/{key}` and `POST /ranges/{key}`
-  responses are streamed rather than assembled in memory: bytes are written
-  to the socket in bounded windows as they're fetched, so response size is no
-  longer capped. `MICROMEGAS_OBJECT_CACHE_MEMORY_BUDGET_MB` instead bounds the
-  sum of in-flight streaming-window bytes across *all* concurrent requests (1
-  MiB per permit). Each request charges `min(response size, a fixed per-stream
-  window)`: a small response charges close to its actual size (so plenty of
-  small reads can run concurrently), while a large one clamps to the window,
-  bounding per-request memory and gating how many large streaming requests can
-  run concurrently regardless of how big the response gets. The server floors
-  this budget at the window's size at startup and refuses to start below it,
-  since a smaller budget would make a large read's charge hang forever instead
-  of failing fast.
+- `--max-concurrent-fetches` / `--demand-reserved-fetches` — total origin-GET concurrency, and the
+  slice always reserved for demand reads so they never queue behind a large prefetch batch.
+- `--max-coalesced-get-bytes` — how large a run of contiguous missing blocks may be merged into a
+  single origin GET.
+- `--memory-budget-mb` — cross-request cap on in-flight streaming memory; the server refuses to
+  start if it is set below one per-stream window.
+
+See [Caching Architecture](../architecture/caching.md#read-path-mechanics) for how demand/prefetch
+prioritization, coalescing, and streaming work.
 
 ## Prefetch
 
-`POST /prefetch` warms the cache for a batch of keys at background priority, without serving any bytes back to the caller. The request body is `Content-Type: application/x-ndjson`: one JSON object per `\n`-terminated line, each describing a key to warm:
+`POST /prefetch` warms the cache for a batch of keys at background priority, returning `202 Accepted` immediately without serving bytes back. The body is `Content-Type: application/x-ndjson`, one JSON object per line:
 
 ```
 {"key": "blobs/abc", "size": 123456}
 {"key": "blobs/def", "size": 654321, "ranges": [[0, 65536]]}
 ```
 
-`size` must be the object's exact current size, supplied by the caller — the server trusts it rather than issuing an origin HEAD, since prefetch targets objects that are typically cold. `ranges` is optional; when absent or empty the whole object `[0, size)` is warmed, otherwise only the listed `[start, end)` ranges are.
-
-The body is parsed incrementally as it arrives, so there is no whole-batch size cap and no key-count cap. The only remaining ceiling is on a single NDJSON line (1 MiB) — a request with a line longer than that is rejected with `400`. There is also no per-item size limit: the fill worker streams the block-index space in bounded windows rather than materializing it, so warming an arbitrarily large (or even bogus) `size` costs constant per-item memory. An oversized `size` just stops warming at the first origin fetch past the object's real end. A malformed line is counted as `rejected` and does not abort the rest of the batch, since newline framing means one bad line can't desynchronize the ones that follow.
-
-The endpoint returns immediately with `202 Accepted` and a small JSON body:
+`size` is the object's exact size (the server trusts it rather than issuing a HEAD); `ranges` is optional and defaults to the whole object. A single NDJSON line is capped at 1 MiB. The response reports counts:
 
 ```json
 {"accepted": 1, "rejected": 0, "dropped": 1}
 ```
 
-- `accepted` — items enqueued onto the background fill queue.
-- `rejected` — items that failed key/prefix or range validation and were skipped; the rest of the batch still proceeds.
-- `dropped` — items load-shed because the queue (`MICROMEGAS_OBJECT_CACHE_PREFETCH_QUEUE_CAPACITY`) was full. Prefetch is best-effort: a full queue never blocks the caller or the response status.
+- `accepted` — enqueued onto the background fill queue.
+- `rejected` — failed key/prefix or range validation; the rest of the batch still proceeds.
+- `dropped` — load-shed because the queue (`MICROMEGAS_OBJECT_CACHE_PREFETCH_QUEUE_CAPACITY`) was full. Prefetch is best-effort — a full queue never blocks the caller.
 
-Fills run at the same `Prefetch` priority described in [Fetch scheduling & memory bounds](#fetch-scheduling-memory-bounds) above, so a large prefetch batch never starves a concurrent demand read. Prefetched blocks are admitted to the SSD tier only (not the RAM tier), so they don't compete with hot demand data for RAM residency; a later demand read against a prefetched block is served from SSD.
+Warmed blocks are admitted to the SSD tier only, so they don't evict hot demand data from RAM.
 
 ## Write-time warming
 
-When a writer (the maintenance daemon, JIT materialization, or a merge) finishes writing a new
-Parquet partition durably to the origin store *and* commits its row to
-`lakehouse_partitions` in PostgreSQL, it POSTs the partition's key to `/prefetch` so the cache
-pulls it from origin at prefetch priority *before* the follow-up query asks for it. This turns the
-first read of a new partition from a cold origin GET into a warm cache hit.
+When the writing service has the cache configured, a freshly-committed Parquet partition is warmed
+automatically: the writer POSTs its key to `/prefetch` so the first query read is a hit instead of
+a cold origin GET. It is fire-and-forget — a slow or unreachable cache never delays or fails a
+write — and costs one extra origin GET per new partition, paid by the cache.
 
-This is **notify-by-key**, not a write-through cache: the writer never pushes bytes into the
-cache — it only names the key that just became available, and the cache fetches it from origin
-itself, exactly like a prefetch triggered any other way. The write/materialization path is never
-delayed or failed by a warm: the POST is fired from a detached, fire-and-forget task, so a slow or
-unreachable cache has no effect on write latency or success.
+There is no separate on/off switch: it follows the same [client opt-in](#client-opt-in) as reads
+(`MICROMEGAS_OBJECT_CACHE_URL` + `MICROMEGAS_OBJECT_CACHE_API_KEY`). The `object_warm_requested`
+metric counts scheduled warms; a failed warm surfaces through `range_cache_client_prefetch_error`
+and just means that object's first read stays a cold miss.
 
-Write-time warming is enabled automatically whenever the writing service has the cache configured
-(`MICROMEGAS_OBJECT_CACHE_URL` + `MICROMEGAS_OBJECT_CACHE_API_KEY` set, per
-[Client opt-in](#client-opt-in) below) — there is no separate on/off switch. The cost is one extra
-origin GET per new partition, paid by the cache, off the write path.
-
-A warm is only ever requested for a non-empty partition (empty partitions have no object to warm).
-The underlying trigger is a general "warm any object by key" primitive (`DataLakeConnection::warm_object`),
-so nothing about it is partition-specific — the write-partition path is simply its first caller.
-The `object_warm_requested` metric counts scheduled warms; a failed warm (unreachable
-cache, non-2xx, etc.) surfaces through the existing `range_cache_client_prefetch_error` metric and
-simply means the first demand read of that object stays a cold miss rather than a hit — it does
-not raise an error anywhere.
+See [Caching Architecture](../architecture/caching.md#cache-warming) for the design.
 
 ## Client opt-in
 
@@ -184,39 +152,23 @@ no-op.
 
 ## In-process L1 cache
 
-Query processes (FlightSQL, the monolith) also carry a small **in-process L1 cache**, independent
-of the `object-cache-srv` deployment described above. It sits closer to the query than this
-service does: L1 caches hot byte ranges directly inside the query process's memory, so a repeat
-read of the same partition never leaves the process, let alone reaches this cache server or the
-origin store. An L1 miss falls through to whatever store L1 wraps — this cache server if
-[client opt-in](#client-opt-in) is configured, otherwise the origin store directly — so the
-L1 → L2 (this service) → origin tiering still holds; L1 is just an additional tier in front of it.
+Query processes (FlightSQL, the monolith) also carry a small **in-process L1 cache** in front of
+this server: a repeat read of the same partition is served from the query process's own memory and
+never reaches this service or the origin. It is a sibling tier of the same object-cache subsystem —
+see [Caching Architecture](../architecture/caching.md) for how L1, this L2 server, and the origin
+fit together, and what L1 does and doesn't cover.
 
-L1 is sized by `MICROMEGAS_OBJECT_CACHE_L1_MB` (default `200`; `0` disables it) in the query
-process's own environment. It belongs to the same `MICROMEGAS_OBJECT_CACHE_*` family as this
-server's knobs — the two are sibling tiers of one object-cache subsystem: `_L1_MB` sizes the
-in-process L1 tier, while `MICROMEGAS_OBJECT_CACHE_RAM_MB` above sizes this server's own RAM tier.
-Set them independently.
+For operators there is one knob: `MICROMEGAS_OBJECT_CACHE_L1_MB` (default `200`; `0` disables), set
+in the *query* process's own environment. It sizes the in-process L1 RAM tier independently of
+`MICROMEGAS_OBJECT_CACHE_RAM_MB` above, which sizes this server's RAM tier.
 
-L1 covers exactly two read paths, both read-repeatedly on the query hot path:
-
-- Parquet partition reads (materialized views under `views/...`), through DataFusion's parquet
-  reader.
-- Static JSON/CSV table reads (`MICROMEGAS_STATIC_TABLES_URL`).
-
-It deliberately excludes raw blob reads (`blobs/{process_id}/{stream_id}/{block_id}`) — ETL
-materialization and the `get_payload`/`parse_block` SQL functions always read those directly from
-the origin/L2 stack, never through L1, since blobs are read exactly once and caching them would
-only add memory pressure for no benefit.
-
-L1 emits the same `RangeCache` hit/miss metrics described in [Monitoring](#monitoring) below, but
-without per-prefix labels, so every L1 hit/miss (parquet or static-table alike) reports
-`prefix="other"` — this gives aggregate L1 observability only, with no way to split lakehouse
-traffic from static-table traffic in the metrics.
+L1 emits the same `range_cache_*` hit/miss metrics as this server (see [Monitoring](#monitoring)),
+but without per-prefix labels — every L1 hit/miss reports `prefix="other"`, giving aggregate L1
+observability only.
 
 ## What gets cached
 
-Only reads. The client falls back transparently to the direct store on any cache error, non-2xx response, or oversized request, so an unreachable or misbehaving cache degrades to direct reads rather than failing requests:
+Only reads are cached, and the client falls back to a direct origin read on any cache error, so an unreachable or misbehaving cache degrades to direct reads rather than failing requests:
 
 | Operation | Path |
 |---|---|
@@ -224,7 +176,7 @@ Only reads. The client falls back transparently to the direct store on any cache
 | Writes (`put`, multipart upload) | Always direct to the origin store |
 | Deletes, listing, copy | Always direct to the origin store |
 
-This works because the lake is **write-once**: blocks are written to a deterministic path exactly once and never modified in place, so a cached range never goes stale and the cache never needs invalidation.
+Cached ranges never need invalidation because the lake is write-once; see [Caching Architecture](../architecture/caching.md) for why.
 
 ## Authentication
 
@@ -259,9 +211,9 @@ The cache emits metrics through the standard micromegas tracing sink (queryable 
 | `object_cache_prefetch_requests` / `object_cache_prefetch_keys_enqueued` | cache server | `POST /prefetch` request and accepted-key counts. |
 | `object_cache_prefetch_dropped` | cache server | Prefetch items load-shed because the queue was full. A sustained non-zero rate means prefetch volume exceeds `MICROMEGAS_OBJECT_CACHE_PREFETCH_QUEUE_CAPACITY` / worker throughput. |
 | `object_cache_prefetch_keys_warmed` / `object_cache_prefetch_fill_error` | cache server | Prefetch fills that completed successfully vs. failed (e.g. key not found at the origin). |
-| `range_cache_client_prefetch_error` | each client | `CacheClientStore::prefetch` calls that failed (transport error or non-2xx). Best-effort — callers do not retry. |
-| `object_warm_requested` | writer (ingestion) | A cache warm was scheduled for a freshly-written object via `DataLakeConnection::warm_object` (e.g. a new partition; see [Write-time warming](#write-time-warming)). |
-| `range_cache_prefetch_admission_unexpected_none` | cache server | Defensive counter in the SSD-only prefetch admission path (`FoyerBackend::put`): bumped if `.force().insert(value)` unexpectedly returns `None`. Should never fire; a sustained non-zero rate points to an admission-path regression. |
+| `range_cache_client_prefetch_error` | each client | Client-side prefetch calls that failed (transport error or non-2xx). Best-effort — callers do not retry. |
+| `object_warm_requested` | writer (ingestion) | A cache warm was scheduled for a freshly-written object (e.g. a new partition; see [Write-time warming](#write-time-warming)). |
+| `range_cache_prefetch_admission_unexpected_none` | cache server | Defensive counter in the SSD-only prefetch admission path: bumped if a force-insert unexpectedly reports no admission. Should never fire; a sustained non-zero rate points to an admission-path regression. |
 
 ### Latency
 
@@ -269,34 +221,34 @@ Spans (queryable in the spans table, correlatable with a trace) cover every fetc
 
 | Metric | Where | Meaning |
 |---|---|---|
-| `range_cache_fetch_permit_wait_ms` (`+ class`) | cache server | Time a coalesced origin fetch spent waiting for a fetch-budget permit before its `get_range` started. The highest-value signal for the #1203 scheduler — a rising `class="demand"` wait means demand is contending with prefetch (or with itself) for the shared budget. |
+| `range_cache_fetch_permit_wait_ms` (`+ class`) | cache server | Time a coalesced origin fetch spent waiting for a fetch-budget permit before its `get_range` started. The highest-value scheduler signal — a rising `class="demand"` wait means demand is contending with prefetch (or with itself) for the shared budget. |
 | `range_cache_origin_get_ms` (`+ class`) | cache server | Duration of the origin `get_range` call itself, once a permit was held. |
 | `object_cache_mem_permit_wait_ms` | cache server | Time a request spent waiting to acquire its cross-request memory-budget permits (`--memory-budget-mb`) before it could start streaming. A rising value means the memory budget, not the fetch budget, is the bottleneck. |
-| `object_cache_ttfb_ms` (`+ prefix`) | cache server | Time to first byte: handler entry to the first chunk being ready to send, now that streaming (#1189/#1222) has landed. |
+| `object_cache_ttfb_ms` (`+ prefix`) | cache server | Time to first byte: handler entry to the first chunk being ready to send. |
 | `range_cache_client_roundtrip_ms` | each client | Time for a streaming cache-path read (`get_range`/`get_full_stream`) to get a usable stream back from the cache server, measured before any body bytes are read. |
 | `range_cache_client_ranges_ms` | each client | Time for a `get_ranges` cache-path read to fully read and reassemble the framed multi-range response body. Not directly comparable to `range_cache_client_roundtrip_ms`, which is measured at time-to-headers rather than time-to-full-body. |
 | `range_cache_client_direct_ms` | each client | Time for the direct-store fallback path taken on a cache miss/error, on any of the above paths. Compare against the corresponding cache-path metric to confirm the cache path is actually winning end-to-end. |
 
 ### Saturation
 
-A background sampler (`object-cache-srv/src/saturation_monitor.rs`) emits these gauges on a fixed interval (5s by default), independent of request volume — the signals needed to tell *which* resource is the bottleneck, not just that requests are slow:
+A background sampler emits these gauges on a fixed interval (5s by default), independent of request volume — the signals needed to tell *which* resource is the bottleneck, not just that requests are slow:
 
 | Metric | Meaning |
 |---|---|
 | `object_cache_fetch_shared_occupancy` / `object_cache_fetch_shared_available` | Occupied/available slots in the total origin-GET concurrency budget (`--max-concurrent-fetches`). |
 | `object_cache_fetch_prefetch_occupancy` / `object_cache_fetch_prefetch_available` | Occupied/available slots in the prefetch-only sub-budget (`--max-concurrent-fetches` minus `--demand-reserved-fetches`). |
-| `object_cache_inflight_entries` | Number of block/`size()` keys currently in flight to origin. A key signal for the #1203 scheduler alongside the permit-wait latency above. |
+| `object_cache_inflight_entries` | Number of block/`size()` keys currently in flight to origin. A key scheduler signal alongside the permit-wait latency above. |
 | `object_cache_mem_budget_occupancy_mb` / `object_cache_mem_budget_available_mb` | Occupied/available MiB of the cross-request streaming memory budget (`--memory-budget-mb`). |
 | `object_cache_prefetch_queue_depth` | Items currently queued in the bounded `/prefetch` queue, waiting for a worker slot. |
-| `object_cache_nic_rx_bytes_per_sec` / `object_cache_nic_tx_bytes_per_sec` | Host-level network throughput. The expected ceiling on the target im4gn.large (#1197) instance type, and previously unmeasured. |
-| `object_cache_foyer_disk_write_bytes_per_sec` / `object_cache_foyer_disk_read_bytes_per_sec` | The foyer disk engine's own write/read throughput (`Statistics::disk_write_bytes` / `disk_read_bytes`), sourced from the cache engine itself rather than host disk enumeration — supersedes the old `object_cache_ssd_*` gauges, which always read 0 in the deployed container. The drain-throughput signal for whether the flushers are keeping up with write-in pressure (see "Tuning the write path" below). |
-| `object_cache_foyer_disk_write_ios_per_sec` / `object_cache_foyer_disk_read_ios_per_sec` | The foyer disk engine's own write/read IO rate (`Statistics::disk_write_ios` / `disk_read_ios`). |
+| `object_cache_nic_rx_bytes_per_sec` / `object_cache_nic_tx_bytes_per_sec` | Host-level network throughput — the expected ceiling on the deployment's instance type. |
+| `object_cache_foyer_disk_write_bytes_per_sec` / `object_cache_foyer_disk_read_bytes_per_sec` | The foyer disk engine's own write/read throughput, sourced from the cache engine rather than host disk enumeration. The drain-throughput signal for whether the flushers are keeping up with write-in pressure (see "Tuning the write path" below). |
+| `object_cache_foyer_disk_write_ios_per_sec` / `object_cache_foyer_disk_read_ios_per_sec` | The foyer disk engine's own write/read IO rate. |
 
 Routine fallback-to-direct is by-design graceful degradation and is logged at `debug` (not `warn`). Genuinely unexpected conditions — a truncated cache response, a backend IO fault, an internal server error — log at `warn`/`error`.
 
 ### Tuning the write path
 
-Prefetch fills are force-admitted to the SSD tier (`.force().insert()`, bypassing the admission picker), so a large prefetch burst can outrun foyer's disk-engine submit queue; when that happens foyer logs a recurring `submit queue overflow, new entry ignored` WARN and silently drops the entry (no crash, but a lower hit rate and more origin traffic). Two knobs control the ceiling:
+Prefetch fills are force-admitted to the SSD tier (bypassing the admission picker), so a large prefetch burst can outrun foyer's disk-engine submit queue; when that happens foyer logs a recurring `submit queue overflow, new entry ignored` WARN and silently drops the entry (no crash, but a lower hit rate and more origin traffic). Two knobs control the ceiling:
 
 - `MICROMEGAS_OBJECT_CACHE_FLUSHERS` — how many blocks can be written to disk concurrently.
 - `MICROMEGAS_OBJECT_CACHE_WRITE_BUFFER_MB` — the flush buffer pool size; the submit-queue overflow threshold is set to 2x this value.

--- a/mkdocs/docs/admin/object-cache.md
+++ b/mkdocs/docs/admin/object-cache.md
@@ -4,6 +4,9 @@
 
 It only caches **reads**. Writes, deletes, and listings always go straight to the origin store — see [What gets cached](#what-gets-cached) below.
 
+!!! info "Looking for the *why*, not the *how*?"
+    This is an operator/deployment guide. For an architecture-level view of how the cache tiers fit together — the in-process L1 cache, this L2 server, the metadata cache, and why there is no invalidation — see [Caching Architecture](../architecture/caching.md).
+
 ## Quick start with the local helper script
 
 ```bash
@@ -133,7 +136,7 @@ The endpoint returns immediately with `202 Accepted` and a small JSON body:
 - `rejected` — items that failed key/prefix or range validation and were skipped; the rest of the batch still proceeds.
 - `dropped` — items load-shed because the queue (`MICROMEGAS_OBJECT_CACHE_PREFETCH_QUEUE_CAPACITY`) was full. Prefetch is best-effort: a full queue never blocks the caller or the response status.
 
-Fills run at the same `Prefetch` priority described in [Fetch scheduling & memory bounds](#fetch-scheduling--memory-bounds) above, so a large prefetch batch never starves a concurrent demand read. Prefetched blocks are admitted to the SSD tier only (not the RAM tier), so they don't compete with hot demand data for RAM residency; a later demand read against a prefetched block is served from SSD.
+Fills run at the same `Prefetch` priority described in [Fetch scheduling & memory bounds](#fetch-scheduling-memory-bounds) above, so a large prefetch batch never starves a concurrent demand read. Prefetched blocks are admitted to the SSD tier only (not the RAM tier), so they don't compete with hot demand data for RAM residency; a later demand read against a prefetched block is served from SSD.
 
 ## Write-time warming
 

--- a/mkdocs/docs/admin/object-cache.md
+++ b/mkdocs/docs/admin/object-cache.md
@@ -180,7 +180,11 @@ Cached ranges never need invalidation because the lake is write-once; see [Cachi
 
 ## Authentication
 
-The cache supports API keys only (no OIDC). Configure a key ring with `MICROMEGAS_API_KEYS` and give each client service its own named key, or pass `--disable-auth` for local development — matching the `--disable-auth` convention used by the other services.
+The cache authenticates with API keys only (no OIDC). Configure a key ring with `MICROMEGAS_API_KEYS` and give **each client its own named key**, so keys can be rotated or revoked per service. Only the two services that use the cache need a key — **FlightSQL and the maintenance daemon**; ingestion is not a client and should not be issued one.
+
+Apply defense in depth: API keys are the application-layer check, but the cache is a purely internal service with no public role, so restrict it at the network layer too. Bind it to a private network and use a security group / firewall / Kubernetes `NetworkPolicy` so that **only FlightSQL and the maintenance daemon can reach its listen endpoint** — nothing else, ingestion or the public internet included, should be able to open a connection.
+
+`--disable-auth` drops the API-key check and is for local development only — never on an endpoint reachable by anything but localhost.
 
 ## Health and readiness
 

--- a/mkdocs/docs/admin/web-app.md
+++ b/mkdocs/docs/admin/web-app.md
@@ -1,4 +1,4 @@
-# Web App Deployment
+# Analytics Web App Deployment
 
 > **TLDR:** The web app is a dev/demo tool. For production use, query via FlightSQL directly.
 

--- a/mkdocs/docs/architecture/caching.md
+++ b/mkdocs/docs/architecture/caching.md
@@ -104,19 +104,23 @@ architecture level the shape is:
 
 ### Cache warming
 
-Two paths populate the cache ahead of demand:
+Warming is **one mechanism with, today, a single producer** — not two independent paths.
 
-- **`POST /prefetch` background warming.** A batch of keys (NDJSON, best-effort, load-shed
-  when the queue is full) is warmed at background priority. Prefetched blocks are admitted to
-  the **SSD tier only** — `FoyerBackend::put` uses `.force().insert()` under the prefetch fill
-  hint (`foyer_backend.rs`) — so they don't evict hot demand data from RAM.
-- **Write-time warming (notify-by-key).** After a writer commits a new partition durably to
-  origin *and* to the `lakehouse_partitions` table, it POSTs the partition's key to `/prefetch`
-  so the cache pulls it before the follow-up query asks for it. This is fire-and-forget off the
-  write path: `DataLakeConnection::warm_object` (`ingestion/src/data_lake_connection.rs`) spawns
-  a detached task, so a slow or unreachable cache never delays or fails the write. It is a
-  general "warm any object by key" primitive; the partition-write path
-  (`write_partition.rs`) is simply its first caller.
+The **mechanism** is the `POST /prefetch` endpoint on `object-cache-srv`: a batch of keys
+(NDJSON, best-effort, load-shed when the queue is full) is filled at background *prefetch*
+priority. Prefetched blocks are admitted to the **SSD tier only** — `FoyerBackend::put` uses
+`.force().insert()` under the prefetch fill hint (`foyer_backend.rs`) — so warming never evicts
+hot demand data from RAM. `POST /prefetch` is a general "warm these keys" primitive that anything
+can drive.
+
+The **only producer wired into the system today** is **write-time warming (notify-by-key)**.
+After a writer commits a new partition durably to origin *and* to the `lakehouse_partitions`
+table, it POSTs the partition's key to `/prefetch` so the cache pulls it before the follow-up
+query asks for it. This is fire-and-forget off the write path: `DataLakeConnection::warm_object`
+(`ingestion/src/data_lake_connection.rs`) spawns a detached task, so a slow or unreachable cache
+never delays or fails the write; its one production caller is the partition-write path
+(`write_partition.rs`). `warm_object` is itself a general "warm any object by key" primitive, so
+new producers can be added without new cache machinery.
 
 ### What is intentionally not cached in L1
 

--- a/mkdocs/docs/architecture/caching.md
+++ b/mkdocs/docs/architecture/caching.md
@@ -104,19 +104,17 @@ architecture level the shape is:
 
 ### Cache warming
 
-Warming is **one mechanism with, today, a single producer** — not two independent paths.
+The cache can be filled ahead of demand through the `POST /prefetch` endpoint on
+`object-cache-srv`: a batch of keys (NDJSON, best-effort, load-shed when the queue is full) is
+filled at background *prefetch* priority. Prefetched blocks are admitted to the **SSD tier
+only** — `FoyerBackend::put` uses `.force().insert()` under the prefetch fill hint
+(`foyer_backend.rs`) — so warming never evicts hot demand data from RAM. `POST /prefetch` is a
+general "warm these keys" primitive that anything can drive.
 
-The **mechanism** is the `POST /prefetch` endpoint on `object-cache-srv`: a batch of keys
-(NDJSON, best-effort, load-shed when the queue is full) is filled at background *prefetch*
-priority. Prefetched blocks are admitted to the **SSD tier only** — `FoyerBackend::put` uses
-`.force().insert()` under the prefetch fill hint (`foyer_backend.rs`) — so warming never evicts
-hot demand data from RAM. `POST /prefetch` is a general "warm these keys" primitive that anything
-can drive.
-
-The **only producer wired into the system today** is **write-time warming (notify-by-key)**.
-After a writer commits a new partition durably to origin *and* to the `lakehouse_partitions`
-table, it POSTs the partition's key to `/prefetch` so the cache pulls it before the follow-up
-query asks for it. This is fire-and-forget off the write path: `DataLakeConnection::warm_object`
+Its one caller today is **write-time warming (notify-by-key)**. After a writer commits a new
+partition durably to origin *and* to the `lakehouse_partitions` table, it POSTs the partition's
+key to `/prefetch` so the cache pulls it before the follow-up query asks for it. This is
+fire-and-forget off the write path: `DataLakeConnection::warm_object`
 (`ingestion/src/data_lake_connection.rs`) spawns a detached task, so a slow or unreachable cache
 never delays or fails the write; its one production caller is the partition-write path
 (`write_partition.rs`). `warm_object` is itself a general "warm any object by key" primitive, so

--- a/mkdocs/docs/architecture/caching.md
+++ b/mkdocs/docs/architecture/caching.md
@@ -131,11 +131,6 @@ Despite the name, `PartitionCache` is **not** part of the caching subsystem. It 
 in-memory snapshot of the partition rows a query planned against, with no cross-query lifetime and
 no eviction. It is called out here only so it is not confused with the object or metadata caches.
 
-### Out of scope
-
-Caches that affect neither query performance nor object-storage cost are intentionally not covered
-here — e.g. the OIDC/JWKS auth-key cache and the data-source config cache.
-
 ## Explicit non-caches
 
 Two "caches you might expect but won't find" are design decisions worth recording:

--- a/mkdocs/docs/architecture/caching.md
+++ b/mkdocs/docs/architecture/caching.md
@@ -19,9 +19,9 @@ with transparent fallback at every hop:
 
 ```mermaid
 flowchart LR
-    Q[Query code<br/>ParquetReader / ReaderFactory<br/>get_range / get_ranges]
-    L1["L1 — in-process<br/>RangeCache + BoundedMemoryBackend (RAM, LFU)<br/>l1_wrap, per query process"]
-    L2["L2 — object-cache-srv<br/>RangeCache + FoyerBackend (RAM+SSD, LRU)<br/>shared over HTTP"]
+    Q[Query engine<br/>DataFusion]
+    L1["L1 — in-process<br/>RAM only<br/>per query process"]
+    L2["L2 — object-cache-srv<br/>RAM + SSD<br/>shared over HTTP"]
     Origin[("Origin object store<br/>S3 / GCS / local")]
 
     Q --> L1
@@ -38,163 +38,132 @@ flowchart LR
     class Origin store
 ```
 
-1. Query code reads a Parquet partition via `ReaderFactory`/`ParquetReader`, calling
-   `object_store.get_range`/`get_ranges`.
-2. That store is **L1-wrapped** (`l1_wrap`, `analytics/src/lakehouse/lakehouse_context.rs`) —
-   an L1 hit never leaves the process.
-3. On an L1 miss it falls through to the inner store: the **L2 `CacheClientStore`**
-   when the cache is configured (`MICROMEGAS_OBJECT_CACHE_URL` + `_API_KEY`), otherwise
-   the origin directly. `CacheClientStore` (`object-cache/src/client.rs`) routes reads
-   to `object-cache-srv` over HTTP and **falls back to a direct origin read on any
-   error** — cache unreachable, non-2xx, or a malformed response (`range_cache_client_fallback`).
-4. `object-cache-srv` serves from its foyer RAM→SSD backend, fetching missing blocks
-   from origin.
+1. The query engine reads a Parquet partition, requesting byte ranges from its object store.
+2. That store is **L1-wrapped** — an L1 hit never leaves the process.
+3. On an L1 miss it falls through to **L2** (the shared `object-cache-srv`) when the cache is
+   configured, otherwise straight to origin. The L2 client **falls back to a direct origin read
+   on any error** — cache unreachable, non-2xx, or a malformed response.
+4. `object-cache-srv` serves from its RAM→SSD backend, fetching missing blocks from origin.
 
-Because every hop degrades to the next one down, a missing or misbehaving cache tier
-lowers hit rate but never fails a read.
+Because every hop degrades to the next one down, a missing or misbehaving cache tier lowers hit
+rate but never fails a read.
 
 ### L1 and L2 are the same subsystem
 
-The key architectural point: **L1 and L2 are not two different caches — they are two
-deployments of one.** Both sit on the `object-cache` crate's `RangeCache`
-(`object-cache/src/range_cache/`), which implements block-granular range caching,
-coalescing, single-flight de-duplication, and the priority-aware fetch budget. They
-differ only in **backend** (the `RangeCacheBackend` trait, `object-cache/src/backend.rs`):
+The key architectural point: **L1 and L2 are not two different caches — they are two deployments
+of one.** Both are built on the same range-cache engine (block-granular range caching, coalescing,
+single-flight de-duplication, priority-aware fetching). They differ only in their storage backend:
 
-| Tier | Where | Backend | Storage | Eviction |
-|---|---|---|---|---|
-| **L1** | in query process (FlightSQL, monolith) | `BoundedMemoryBackend` | RAM only | **LFU** |
-| **L2** | shared `object-cache-srv` over HTTP | `FoyerBackend` | RAM + SSD hybrid | RAM tier: **LRU** |
+| Tier | Where | Storage | Eviction |
+|---|---|---|---|
+| **L1** | in each query process (FlightSQL, monolith) | RAM only | **LFU** |
+| **L2** | shared `object-cache-srv`, over HTTP | RAM + SSD | **LRU** (RAM tier) |
 
-The eviction-policy difference is intentional. L1's `BoundedMemoryBackend` uses
-`LfuConfig` (`bounded_memory_backend.rs`): with a small in-process RAM budget, frequency
-is the better signal for keeping the genuinely hot partitions resident. L2's foyer RAM
-tier uses `LruConfig` (`foyer_backend.rs`): it fronts a large SSD tier, so its RAM job
-is to catch recency, with the SSD tier providing capacity behind it.
+The eviction-policy difference is intentional. L1 has a small in-process RAM budget, so
+**frequency** (LFU) is the better signal for keeping the genuinely hot partitions resident.
+L2's RAM tier fronts a large SSD tier, so its job is to catch **recency** (LRU), with the SSD tier
+providing capacity behind it.
 
 ### Why it works: the write-once lake invariant
 
-Blocks and partitions are written to deterministic paths exactly once and never mutated.
-A cached range therefore can never go stale, so **there is no invalidation logic anywhere
-in the subsystem.** Only reads are cached; writes, deletes, and listings always go
-straight to origin. This is what lets the cache be a pure pass-through with transparent
-fallback rather than a coherence-managed store.
+Blocks and partitions are written to deterministic paths exactly once and never mutated. A cached
+range therefore can never go stale, so **there is no invalidation logic anywhere in the
+subsystem.** Only reads are cached; writes, deletes, and listings always go straight to origin.
+This is what lets the cache be a pure pass-through with transparent fallback rather than a
+coherence-managed store.
 
 ## Read-path mechanics
 
-These behaviors live in the shared `RangeCache` and so apply to both tiers (L1 exercises
-them in-process; L2 over HTTP). They are documented at operator granularity in the
-[deployment guide](../admin/object-cache.md#fetch-scheduling-memory-bounds); at
-architecture level the shape is:
+Because both tiers share the same range-cache engine, these behaviors apply to both. They are
+documented at operator granularity in the
+[deployment guide](../admin/object-cache.md#fetch-scheduling-memory-bounds); at architecture level
+the shape is:
 
-- **Block-granular range caching + coalescing.** Reads are cached per fixed-size block;
-  contiguous missing blocks are merged into a single origin GET rather than one GET per block.
-- **Priority-aware shared fetch budget.** Every origin fetch is either *demand* (a real
-  read) or *prefetch* (background warming). A reserved slice of the fetch budget is always
-  available to demand reads, so a demand read is never stuck behind a large prefetch batch.
-  A prefetched-but-not-yet-fetched block is **promoted** to demand priority if a demand
-  read arrives for it.
-- **Single-flight de-duplication.** Concurrent reads of the same block coalesce into one
-  origin GET via the `FetchScheduler`'s in-flight map (`range_cache/scheduler.rs`); joiners
-  wait on the owner's fetch instead of issuing their own.
-- **Streaming responses with a cross-request memory budget.** `object-cache-srv` streams
-  bytes to the socket in bounded windows rather than buffering whole responses, and bounds
-  the *sum* of in-flight window bytes across all concurrent requests — so response size is
-  uncapped while per-server memory stays bounded.
+- **Block-granular range caching + coalescing.** Reads are cached per fixed-size block; contiguous
+  missing blocks are merged into a single origin GET rather than one GET per block.
+- **Priority-aware shared fetch budget.** Every origin fetch is either *demand* (a real read) or
+  *prefetch* (background warming). A reserved slice of the budget is always available to demand
+  reads, so a demand read is never stuck behind a large prefetch batch — and a prefetch already
+  in flight is **promoted** to demand priority if a real read arrives for it.
+- **Single-flight de-duplication.** Concurrent reads of the same block coalesce into one origin
+  GET; later readers wait on the in-flight fetch instead of issuing their own.
+- **Streaming with a memory bound.** `object-cache-srv` streams responses rather than buffering
+  them whole, and bounds the total in-flight streaming memory across all concurrent requests — so
+  response size is uncapped while server memory stays bounded.
 
 ### Cache warming
 
-The cache can be filled ahead of demand through the `POST /prefetch` endpoint on
-`object-cache-srv`: a batch of keys (NDJSON, best-effort, load-shed when the queue is full) is
-filled at background *prefetch* priority. Prefetched blocks are admitted to the **SSD tier
-only** — `FoyerBackend::put` uses `.force().insert()` under the prefetch fill hint
-(`foyer_backend.rs`) — so warming never evicts hot demand data from RAM. `POST /prefetch` is a
-general "warm these keys" primitive that anything can drive.
+The cache can be filled ahead of demand through `object-cache-srv`'s `POST /prefetch` endpoint: a
+batch of keys is filled at background *prefetch* priority. Warming blocks are admitted to the
+**SSD tier only**, so warming never evicts hot demand data from RAM. It is a general "warm these
+keys" primitive that anything can drive.
 
-Its one caller today is **write-time warming (notify-by-key)**. After a writer commits a new
-partition durably to origin *and* to the `lakehouse_partitions` table, it POSTs the partition's
-key to `/prefetch` so the cache pulls it before the follow-up query asks for it. This is
-fire-and-forget off the write path: `DataLakeConnection::warm_object`
-(`ingestion/src/data_lake_connection.rs`) spawns a detached task, so a slow or unreachable cache
-never delays or fails the write; its one production caller is the partition-write path
-(`write_partition.rs`). `warm_object` is itself a general "warm any object by key" primitive, so
-new producers can be added without new cache machinery.
+Its one caller today is **write-time warming**. After a writer commits a new partition — durably
+to origin *and* to Postgres — it notifies the cache of the new key so the cache pulls it before
+the follow-up query asks for it. This is fire-and-forget off the write path: a slow or unreachable
+cache never delays or fails the write, and new warming producers can be added without new cache
+machinery.
 
 ### What is intentionally not cached in L1
 
-`l1_wrap` is applied only to the lakehouse view store (namespace `"lakehouse"`) and the
-static-tables store (namespace `"static"`). **Raw blob reads (`blobs/...`) deliberately
-bypass L1.** Blobs are read exactly once during ETL materialization (and by the
-`get_payload`/`parse_block` SQL functions), so caching them in-process would add memory
-pressure for no reuse benefit. They still go through the L2/origin stack like any other read.
+L1 wraps only the query read paths — materialized Parquet views and static tables. **Raw
+telemetry blocks (`blobs/...`) deliberately bypass L1:** they are read exactly once during ETL, so
+caching them in-process would add memory pressure with no reuse benefit. They still flow through
+the L2/origin stack like any other read.
 
 ## Other caches in the system
 
 Two more caches affect query performance and belong in the end-to-end picture.
 
-### Parsed partition-metadata cache (`MetadataCache`)
+### Parsed partition-metadata cache
 
-`analytics/src/lakehouse/metadata_cache.rs` is a `moka` cache mapping a Parquet file path →
-its parsed `Arc<ParquetMetaData>`. It is byte-weighted and size-evicted, sized by
-**`MICROMEGAS_METADATA_CACHE_MB`** (default 50 MB, read in `lakehouse_context.rs`).
-
-This cache is what makes the **postgres partition-metadata bypass** work. The postgres
-`partition_metadata` table was removed (#1121/#1236); partition metadata is now read from the
-Parquet **footer** through the object cache (#1235). `ObjectStoreFetch`
-(`analytics/src/lakehouse/partition_metadata.rs`) reads the footer bytes directly from the
-object store — which is itself L1/L2-backed — so those footer bytes flow through the *same*
-byte cache as the data. `MetadataCache` then caches the *parsed* result on top, so a hot
-footer is neither re-fetched (byte cache) nor re-parsed (metadata cache). This was a
-deliberate caching-architecture decision: it moved a hot metadata read off postgres and onto
-the cached object path.
+A separate in-process cache maps a Parquet file path to its **parsed** footer metadata, sized by
+`MICROMEGAS_METADATA_CACHE_MB` (default 50 MB). It is what makes the **Postgres partition-metadata
+bypass** work: the `partition_metadata` table was removed, and partition metadata is now read from
+the Parquet **footer** through the object cache. The footer bytes flow
+through the *same* L1/L2 byte cache as the data, and this cache holds the parsed result on top — so
+a hot footer is neither re-fetched nor re-parsed. It was a deliberate caching decision to move a
+hot metadata read off Postgres and onto the cached object path.
 
 ### `PartitionCache` is not a shared cache
 
-Despite the name, `analytics/src/lakehouse/partition_cache.rs` is **not** part of the caching
-subsystem. It is a per-query, in-memory `Vec<Partition>` snapshot of `lakehouse_partitions`
-rows, populated by a `SELECT` at query planning time. It has no cross-query lifetime and no
-eviction. It is documented here only so it is not confused with the object cache or the
-metadata cache.
+Despite the name, `PartitionCache` is **not** part of the caching subsystem. It is a per-query,
+in-memory snapshot of the partition rows a query planned against, with no cross-query lifetime and
+no eviction. It is called out here only so it is not confused with the object or metadata caches.
 
 ### Out of scope
 
-Caches that affect neither query performance nor object-storage cost are intentionally not
-covered here — e.g. the OIDC/JWKS auth-key cache (`auth/src/oidc.rs`) and the data-source
-config cache (`analytics-web-srv/src/data_source_cache.rs`).
+Caches that affect neither query performance nor object-storage cost are intentionally not covered
+here — e.g. the OIDC/JWKS auth-key cache and the data-source config cache.
 
 ## Explicit non-caches
 
 Two "caches you might expect but won't find" are design decisions worth recording:
 
-- **No DataFusion `CacheManager`.** `make_runtime_env` (`analytics/src/lakehouse/runtime.rs`)
-  builds the `RuntimeEnv` with only a memory pool — no `CacheManager`, `ListFilesCache`, or
-  `FileStatisticsCache`. Parquet caching is deliberately delegated to `MetadataCache` (footers)
-  plus `l1_wrap` (byte ranges), which are aware of the write-once invariant and need no
-  invalidation.
-- **No query-result cache.** Results are recomputed per query. Freshness of continuously
+- **No DataFusion file/metadata cache.** DataFusion's own `CacheManager` is not configured; Parquet
+  caching is deliberately delegated to the footer metadata cache and the L1 byte cache, both of
+  which rely on the write-once invariant and need no invalidation.
+- **No query-result cache.** Results are recomputed per query; freshness of continuously
   materialized views is prioritized over result reuse.
 
 ## Observability
 
-`object-cache-srv` emits a rich metrics/spans taxonomy — hit rate, fetch scheduling, memory
-and fetch-budget saturation gauges, and per-tier latency — all tabulated in
-[Object Cache Deployment → Monitoring](../admin/object-cache.md#monitoring). Two in-process
-signals are not covered there:
+`object-cache-srv` emits a rich metrics/spans taxonomy — hit rate, fetch scheduling, memory and
+fetch-budget saturation, per-tier latency — all tabulated in
+[Object Cache Deployment → Monitoring](../admin/object-cache.md#monitoring). Two in-process signals
+are not covered there:
 
-- **`MetadataCache`**: `metadata_cache_entry_count` (on insert) and `metadata_cache_eviction_delay`
-  (on size eviction).
-- **L1 `RangeCache`**: the same `range_cache_*` hit/miss counters as L2, but **aggregate only** —
-  L1 reports `prefix="other"` for every hit/miss, so parquet and static-table traffic can't be
-  split apart in L1 metrics.
+- **Metadata cache**: `metadata_cache_entry_count` and `metadata_cache_eviction_delay`.
+- **L1 byte cache**: the same `range_cache_*` hit/miss counters as L2, but **aggregate only** — L1
+  reports `prefix="other"` for every hit/miss, so its parquet and static-table traffic can't be
+  split apart.
 
 ## Forward-looking
 
-The in-process cache family is designed to grow. The env-var rename to the
-`MICROMEGAS_OBJECT_CACHE_*` family (`tasks/completed/rename_l1_cache_env_var_plan.md`) was done
-in part to leave room for a **planned DataFusion metadata cache** to land as a second in-process
-(L1-tier) cache alongside the byte-range L1. When it does, it has a home in this architecture:
-another in-process tier over the same write-once lake, warmed and evicted independently of the
-byte cache.
+The in-process cache family is designed to grow. A **planned DataFusion metadata cache** would land
+as a second in-process tier alongside the byte-range L1 — another cache over the same write-once
+lake, warmed and evicted independently. The `MICROMEGAS_OBJECT_CACHE_*` env-var naming was chosen
+in part to leave room for it.
 
 ## Configuration summary
 
@@ -213,6 +182,6 @@ byte cache.
 - **Cache server:** `rust/object-cache-srv/`
 - **In-process caches:** `rust/analytics/src/lakehouse/` — `metadata_cache.rs`,
   `partition_metadata.rs`, `lakehouse_context.rs`, `partition_cache.rs`, `runtime.rs`
-- **Write-time warming:** `rust/ingestion/src/data_lake_connection.rs`
+- **Write-time warming:** `rust/ingestion/src/data_lake_connection.rs`,
+  `rust/analytics/src/lakehouse/write_partition.rs`
 - **Deployment guide:** [Object Cache Deployment](../admin/object-cache.md)
-- **Related PRs:** #1188, #1216, #1220, #1225, #1227, #1235, #1236, #1237, #1239

--- a/mkdocs/docs/architecture/caching.md
+++ b/mkdocs/docs/architecture/caching.md
@@ -1,0 +1,216 @@
+# Caching Architecture
+
+Caching is central to Micromegas read performance. Queries read the same Parquet
+partitions and Parquet footers over and over, and the origin object store (S3/GCS)
+is the slowest and most expensive hop in that path. Micromegas answers this with a
+small family of caches that share one design principle — **the lake is write-once,
+so cached bytes never go stale** — and therefore need no invalidation logic at all.
+
+This page describes the caching subsystem as a whole: *what* the tiers are and *why*
+they exist. For operator concerns — environment variables, CLI flags, deployment,
+and the full metrics taxonomy for `object-cache-srv` — see the companion
+[Object Cache Deployment](../admin/object-cache.md) guide. This page cross-links to
+it rather than duplicating it.
+
+## The tiered object read path
+
+Reads of lake objects (Parquet partitions, static tables) stack through three tiers,
+with transparent fallback at every hop:
+
+```mermaid
+flowchart LR
+    Q[Query code<br/>ParquetReader / ReaderFactory<br/>get_range / get_ranges]
+    L1["L1 — in-process<br/>RangeCache + BoundedMemoryBackend (RAM, LFU)<br/>l1_wrap, per query process"]
+    L2["L2 — object-cache-srv<br/>RangeCache + FoyerBackend (RAM+SSD, LRU)<br/>shared over HTTP"]
+    Origin[("Origin object store<br/>S3 / GCS / local")]
+
+    Q --> L1
+    L1 -->|miss| L2
+    L2 -->|miss| Origin
+    L1 -.->|"L2 not configured"| Origin
+    L2 -.->|"any error<br/>(fallback)"| Origin
+
+    classDef proc fill:#fff3e0
+    classDef svc fill:#f3e5f5
+    classDef store fill:#e1f5fe
+    class Q,L1 proc
+    class L2 svc
+    class Origin store
+```
+
+1. Query code reads a Parquet partition via `ReaderFactory`/`ParquetReader`, calling
+   `object_store.get_range`/`get_ranges`.
+2. That store is **L1-wrapped** (`l1_wrap`, `analytics/src/lakehouse/lakehouse_context.rs`) —
+   an L1 hit never leaves the process.
+3. On an L1 miss it falls through to the inner store: the **L2 `CacheClientStore`**
+   when the cache is configured (`MICROMEGAS_OBJECT_CACHE_URL` + `_API_KEY`), otherwise
+   the origin directly. `CacheClientStore` (`object-cache/src/client.rs`) routes reads
+   to `object-cache-srv` over HTTP and **falls back to a direct origin read on any
+   error** — cache unreachable, non-2xx, or a malformed response (`range_cache_client_fallback`).
+4. `object-cache-srv` serves from its foyer RAM→SSD backend, fetching missing blocks
+   from origin.
+
+Because every hop degrades to the next one down, a missing or misbehaving cache tier
+lowers hit rate but never fails a read.
+
+### L1 and L2 are the same subsystem
+
+The key architectural point: **L1 and L2 are not two different caches — they are two
+deployments of one.** Both sit on the `object-cache` crate's `RangeCache`
+(`object-cache/src/range_cache/`), which implements block-granular range caching,
+coalescing, single-flight de-duplication, and the priority-aware fetch budget. They
+differ only in **backend** (the `RangeCacheBackend` trait, `object-cache/src/backend.rs`):
+
+| Tier | Where | Backend | Storage | Eviction |
+|---|---|---|---|---|
+| **L1** | in query process (FlightSQL, monolith) | `BoundedMemoryBackend` | RAM only | **LFU** |
+| **L2** | shared `object-cache-srv` over HTTP | `FoyerBackend` | RAM + SSD hybrid | RAM tier: **LRU** |
+
+The eviction-policy difference is intentional. L1's `BoundedMemoryBackend` uses
+`LfuConfig` (`bounded_memory_backend.rs`): with a small in-process RAM budget, frequency
+is the better signal for keeping the genuinely hot partitions resident. L2's foyer RAM
+tier uses `LruConfig` (`foyer_backend.rs`): it fronts a large SSD tier, so its RAM job
+is to catch recency, with the SSD tier providing capacity behind it.
+
+### Why it works: the write-once lake invariant
+
+Blocks and partitions are written to deterministic paths exactly once and never mutated.
+A cached range therefore can never go stale, so **there is no invalidation logic anywhere
+in the subsystem.** Only reads are cached; writes, deletes, and listings always go
+straight to origin. This is what lets the cache be a pure pass-through with transparent
+fallback rather than a coherence-managed store.
+
+## Read-path mechanics
+
+These behaviors live in the shared `RangeCache` and so apply to both tiers (L1 exercises
+them in-process; L2 over HTTP). They are documented at operator granularity in the
+[deployment guide](../admin/object-cache.md#fetch-scheduling-memory-bounds); at
+architecture level the shape is:
+
+- **Block-granular range caching + coalescing.** Reads are cached per fixed-size block;
+  contiguous missing blocks are merged into a single origin GET rather than one GET per block.
+- **Priority-aware shared fetch budget.** Every origin fetch is either *demand* (a real
+  read) or *prefetch* (background warming). A reserved slice of the fetch budget is always
+  available to demand reads, so a demand read is never stuck behind a large prefetch batch.
+  A prefetched-but-not-yet-fetched block is **promoted** to demand priority if a demand
+  read arrives for it.
+- **Single-flight de-duplication.** Concurrent reads of the same block coalesce into one
+  origin GET via the `FetchScheduler`'s in-flight map (`range_cache/scheduler.rs`); joiners
+  wait on the owner's fetch instead of issuing their own.
+- **Streaming responses with a cross-request memory budget.** `object-cache-srv` streams
+  bytes to the socket in bounded windows rather than buffering whole responses, and bounds
+  the *sum* of in-flight window bytes across all concurrent requests — so response size is
+  uncapped while per-server memory stays bounded.
+
+### Cache warming
+
+Two paths populate the cache ahead of demand:
+
+- **`POST /prefetch` background warming.** A batch of keys (NDJSON, best-effort, load-shed
+  when the queue is full) is warmed at background priority. Prefetched blocks are admitted to
+  the **SSD tier only** — `FoyerBackend::put` uses `.force().insert()` under the prefetch fill
+  hint (`foyer_backend.rs`) — so they don't evict hot demand data from RAM.
+- **Write-time warming (notify-by-key).** After a writer commits a new partition durably to
+  origin *and* to the `lakehouse_partitions` table, it POSTs the partition's key to `/prefetch`
+  so the cache pulls it before the follow-up query asks for it. This is fire-and-forget off the
+  write path: `DataLakeConnection::warm_object` (`ingestion/src/data_lake_connection.rs`) spawns
+  a detached task, so a slow or unreachable cache never delays or fails the write. It is a
+  general "warm any object by key" primitive; the partition-write path
+  (`write_partition.rs`) is simply its first caller.
+
+### What is intentionally not cached in L1
+
+`l1_wrap` is applied only to the lakehouse view store (namespace `"lakehouse"`) and the
+static-tables store (namespace `"static"`). **Raw blob reads (`blobs/...`) deliberately
+bypass L1.** Blobs are read exactly once during ETL materialization (and by the
+`get_payload`/`parse_block` SQL functions), so caching them in-process would add memory
+pressure for no reuse benefit. They still go through the L2/origin stack like any other read.
+
+## Other caches in the system
+
+Two more caches affect query performance and belong in the end-to-end picture.
+
+### Parsed partition-metadata cache (`MetadataCache`)
+
+`analytics/src/lakehouse/metadata_cache.rs` is a `moka` cache mapping a Parquet file path →
+its parsed `Arc<ParquetMetaData>`. It is byte-weighted and size-evicted, sized by
+**`MICROMEGAS_METADATA_CACHE_MB`** (default 50 MB, read in `lakehouse_context.rs`).
+
+This cache is what makes the **postgres partition-metadata bypass** work. The postgres
+`partition_metadata` table was removed (#1121/#1236); partition metadata is now read from the
+Parquet **footer** through the object cache (#1235). `ObjectStoreFetch`
+(`analytics/src/lakehouse/partition_metadata.rs`) reads the footer bytes directly from the
+object store — which is itself L1/L2-backed — so those footer bytes flow through the *same*
+byte cache as the data. `MetadataCache` then caches the *parsed* result on top, so a hot
+footer is neither re-fetched (byte cache) nor re-parsed (metadata cache). This was a
+deliberate caching-architecture decision: it moved a hot metadata read off postgres and onto
+the cached object path.
+
+### `PartitionCache` is not a shared cache
+
+Despite the name, `analytics/src/lakehouse/partition_cache.rs` is **not** part of the caching
+subsystem. It is a per-query, in-memory `Vec<Partition>` snapshot of `lakehouse_partitions`
+rows, populated by a `SELECT` at query planning time. It has no cross-query lifetime and no
+eviction. It is documented here only so it is not confused with the object cache or the
+metadata cache.
+
+### Out of scope
+
+Caches that affect neither query performance nor object-storage cost are intentionally not
+covered here — e.g. the OIDC/JWKS auth-key cache (`auth/src/oidc.rs`) and the data-source
+config cache (`analytics-web-srv/src/data_source_cache.rs`).
+
+## Explicit non-caches
+
+Two "caches you might expect but won't find" are design decisions worth recording:
+
+- **No DataFusion `CacheManager`.** `make_runtime_env` (`analytics/src/lakehouse/runtime.rs`)
+  builds the `RuntimeEnv` with only a memory pool — no `CacheManager`, `ListFilesCache`, or
+  `FileStatisticsCache`. Parquet caching is deliberately delegated to `MetadataCache` (footers)
+  plus `l1_wrap` (byte ranges), which are aware of the write-once invariant and need no
+  invalidation.
+- **No query-result cache.** Results are recomputed per query. Freshness of continuously
+  materialized views is prioritized over result reuse.
+
+## Observability
+
+`object-cache-srv` emits a rich metrics/spans taxonomy — hit rate, fetch scheduling, memory
+and fetch-budget saturation gauges, and per-tier latency — all tabulated in
+[Object Cache Deployment → Monitoring](../admin/object-cache.md#monitoring). Two in-process
+signals are not covered there:
+
+- **`MetadataCache`**: `metadata_cache_entry_count` (on insert) and `metadata_cache_eviction_delay`
+  (on size eviction).
+- **L1 `RangeCache`**: the same `range_cache_*` hit/miss counters as L2, but **aggregate only** —
+  L1 reports `prefix="other"` for every hit/miss, so parquet and static-table traffic can't be
+  split apart in L1 metrics.
+
+## Forward-looking
+
+The in-process cache family is designed to grow. The env-var rename to the
+`MICROMEGAS_OBJECT_CACHE_*` family (`tasks/completed/rename_l1_cache_env_var_plan.md`) was done
+in part to leave room for a **planned DataFusion metadata cache** to land as a second in-process
+(L1-tier) cache alongside the byte-range L1. When it does, it has a home in this architecture:
+another in-process tier over the same write-once lake, warmed and evicted independently of the
+byte cache.
+
+## Configuration summary
+
+| Variable | Tier | Default | Purpose |
+|---|---|---|---|
+| `MICROMEGAS_OBJECT_CACHE_L1_MB` | L1 in-process | 200 | In-process RAM range cache; `0` disables |
+| `MICROMEGAS_METADATA_CACHE_MB` | in-process | 50 | Parsed Parquet-footer metadata cache |
+| `MICROMEGAS_OBJECT_CACHE_URL` / `_API_KEY` | L2 client opt-in | — | Route reads through `object-cache-srv` |
+| (`object-cache-srv` server knobs) | L2 server | — | See [Object Cache Deployment](../admin/object-cache.md#environment-variables) |
+
+## References
+
+- **Shared cache crate:** `rust/object-cache/` — `range_cache/` (`mod.rs`, `fetch.rs`,
+  `scheduler.rs`), `l1_store.rs`, `backend.rs`, `bounded_memory_backend.rs`, `foyer_backend.rs`,
+  `client.rs`, `prefetch.rs`
+- **Cache server:** `rust/object-cache-srv/`
+- **In-process caches:** `rust/analytics/src/lakehouse/` — `metadata_cache.rs`,
+  `partition_metadata.rs`, `lakehouse_context.rs`, `partition_cache.rs`, `runtime.rs`
+- **Write-time warming:** `rust/ingestion/src/data_lake_connection.rs`
+- **Deployment guide:** [Object Cache Deployment](../admin/object-cache.md)
+- **Related PRs:** #1188, #1216, #1220, #1225, #1227, #1235, #1236, #1237, #1239

--- a/mkdocs/docs/architecture/index.md
+++ b/mkdocs/docs/architecture/index.md
@@ -31,6 +31,11 @@ graph TD
         S3[(Object Storage<br/>S3/GCS/Local<br/>Raw Payloads)]
     end
     
+    subgraph "Caching (read path)"
+        L2[object-cache-srv<br/>shared L2<br/>RAM+SSD]
+        L1[in-process L1<br/>RAM range cache]
+    end
+    
     subgraph "Maintenance"
         Admin[telemetry-admin<br/>crond]
     end
@@ -65,7 +70,9 @@ graph TD
     Ingestion --> S3
     
     PG --> DataFusion
-    S3 --> DataFusion
+    S3 -->|reads| L2
+    L2 --> L1
+    L1 --> DataFusion
     DataFusion --> Parquet
     DataFusion --> FlightSQL
     
@@ -84,11 +91,13 @@ graph TD
     classDef service fill:#f3e5f5
     classDef storage fill:#e1f5fe
     classDef client fill:#fce4ec
+    classDef cache fill:#fff8e1
     
     class App1,App2,App3,Otel app
     class Lib1,Lib2,Lib3,Sink1,Sink2,Sink3 tracing
     class Ingestion,FlightSQL,DataFusion,Admin,WebApp service
     class PG,S3,Parquet storage
+    class L1,L2 cache
     class PyClient,Grafana,Custom,Browser client
 ```
 
@@ -103,6 +112,7 @@ graph TD
 - **PostgreSQL**: Stores metadata, process information, and stream definitions
 - **Object Storage**: Stores raw telemetry payloads in efficient binary format (S3, GCS, or local files)
 - **Lakehouse**: Materialized Parquet views created on-demand for fast analytics
+- **Read Caching**: Reads of lake objects are served through a tiered cache — an in-process **L1** and a shared **L2** (`object-cache-srv`) — before falling through to the origin store; writes go straight to origin. See [Caching Architecture](caching.md) for how the tiers fit together.
 
 #### Analytics Engine
 - **DataFusion**: SQL query engine with vectorized execution optimized for Parquet (columnar format)

--- a/mkdocs/docs/development/build.md
+++ b/mkdocs/docs/development/build.md
@@ -75,12 +75,6 @@ python3 ../build/rust_ci.py
 # Clean build
 cargo clean && cargo build
 
-# Release with debug symbols for profiling
-cargo build --profile release-debug
-
-# Profiling build
-cargo build --profile profiling
-
 # Cross-compile for Windows (from Linux)
 rustup target add x86_64-pc-windows-gnu
 cargo build --target x86_64-pc-windows-gnu

--- a/mkdocs/docs/gateway/configuration.md
+++ b/mkdocs/docs/gateway/configuration.md
@@ -26,7 +26,7 @@ export MICROMEGAS_GATEWAY_HEADERS='{
 | `blocked_headers` | Headers to block (overrides allows) |
 
 **Default headers (if not configured):**
-- `Authorization`, `X-Request-ID`, `X-User-ID`, `X-User-Email`, `User-Agent`
+- `Authorization`, `User-Agent`, `X-Client-Type`, `X-Correlation-ID`, `X-Request-ID`, `X-User-Email`, `X-User-ID`, `X-User-Name`
 - Blocks: `Cookie`, `Set-Cookie`, `X-Client-IP`
 
 **Security:**

--- a/mkdocs/docs/grafana/authentication.md
+++ b/mkdocs/docs/grafana/authentication.md
@@ -33,8 +33,8 @@ Enterprise authentication via identity provider (Google, Auth0, Azure AD, Okta).
    ```
 
 3. **Configure Grafana datasource**:
-   - Auth Method: API Key
-   - API Key: Paste your generated key
+   - Auth Type: token
+   - Token: Paste your generated key
    - Save & Test
 
 ## OAuth 2.0 Client Credentials
@@ -50,7 +50,7 @@ Enterprise authentication via identity provider (Google, Auth0, Azure AD, Okta).
 2. **Configure server** with OIDC settings (see [Admin Guide](../admin/authentication.md))
 
 3. **Configure Grafana datasource**:
-   - Auth Method: OAuth 2.0 Client Credentials
+   - Auth Type: oauth2-client-credentials
    - OIDC Issuer: Your provider URL
    - Client ID: From step 1
    - Client Secret: From step 1
@@ -87,7 +87,7 @@ Create a Machine-to-Machine application in Auth0:
 
 **Grafana Configuration**:
 ```
-Auth Method: OAuth 2.0 Client Credentials
+Auth Type: oauth2-client-credentials
 OIDC Issuer: https://YOUR-TENANT.auth0.com
 Client ID: (from Auth0 application)
 Client Secret: (from Auth0 application)
@@ -108,7 +108,7 @@ gcloud iam service-accounts keys create credentials.json \
 
 **Grafana Configuration**:
 ```
-Auth Method: OAuth 2.0 Client Credentials
+Auth Type: oauth2-client-credentials
 OIDC Issuer: https://accounts.google.com
 Client ID: grafana-prod@PROJECT.iam.gserviceaccount.com
 Client Secret: (from credentials.json)

--- a/mkdocs/docs/grafana/configuration.md
+++ b/mkdocs/docs/grafana/configuration.md
@@ -33,19 +33,14 @@ This guide covers configuring the Micromegas datasource in Grafana.
 !!! warning "Security Recommendation"
     Always enable TLS/SSL for production deployments to encrypt data in transit.
 
-### Skip TLS Verification
-
-**Skip TLS Verify**: Only for self-signed certificates
-
-!!! danger "Use Only for Development"
-    Never skip TLS verification in production. Use valid certificates instead.
-
 ## Authentication
 
-Choose between two authentication methods:
+Select an authentication type from the **Auth Type** dropdown:
 
-- **API Key**: Simple authentication with a single credential
-- **OAuth 2.0 Client Credentials**: Enterprise authentication with identity provider
+- **none**: No authentication
+- **username/password**: Basic authentication with a username and password
+- **token**: Static bearer token
+- **oauth2-client-credentials**: Enterprise authentication with an identity provider
 
 See the [Authentication Guide](authentication.md) for detailed setup instructions.
 
@@ -75,8 +70,8 @@ key2: value2
 ```
 Host: localhost:50051
 TLS/SSL: Disabled
-Auth Method: API Key
-API Key: dev-key-12345
+Auth Type: token
+Token: dev-key-12345
 ```
 
 ### Production Setup
@@ -84,7 +79,7 @@ API Key: dev-key-12345
 ```
 Host: analytics.example.com:50051
 TLS/SSL: Enabled
-Auth Method: OAuth 2.0 Client Credentials
+Auth Type: oauth2-client-credentials
 OIDC Issuer: https://accounts.google.com
 Client ID: grafana-prod@project.iam.gserviceaccount.com
 Client Secret: ********
@@ -95,8 +90,8 @@ Client Secret: ********
 ```
 Host: analytics.example.com:50051
 TLS/SSL: Enabled
-Auth Method: API Key
-API Key: prod-key-67890
+Auth Type: token
+Token: prod-key-67890
 Metadata:
   environment: production
   region: us-east-1

--- a/mkdocs/docs/grafana/usage.md
+++ b/mkdocs/docs/grafana/usage.md
@@ -100,8 +100,8 @@ The dashboard time range is automatically applied - no need for time filter macr
 
 ```sql
 SELECT
-  time_bucket('1 minute', time) AS time,
-  process_name,
+  date_bin('1 minute', time) AS time,
+  exe,
   COUNT(*) as event_count
 FROM log_entries
 WHERE level = 2
@@ -128,12 +128,12 @@ LIMIT 100
 
 ```sql
 SELECT
-  time_bucket('5 minutes', time) AS time,
-  metric_name,
+  date_bin('5 minutes', time) AS time,
+  name,
   AVG(value) as avg_value,
   MAX(value) as max_value
 FROM measures
-WHERE metric_name LIKE 'cpu.%'
+WHERE name LIKE 'cpu.%'
 GROUP BY 1, 2
 ORDER BY 1
 ```
@@ -245,7 +245,7 @@ ORDER BY time_bin
 -- ⚠️ Acceptable: Aggregate raw data
 -- Slow - scans all matching rows
 SELECT
-  time_bucket('1 minute', time) AS time,
+  date_bin('1 minute', time) AS time,
   COUNT(*) as error_count
 FROM log_entries
 WHERE level <= 2
@@ -275,7 +275,7 @@ The bottleneck in queries is **data scanning**, not data transfer. Aggregating r
 
 Both return the same amount of data, but `log_stats` is 100,000x faster because it scans 100,000x less data.
 
-**Recommendation**: Use `log_stats` for log volume analysis and trend monitoring. For other frequently-used aggregation queries, ask your administrator to create custom materialized views. See [Admin Guide - Materialized Views](../admin/authentication.md) for setup details.
+**Recommendation**: Use `log_stats` for log volume analysis and trend monitoring. For other frequently-used aggregation queries, ask your administrator to create custom materialized views. See [Admin Guide - Materialized Views](../admin/maintenance.md) for setup details.
 
 ## Advanced: Manual Time Filter Macros
 

--- a/mkdocs/docs/native/index.md
+++ b/mkdocs/docs/native/index.md
@@ -87,7 +87,7 @@ void mm_log(MmHandle *handle, int level, const char *target, const char *msg);
 ```
 
 Emits a log event.  `target` is a subsystem name (e.g. `"myapp.render"`).
-Both `target` and `msg` may be `NULL` (silently ignored).
+A `NULL` `target` is substituted with `"capi"`; a `NULL` `msg` is silently ignored (no event is emitted).
 
 ### `mm_metric_i` / `mm_metric_f`
 

--- a/mkdocs/docs/query-guide/functions-reference.md
+++ b/mkdocs/docs/query-guide/functions-reference.md
@@ -74,24 +74,6 @@ See [Admin Functions Reference](../admin/functions-reference.md#list_view_sets) 
 
 **⚠️ DESTRUCTIVE OPERATION:** See [Admin Functions Reference](../admin/functions-reference.md#retire_partition_by_filefile_path) for details.
 
-#### `delete_duplicate_processes()` 🔧
-
-**Administrative Function** - Deletes duplicate processes within the query time range. Keeps the earliest entry per `process_id`.
-
-**⚠️ DESTRUCTIVE OPERATION:** See [Admin Functions Reference](../admin/functions-reference.md) for details.
-
-#### `delete_duplicate_streams()` 🔧
-
-**Administrative Function** - Deletes duplicate streams within the query time range. Keeps the earliest entry per `stream_id`.
-
-**⚠️ DESTRUCTIVE OPERATION:** See [Admin Functions Reference](../admin/functions-reference.md) for details.
-
-#### `delete_duplicate_blocks()` 🔧
-
-**Administrative Function** - Deletes duplicate blocks within the query time range. Keeps the earliest entry per `block_id`.
-
-**⚠️ DESTRUCTIVE OPERATION:** See [Admin Functions Reference](../admin/functions-reference.md) for details.
-
 #### `perfetto_trace_chunks(process_id, span_types, start_time, end_time)`
 
 Generates Perfetto trace chunks from process telemetry data for visualization and performance analysis.

--- a/mkdocs/docs/query-guide/python-api.md
+++ b/mkdocs/docs/query-guide/python-api.md
@@ -393,7 +393,7 @@ log_streams = client.query_streams(
 )
 
 print(f"Found {len(streams)} total streams")
-print(f"Stream types: {streams['stream_type'].value_counts()}")
+print(f"Streams per process:\n{streams['process_id'].value_counts()}")
 ```
 
 ### `query_blocks(begin, end, limit, stream_id)`
@@ -428,8 +428,8 @@ for _, span in slow_spans.iterrows():
     duration_ms = span['duration'] / 1000000  # Convert nanoseconds to milliseconds
     print(f"  {span['name']}: {duration_ms:.2f}ms")
 
-# Analyze span hierarchy
-root_spans = spans[spans['parent_span_id'].isna()]
+# Analyze span hierarchy (root spans have depth 0)
+root_spans = spans[spans['depth'] == 0]
 print(f"Found {len(root_spans)} root operations")
 ```
 

--- a/mkdocs/docs/query-guide/schema-reference.md
+++ b/mkdocs/docs/query-guide/schema-reference.md
@@ -35,9 +35,9 @@ Contains metadata about processes that have sent telemetry data.
 | `computer` | `Dictionary(Int16, Utf8)` | Computer/hostname |
 | `distro` | `Dictionary(Int16, Utf8)` | Operating system distribution |
 | `cpu_brand` | `Dictionary(Int16, Utf8)` | CPU brand information |
-| `tsc_frequency` | `UInt64` | Time stamp counter frequency |
+| `tsc_frequency` | `Int64` | Time stamp counter frequency |
 | `start_time` | `Timestamp(Nanosecond)` | Process start time |
-| `start_ticks` | `UInt64` | Process start time in ticks |
+| `start_ticks` | `Int64` | Process start time in ticks |
 | `insert_time` | `Timestamp(Nanosecond)` | When the process data was first inserted |
 | `parent_process_id` | `Dictionary(Int16, Utf8)` | Parent process identifier |
 | `properties` | `Dictionary(Int32, Binary)` | Additional process metadata (JSONB format) |
@@ -72,6 +72,7 @@ Contains information about data streams within processes.
 | `tags` | `List<Utf8>` | Stream tags |
 | `properties` | `Dictionary(Int32, Binary)` | Stream properties (JSONB format) |
 | `insert_time` | `Timestamp(Nanosecond)` | When the stream data was first inserted |
+| `format` | `Utf8` | Stream payload format (e.g. for OTLP support) |
 | `last_update_time` | `Timestamp(Nanosecond)` | When the stream data was last updated |
 
 **Example Queries:**
@@ -352,6 +353,7 @@ Asynchronous span events for tracking async operations with call hierarchy depth
 | `span_id` | `Int64` | Async span identifier |
 | `parent_span_id` | `Int64` | Parent span identifier |
 | `depth` | `UInt32` | Nesting depth in async call hierarchy |
+| `hash` | `UInt32` | Hash of the span's scope descriptor |
 | `name` | `Dictionary(Int16, Utf8)` | Span name (function) |
 | `filename` | `Dictionary(Int16, Utf8)` | Source file |
 | `target` | `Dictionary(Int16, Utf8)` | Module/target |

--- a/mkdocs/docs/unreal/examples.md
+++ b/mkdocs/docs/unreal/examples.md
@@ -110,11 +110,11 @@ void AMyGameMode::Tick(float DeltaSeconds)
                        TEXT("FPS"), TEXT("fps"), 1.0f / DeltaSeconds);
     
     // Game state metrics
-    MICROMEGAS_IMETRIC("Game", MicromegasTracing::Verbosity::Low,
+    MICROMEGAS_IMETRIC("Game", MicromegasTracing::Verbosity::Min,
                        TEXT("PlayerCount"), TEXT("count"), 
                        GetNumPlayers());
     
-    MICROMEGAS_IMETRIC("Game", MicromegasTracing::Verbosity::Low,
+    MICROMEGAS_IMETRIC("Game", MicromegasTracing::Verbosity::Min,
                        TEXT("AICount"), TEXT("count"),
                        GetWorld()->GetNumPawns() - GetNumPlayers());
     
@@ -123,7 +123,7 @@ void AMyGameMode::Tick(float DeltaSeconds)
     if (++FrameCounter % 60 == 0)
     {
         FPlatformMemoryStats MemStats = FPlatformMemory::GetStats();
-        MICROMEGAS_IMETRIC("Memory", MicromegasTracing::Verbosity::Low,
+        MICROMEGAS_IMETRIC("Memory", MicromegasTracing::Verbosity::Min,
                            TEXT("WorkingSetSize"), TEXT("bytes"),
                            MemStats.UsedPhysical);
     }
@@ -216,7 +216,7 @@ float AMyActor::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent,
                    *GetName(), ActualDamage,
                    DamageCauser ? *DamageCauser->GetName() : TEXT("Unknown")));
     
-    MICROMEGAS_FMETRIC("Combat", MicromegasTracing::Verbosity::High,
+    MICROMEGAS_FMETRIC("Combat", MicromegasTracing::Verbosity::Max,
                        TEXT("DamageDealt"), TEXT("points"), ActualDamage);
     
     return ActualDamage;
@@ -258,7 +258,7 @@ void AMyPlayerController::OnFire()
 {
     MICROMEGAS_LOG("Player.Input", MicromegasTracing::LogLevel::Trace,
                    TEXT("Fire action"));
-    MICROMEGAS_IMETRIC("Player.Actions", MicromegasTracing::Verbosity::High,
+    MICROMEGAS_IMETRIC("Player.Actions", MicromegasTracing::Verbosity::Max,
                        TEXT("Fire"), TEXT("count"), 1);
     
     // Fire logic...
@@ -266,7 +266,7 @@ void AMyPlayerController::OnFire()
 
 void AMyPlayerController::OnJump()
 {
-    MICROMEGAS_IMETRIC("Player.Actions", MicromegasTracing::Verbosity::High,
+    MICROMEGAS_IMETRIC("Player.Actions", MicromegasTracing::Verbosity::Max,
                        TEXT("Jump"), TEXT("count"), 1);
     // Jump logic...
 }
@@ -332,7 +332,7 @@ void AMyGameState::Tick(float DeltaSeconds)
 void AMyGameState::ServerRPC_Implementation(const FString& Data)
 {
     MICROMEGAS_SPAN_SCOPE("Network.RPC", "ServerRPC");
-    MICROMEGAS_IMETRIC("Network.RPC", MicromegasTracing::Verbosity::High,
+    MICROMEGAS_IMETRIC("Network.RPC", MicromegasTracing::Verbosity::Max,
                        TEXT("ServerCalls"), TEXT("count"), 1);
     
     // Process RPC...
@@ -340,7 +340,7 @@ void AMyGameState::ServerRPC_Implementation(const FString& Data)
 
 void AMyGameState::ClientRPC_Implementation(const FString& Data)
 {
-    MICROMEGAS_IMETRIC("Network.RPC", MicromegasTracing::Verbosity::High,
+    MICROMEGAS_IMETRIC("Network.RPC", MicromegasTracing::Verbosity::Max,
                        TEXT("ClientCalls"), TEXT("count"), 1);
     
     // Process RPC...
@@ -348,7 +348,7 @@ void AMyGameState::ClientRPC_Implementation(const FString& Data)
 
 void AMyGameState::OnRep_ReplicatedProperty()
 {
-    MICROMEGAS_IMETRIC("Network.Replication", MicromegasTracing::Verbosity::High,
+    MICROMEGAS_IMETRIC("Network.Replication", MicromegasTracing::Verbosity::Max,
                        TEXT("PropertyUpdates"), TEXT("count"), 1);
 }
 ```
@@ -391,7 +391,7 @@ void UMyAssetManager::OnLevelStreamingComplete(ULevelStreaming* StreamedLevel)
                        *StreamedLevel->GetWorldAssetPackageFName().ToString(),
                        SizeBytes / (1024.0f * 1024.0f)));
         
-        MICROMEGAS_IMETRIC("Content.Streaming", MicromegasTracing::Verbosity::Low,
+        MICROMEGAS_IMETRIC("Content.Streaming", MicromegasTracing::Verbosity::Min,
                            TEXT("LevelSize"), TEXT("bytes"), SizeBytes);
     }
 }
@@ -420,7 +420,7 @@ void AMyAIController::OnMoveCompleted(FAIRequestID RequestID, EPathFollowingResu
                    FString::Printf(TEXT("AI move completed: %s"), 
                    *UEnum::GetValueAsString(Result)));
     
-    MICROMEGAS_IMETRIC("AI.Movement", MicromegasTracing::Verbosity::High,
+    MICROMEGAS_IMETRIC("AI.Movement", MicromegasTracing::Verbosity::Max,
                        TEXT("MovesCompleted"), TEXT("count"), 1);
     
     Super::OnMoveCompleted(RequestID, Result);
@@ -453,7 +453,7 @@ void FMySceneProxy::GetDynamicMeshElements(...)
     MICROMEGAS_SPAN_SCOPE("Render.SceneProxy", "GetDynamicMeshElements");
     
     // Expensive rendering operations
-    MICROMEGAS_IMETRIC("Render", MicromegasTracing::Verbosity::High,
+    MICROMEGAS_IMETRIC("Render", MicromegasTracing::Verbosity::Max,
                        TEXT("DynamicElements"), TEXT("count"), Elements.Num());
 }
 ```
@@ -552,7 +552,7 @@ void UMyGameSubsystem::HandleError(const FString& ErrorContext, const FString& E
                    FString::Printf(TEXT("[%s] %s"), *ErrorContext, *ErrorMessage));
     
     // Track error metrics
-    MICROMEGAS_IMETRIC("Errors", MicromegasTracing::Verbosity::Low,
+    MICROMEGAS_IMETRIC("Errors", MicromegasTracing::Verbosity::Min,
                        *FString::Printf(TEXT("Error.%s"), *ErrorContext),
                        TEXT("count"), 1);
     

--- a/mkdocs/docs/unreal/instrumentation-api.md
+++ b/mkdocs/docs/unreal/instrumentation-api.md
@@ -162,7 +162,7 @@ MICROMEGAS_FMETRIC("Game", MicromegasTracing::Verbosity::Max,
 
 ## Spans/Tracing API
 
-**Important:** Spans are **disabled by default**. Enable with console command: `telemetry.spans.enable 1`. Use reasonable sampling strategy for high-frequency spans.
+**Important:** Spans are **disabled by default in the editor** and **enabled by default in non-editor (game) builds**. Toggle with the console command `telemetry.spans.enable 0/1`. Use a reasonable sampling strategy for high-frequency spans.
 
 ### MICROMEGAS_SPAN_FUNCTION
 
@@ -769,7 +769,7 @@ MICROMEGAS_LOG("Render", MicromegasTracing::LogLevel::Info, TEXT("Render thread"
 // Safe from worker threads
 ParallelFor(NumItems, [](int32 Index)
 {
-    MICROMEGAS_IMETRIC("Worker", MicromegasTracing::Verbosity::High,
+    MICROMEGAS_IMETRIC("Worker", MicromegasTracing::Verbosity::Max,
                        TEXT("ItemProcessed"), TEXT("count"), 1);
 });
 ```
@@ -795,7 +795,7 @@ void UMyGameplayAbility::ActivateAbility(...)
 void UAnimInstance::NativeUpdateAnimation(float DeltaSeconds)
 {
     MICROMEGAS_SPAN_FUNCTION("Animation");
-    MICROMEGAS_FMETRIC("Animation", MicromegasTracing::Verbosity::High,
+    MICROMEGAS_FMETRIC("Animation", MicromegasTracing::Verbosity::Max,
                        TEXT("UpdateTime"), TEXT("ms"), DeltaSeconds * 1000);
     
     Super::NativeUpdateAnimation(DeltaSeconds);

--- a/mkdocs/docs/web-app/notebooks/screens-as-code.md
+++ b/mkdocs/docs/web-app/notebooks/screens-as-code.md
@@ -39,7 +39,7 @@ This creates `micromegas-screens.json` with the server URL and a `managed_by` li
 
 ```json
 {
-  "managed_by": "https://github.com/org/repo/tree/main/screens",
+  "managed_by": "https://github.com/org/repo",
   "server": "https://micromegas.example.com"
 }
 ```
@@ -123,7 +123,7 @@ Refresh local files from server. With no arguments, pulls all locally-tracked sc
 micromegas-screens plan [NAME...]
 ```
 
-Preview what `apply` would change. Shows creates, updates, deletes, and untracked screens, and prints a **unified diff** for each modified screen. Pass `--color` to get colored diff output in a terminal. Read-only — no server mutations.
+Preview what `apply` would change. Shows creates, updates, deletes, and untracked screens, and prints a **unified diff** for each modified screen. Colored diff output is on by default in a terminal; pass `--no-color` to disable it. Read-only — no server mutations.
 
 ### `apply`
 

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -104,7 +104,7 @@ nav:
         - Variables: web-app/notebooks/variables.md
         - Execution & Auto-Run: web-app/notebooks/execution.md
         - Screens as Code: web-app/notebooks/screens-as-code.md
-    - Deployment: admin/web-app.md
+    - Analytics Web App Deployment: admin/web-app.md
   - Integrations:
     - OpenTelemetry (OTLP): otlp/index.md
     - Unreal Engine:
@@ -131,7 +131,10 @@ nav:
         - Caching: architecture/caching.md
     - Administration:
         - Authentication: admin/authentication.md
-        - Web App Deployment: admin/web-app.md
+        - Telemetry Ingestion Server: admin/ingestion.md
+        - FlightSQL Server: admin/flight-sql.md
+        - Maintenance Daemon: admin/maintenance.md
+        - Analytics Web App Deployment: admin/web-app.md
         - Monolith Deployment: admin/monolith.md
         - Object Cache Deployment: admin/object-cache.md
         - Service Lifecycle & Shutdown: admin/service-lifecycle.md

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -126,7 +126,9 @@ nav:
     - Blender Add-on: blender/index.md
     - Native SDK (C ABI): native/index.md
   - Operations:
-    - Architecture: architecture/index.md
+    - Architecture:
+        - Overview: architecture/index.md
+        - Caching: architecture/caching.md
     - Administration:
         - Authentication: admin/authentication.md
         - Web App Deployment: admin/web-app.md


### PR DESCRIPTION
## Summary

Documentation-only branch improving the docs site, README, and query skill.

- Add a **caching architecture** page describing the tiered L1 (in-process) → L2 (`object-cache-srv`) → origin read path, and surface the tiered read cache in the overview architecture diagram (#1238).
- Refocus the `admin/object-cache.md` guide on configuration; move design detail to the architecture page and correct the cache-warming and cache-client framing (ingestion neither reads nor warms; encourage defense-in-depth for cache auth).
- Add per-service admin guides for the **ingestion**, **FlightSQL**, and **maintenance-daemon** services.
- Fill README gaps (web app, maintenance daemon, C ABI/Blender, monolith, cache).
- Fix code-verified inaccuracies across the docs: schema/config references, removed `delete_duplicate_*()` UDFs, and correct object-cache binary name; tighten the `micromegas-query` skill's schema/config docs.

Closes #1238

## Test plan

- `mkdocs build --strict` from `mkdocs/` passes with no broken links or nav errors.
- Docs-only change: no code paths affected; spot-checked rendered pages and cross-links.
