### PR TITLE
Bump Rust toolchain to 1.97.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file documents the historical progress of the Micromegas project. For curre
 
 ## Unreleased
 
+* **Build:**
+  * Bump the pinned Rust toolchain to 1.97.0; fix new `clippy::useless_borrows_in_formatting` lints the version tightened, and regenerate the datafusion-wasm bindings whose internal closure-glue symbol names changed under the new compiler
 * **Caching:**
   * Fix a demand-fill leak where a cached block stored as a slice of its coalesced origin-GET buffer pinned the whole parent allocation, letting RAM-tier RSS run up to `max_coalesced_get_bytes / block_size`x its accounted weight; copy on demand admission in both `FoyerBackend` and the L1 `BoundedMemoryBackend` to detach the cached block, and export accounted RAM-tier usage as a new `object_cache_ram_tier_usage_bytes` saturation gauge (#1276)
 * **Docs:**

--- a/analytics-web-app/src/lib/datafusion-wasm/micromegas_datafusion_wasm.d.ts
+++ b/analytics-web-app/src/lib/datafusion-wasm/micromegas_datafusion_wasm.d.ts
@@ -57,9 +57,9 @@ export interface InitOutput {
     readonly rust_zstd_wasm_shim_memmove: (a: number, b: number, c: number) => number;
     readonly rust_zstd_wasm_shim_memset: (a: number, b: number, c: number) => number;
     readonly rust_zstd_wasm_shim_qsort: (a: number, b: number, c: number, d: number) => void;
-    readonly wasm_bindgen__closure__destroy__h183da260ea923a80: (a: number, b: number) => void;
-    readonly wasm_bindgen__convert__closures_____invoke__hfae9e52dc32fd6e8: (a: number, b: number, c: any) => [number, number];
-    readonly wasm_bindgen__convert__closures_____invoke__h306385afed1edfaa: (a: number, b: number, c: any, d: any) => void;
+    readonly wasm_bindgen_531d9694881ee3b8___closure__destroy___dyn_core_7d5f0a2ba6a62c33___ops__function__FnMut__wasm_bindgen_531d9694881ee3b8___JsValue____Output___core_7d5f0a2ba6a62c33___result__Result_____wasm_bindgen_531d9694881ee3b8___JsError___: (a: number, b: number) => void;
+    readonly wasm_bindgen_531d9694881ee3b8___convert__closures_____invoke___wasm_bindgen_531d9694881ee3b8___JsValue__core_7d5f0a2ba6a62c33___result__Result_____wasm_bindgen_531d9694881ee3b8___JsError___true_: (a: number, b: number, c: any) => [number, number];
+    readonly wasm_bindgen_531d9694881ee3b8___convert__closures_____invoke___js_sys_f55d77ba675af7f1___Function_fn_wasm_bindgen_531d9694881ee3b8___JsValue_____wasm_bindgen_531d9694881ee3b8___sys__Undefined___js_sys_f55d77ba675af7f1___Function_fn_wasm_bindgen_531d9694881ee3b8___JsValue_____wasm_bindgen_531d9694881ee3b8___sys__Undefined_______true_: (a: number, b: number, c: any, d: any) => void;
     readonly __wbindgen_exn_store: (a: number) => void;
     readonly __externref_table_alloc: () => number;
     readonly __wbindgen_externrefs: WebAssembly.Table;

--- a/analytics-web-app/src/lib/datafusion-wasm/micromegas_datafusion_wasm.js
+++ b/analytics-web-app/src/lib/datafusion-wasm/micromegas_datafusion_wasm.js
@@ -129,7 +129,7 @@ function __wbg_get_imports() {
                     const a = state0.a;
                     state0.a = 0;
                     try {
-                        return wasm_bindgen__convert__closures_____invoke__h306385afed1edfaa(a, state0.b, arg0, arg1);
+                        return wasm_bindgen_531d9694881ee3b8___convert__closures_____invoke___js_sys_f55d77ba675af7f1___Function_fn_wasm_bindgen_531d9694881ee3b8___JsValue_____wasm_bindgen_531d9694881ee3b8___sys__Undefined___js_sys_f55d77ba675af7f1___Function_fn_wasm_bindgen_531d9694881ee3b8___JsValue_____wasm_bindgen_531d9694881ee3b8___sys__Undefined_______true_(a, state0.b, arg0, arg1);
                     } finally {
                         state0.a = a;
                     }
@@ -184,8 +184,8 @@ function __wbg_get_imports() {
             return ret;
         },
         __wbindgen_cast_0000000000000001: function(arg0, arg1) {
-            // Cast intrinsic for `Closure(Closure { dtor_idx: 108, function: Function { arguments: [Externref], shim_idx: 32493, ret: Result(Unit), inner_ret: Some(Result(Unit)) }, mutable: true }) -> Externref`.
-            const ret = makeMutClosure(arg0, arg1, wasm.wasm_bindgen__closure__destroy__h183da260ea923a80, wasm_bindgen__convert__closures_____invoke__hfae9e52dc32fd6e8);
+            // Cast intrinsic for `Closure(Closure { dtor_idx: 109, function: Function { arguments: [Externref], shim_idx: 32463, ret: Result(Unit), inner_ret: Some(Result(Unit)) }, mutable: true }) -> Externref`.
+            const ret = makeMutClosure(arg0, arg1, wasm.wasm_bindgen_531d9694881ee3b8___closure__destroy___dyn_core_7d5f0a2ba6a62c33___ops__function__FnMut__wasm_bindgen_531d9694881ee3b8___JsValue____Output___core_7d5f0a2ba6a62c33___result__Result_____wasm_bindgen_531d9694881ee3b8___JsError___, wasm_bindgen_531d9694881ee3b8___convert__closures_____invoke___wasm_bindgen_531d9694881ee3b8___JsValue__core_7d5f0a2ba6a62c33___result__Result_____wasm_bindgen_531d9694881ee3b8___JsError___true_);
             return ret;
         },
         __wbindgen_cast_0000000000000002: function(arg0, arg1) {
@@ -216,15 +216,15 @@ function __wbg_get_imports() {
     };
 }
 
-function wasm_bindgen__convert__closures_____invoke__hfae9e52dc32fd6e8(arg0, arg1, arg2) {
-    const ret = wasm.wasm_bindgen__convert__closures_____invoke__hfae9e52dc32fd6e8(arg0, arg1, arg2);
+function wasm_bindgen_531d9694881ee3b8___convert__closures_____invoke___wasm_bindgen_531d9694881ee3b8___JsValue__core_7d5f0a2ba6a62c33___result__Result_____wasm_bindgen_531d9694881ee3b8___JsError___true_(arg0, arg1, arg2) {
+    const ret = wasm.wasm_bindgen_531d9694881ee3b8___convert__closures_____invoke___wasm_bindgen_531d9694881ee3b8___JsValue__core_7d5f0a2ba6a62c33___result__Result_____wasm_bindgen_531d9694881ee3b8___JsError___true_(arg0, arg1, arg2);
     if (ret[1]) {
         throw takeFromExternrefTable0(ret[0]);
     }
 }
 
-function wasm_bindgen__convert__closures_____invoke__h306385afed1edfaa(arg0, arg1, arg2, arg3) {
-    wasm.wasm_bindgen__convert__closures_____invoke__h306385afed1edfaa(arg0, arg1, arg2, arg3);
+function wasm_bindgen_531d9694881ee3b8___convert__closures_____invoke___js_sys_f55d77ba675af7f1___Function_fn_wasm_bindgen_531d9694881ee3b8___JsValue_____wasm_bindgen_531d9694881ee3b8___sys__Undefined___js_sys_f55d77ba675af7f1___Function_fn_wasm_bindgen_531d9694881ee3b8___JsValue_____wasm_bindgen_531d9694881ee3b8___sys__Undefined_______true_(arg0, arg1, arg2, arg3) {
+    wasm.wasm_bindgen_531d9694881ee3b8___convert__closures_____invoke___js_sys_f55d77ba675af7f1___Function_fn_wasm_bindgen_531d9694881ee3b8___JsValue_____wasm_bindgen_531d9694881ee3b8___sys__Undefined___js_sys_f55d77ba675af7f1___Function_fn_wasm_bindgen_531d9694881ee3b8___JsValue_____wasm_bindgen_531d9694881ee3b8___sys__Undefined_______true_(arg0, arg1, arg2, arg3);
 }
 
 const WasmQueryEngineFinalization = (typeof FinalizationRegistry === 'undefined')

--- a/mkdocs/docs/development/build.md
+++ b/mkdocs/docs/development/build.md
@@ -4,7 +4,7 @@ This guide covers building Micromegas from source and setting up a development e
 
 ## Prerequisites
 
-- **[Rust](https://rustup.rs/)** - Toolchain version pinned in `rust/rust-toolchain.toml` (currently `1.96.0`); `rustup` will install it automatically on first build
+- **[Rust](https://rustup.rs/)** - Toolchain version pinned in `rust/rust-toolchain.toml`; `rustup` will install it automatically on first build
 - **[Python 3.8+](https://www.python.org/downloads/)**
 - **[Docker](https://www.docker.com/get-started/)** - For running PostgreSQL
 - **[Git](https://git-scm.com/downloads)**

--- a/rust/analytics/src/lakehouse/jit_partitions.rs
+++ b/rust/analytics/src/lakehouse/jit_partitions.rs
@@ -480,8 +480,8 @@ pub async fn is_jit_partition_up_to_date(
         "[{}, {}] {} {}",
         min_insert_time.to_rfc3339(),
         max_insert_time.to_rfc3339(),
-        &*view_meta.view_set_name,
-        &*view_meta.view_instance_id,
+        *view_meta.view_set_name,
+        *view_meta.view_instance_id,
     );
 
     // CRITICAL: Use inclusive inequalities (<=, >=) to prevent race conditions.

--- a/rust/analytics/src/lakehouse/write_partition.rs
+++ b/rust/analytics/src/lakehouse/write_partition.rs
@@ -284,8 +284,8 @@ async fn insert_partition(
     logger
         .write_log_entry(format!(
             "[PARTITION_WRITE_START] view={}/{} time_range=[{}, {}] source_rows={} - lock acquired",
-            &partition.view_metadata.view_set_name,
-            &partition.view_metadata.view_instance_id,
+            partition.view_metadata.view_set_name,
+            partition.view_metadata.view_instance_id,
             partition.begin_insert_time(),
             partition.end_insert_time(),
             source_row_count
@@ -349,8 +349,8 @@ async fn insert_partition(
             logger
                 .write_log_entry(format!(
                     "[PARTITION_INSERT_ERROR] view={}/{} time_range=[{}, {}] source_rows={} error={}",
-                    &partition.view_metadata.view_set_name,
-                    &partition.view_metadata.view_instance_id,
+                    partition.view_metadata.view_set_name,
+                    partition.view_metadata.view_instance_id,
                     partition.begin_insert_time(),
                     partition.end_insert_time(),
                     source_row_count,
@@ -545,8 +545,8 @@ pub async fn write_partition_from_rows(
     let file_id = uuid::Uuid::new_v4();
     let file_path = format!(
         "views/{}/{}/{}/{}_{file_id}.parquet",
-        &view_metadata.view_set_name,
-        &view_metadata.view_instance_id,
+        view_metadata.view_set_name,
+        view_metadata.view_instance_id,
         insert_range.begin.format("%Y-%m-%d"),
         insert_range.begin.format("%H-%M-%S")
     );

--- a/rust/analytics/src/metadata.rs
+++ b/rust/analytics/src/metadata.rs
@@ -94,7 +94,7 @@ pub fn get_thread_name_from_stream_metadata(stream: &StreamMetadata) -> Result<S
     const THREAD_ID_KEY: &str = "thread-id";
 
     if stream.properties.is_empty() {
-        return Ok(format!("{}", &stream.stream_id));
+        return Ok(format!("{}", stream.stream_id));
     }
 
     let jsonb = RawJsonb::new(&stream.properties);

--- a/rust/analytics/src/payload.rs
+++ b/rust/analytics/src/payload.rs
@@ -32,7 +32,7 @@ pub async fn fetch_block_payload(
         span_scope!("decode");
         let payload: micromegas_telemetry::block_wire_format::BlockPayload =
             ciborium::from_reader(&buffer[..])
-                .with_context(|| format!("reading payload {}", &block_id))?;
+                .with_context(|| format!("reading payload {}", block_id))?;
         Ok(payload)
     }
 }

--- a/rust/datafusion-wasm/Cargo.lock
+++ b/rust/datafusion-wasm/Cargo.lock
@@ -1507,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "fast-float2"

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.97.0"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-unknown-unknown", "x86_64-pc-windows-gnu"]

--- a/rust/telemetry-sink/src/tracing_interop.rs
+++ b/rust/telemetry-sink/src/tracing_interop.rs
@@ -74,7 +74,7 @@ where
             line: 0,
         };
 
-        log_interop(&log_desc, format_args!("{}", &buffer));
+        log_interop(&log_desc, format_args!("{}", buffer));
     }
 }
 

--- a/rust/transit/src/parser.rs
+++ b/rust/transit/src/parser.rs
@@ -144,7 +144,7 @@ fn parse_custom_instance<'a>(
     if let Some(reader) = custom_readers.get(&*udt.name) {
         (*reader)(bump, udt, udts, dependencies, object_window)
     } else {
-        log::warn!("unknown custom object {}", &udt.name);
+        log::warn!("unknown custom object {}", udt.name);
         Ok(Value::Object(bump.alloc(Object {
             type_name: udt.name.as_str(),
             members: &[],


### PR DESCRIPTION
## Summary

* Bump the pinned Rust toolchain from 1.96.0 to 1.97.0 (`rust/rust-toolchain.toml`), which also bumps the `ethnum` dependency in `rust/datafusion-wasm/Cargo.lock` (1.5.2 -> 1.5.3)
* Stop hardcoding the toolchain version number in the Build Guide docs, so it can't go stale on future bumps
* Fix new `clippy::useless_borrows_in_formatting` lints that Rust 1.97.0's clippy started flagging (redundant `&` references in `format!`/`log::warn!` arguments) across `transit`, `telemetry-sink`, and `analytics`
* Regenerate the tracked datafusion-wasm JS/TS bindings — the new compiler changed the mangled names of wasm-bindgen's internal closure glue exports; no functional/API change

## Test plan

* [x] `python3 build/rust_ci.py` passes clean (format, clippy, unused-deps, advisory/license checks, tests, and the full WASM pipeline including the bindings freshness check)
* [x] `cargo build` succeeds standalone in `rust/datafusion-wasm`
