### PR TITLE
Quiet cargo-audit and cargo-deny gate output

### DIFF
--- a/rust/.cargo/audit.toml
+++ b/rust/.cargo/audit.toml
@@ -1,9 +1,11 @@
 # cargo-audit configuration — see https://docs.rs/cargo-audit
 #
-# Add an advisory ID here ONLY when there is no fixed version available yet.
-# Every entry MUST carry a comment: the advisory URL, why it does not apply
-# (or cannot be fixed yet), and a condition for removal. Revisit on each
-# dependency bump — remove the ignore as soon as a fix ships.
+# Add an advisory ID here ONLY when it cannot be resolved by a dependency
+# bump — either no fixed version exists (vulnerabilities) or the crate is
+# unmaintained with no maintained drop-in (informational warnings). Every
+# entry MUST carry a comment: the advisory URL/ID, why it can't be fixed
+# now, and a condition for removal. Revisit on each dependency bump — remove
+# the ignore as soon as a fix ships or the dependency drops the crate.
 [advisories]
 ignore = [
     # rsa 0.9.10, in micromegas-auth. RUSTSEC-2023-0071 is the "Marvin"
@@ -31,4 +33,16 @@ ignore = [
     # a fix ships; rollout tracked under #1246.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
+
+    # paste 1.0.15 (RUSTSEC-2024-0436): unmaintained, not a vulnerability.
+    # Pulled transitively by the Arrow/Foyer stack (arrow-flight, foyer-memory)
+    # as a proc-macro; there is no maintained drop-in and nothing to bump on
+    # our side. Remove when those upstreams stop depending on `paste`.
+    "RUSTSEC-2024-0436",
+
+    # proc-macro-error2 2.0.1 (RUSTSEC-2026-0173): unmaintained, not a
+    # vulnerability. A build-time proc-macro reached transitively via
+    # defmt-macros; no maintained replacement and nothing to bump on our side.
+    # Remove when the dependency drops it.
+    "RUSTSEC-2026-0173",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,7 +29,7 @@ micromegas-telemetry = { path = "telemetry", version = "0.27.0" }
 micromegas-telemetry-sink = { path = "telemetry-sink", version = "0.27.0" }
 micromegas-tracing = { path = "tracing", version = "0.27.0", default-features = false }
 micromegas-transit = { path = "transit", version = "0.27.0" }
-micromegas = { path = "public" }
+micromegas = { path = "public", version = "0.27.0" }
 
 anyhow = "1.0"
 arrow-flight = { version = "58.0", features = ["flight-sql-experimental"] }

--- a/rust/datafusion-wasm/.cargo/audit.toml
+++ b/rust/datafusion-wasm/.cargo/audit.toml
@@ -1,0 +1,13 @@
+# cargo-audit configuration for the datafusion-wasm tree.
+#
+# This crate is excluded from the main workspace and has its own Cargo.lock,
+# and cargo-audit has no --config flag and does not inherit a parent
+# directory's config, so ignores for this tree must live here (see
+# ../.cargo/audit.toml for the main-tree list and the ignore policy).
+[advisories]
+ignore = [
+    # paste 1.0.15 (RUSTSEC-2024-0436): unmaintained, not a vulnerability.
+    # Pulled transitively by the Arrow stack as a proc-macro; no maintained
+    # drop-in and nothing to bump on our side. Remove when upstream drops it.
+    "RUSTSEC-2024-0436",
+]

--- a/rust/datafusion-wasm/Cargo.lock
+++ b/rust/datafusion-wasm/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -47,7 +47,9 @@ confidence-threshold = 0.8
 # `datafusion-wasm` tree (which shares this config via `--config ../deny.toml`
 # and whose duplicates are a subset of the main tree's).
 multiple-versions = "deny"
-wildcards = "warn"
+# All internal path/workspace deps carry an explicit version, so any
+# remaining wildcard would be a real external `*` requirement — deny it.
+wildcards = "deny"
 skip = [
     # windows-* API crate family (split across major versions during the
     # ongoing windows-rs ecosystem migration)

--- a/rust/monolith/Cargo.toml
+++ b/rust/monolith/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 authors.workspace = true
 
 [dependencies]
-analytics-web-srv = { path = "../analytics-web-srv" }
+analytics-web-srv = { path = "../analytics-web-srv", version = "0.27.0" }
 micromegas = { workspace = true, features = ["server"] }
 
 anyhow.workspace = true


### PR DESCRIPTION
## Summary

Follow-up to #1269 (cargo-audit/cargo-deny CI gates), cleaning up both gates' output so their signal is unambiguous — the gates now run with zero non-fatal diagnostics on both the main workspace and the `datafusion-wasm` tree.

### cargo-deny (17 diagnostics → 0)

`cargo deny` printed 9 `warning[wildcard]` and 8 `bug[unresolved-workspace-dependency]`, all tracing to two internal path dependencies missing an explicit version — the only version-less internal crates in the workspace:

- `micromegas = { path = "public" }` in `rust/Cargo.toml`
- `analytics-web-srv = { path = "../analytics-web-srv" }` in `rust/monolith/Cargo.toml`

Changes:
- Add `version = "0.27.0"` to both, matching every other internal crate. Removes all 17 diagnostics at the source.
- Tighten `bans.wildcards` from `warn` to `deny`: with all internal deps versioned, any remaining wildcard is a genuine external `*` and should fail.

### cargo-audit (3 warnings main / 2 wasm → 0)

- Bump `anyhow` 1.0.102 → 1.0.103 in both lockfiles, clearing the unsound-`downcast_mut` advisory RUSTSEC-2026-0190.
- Add documented ignores for the two remaining warnings — both unmaintained transitive proc-macros with no maintained drop-in and nothing to bump: `paste` (RUSTSEC-2024-0436) and `proc-macro-error2` (RUSTSEC-2026-0173).
- Add a scoped `rust/datafusion-wasm/.cargo/audit.toml` for `paste`, since cargo-audit has no `--config` flag and does not inherit the main tree's config.

Related: #1246

## Test plan

- `cd rust && cargo audit` → exit 0, no warnings.
- `cd rust && cargo deny check licenses bans sources` → exit 0, no warnings/bugs.
- `cd rust/datafusion-wasm && cargo audit` → exit 0, no warnings.
- `cd rust/datafusion-wasm && cargo deny --config ../deny.toml check licenses bans sources --allow unnecessary-skip` → exit 0.
- `python3 build/rust_ci.py native` → full pipeline passes.
- Lockfile changes are limited to the `anyhow` bump; the added deny version requirements match already-resolved versions.
