### PR TITLE
Document object-cache disk-path wipe-on-format-change behavior

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -202,7 +202,7 @@ docker run -d --name analytics-web \
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `MICROMEGAS_OBJECT_CACHE_ORIGIN_URI` | Yes | Bucket-only origin URI (e.g. `s3://my-bucket`, no path — the lake-root prefix arrives inside each request key) |
-| `MICROMEGAS_OBJECT_CACHE_DISK_PATH` | Yes | Local disk path for the cache backend |
+| `MICROMEGAS_OBJECT_CACHE_DISK_PATH` | Yes | Local disk path for the cache backend. Used exclusively by the cache: on a format-changing upgrade its **contents are wiped** on startup and rewarmed from origin (safe for cache data — see the [admin guide](../mkdocs/docs/admin/object-cache.md)). Point it at a dedicated volume, never a shared directory. |
 | `MICROMEGAS_API_KEYS` | Yes* | JSON array of `{"name":"...","key":"..."}` |
 | `MICROMEGAS_OBJECT_CACHE_RAM_MB` | No | In-memory cache size (default `512`) |
 | `MICROMEGAS_OBJECT_CACHE_DISK_GB` | No | On-disk cache size (default `50`) |

--- a/mkdocs/docs/admin/object-cache.md
+++ b/mkdocs/docs/admin/object-cache.md
@@ -58,6 +58,9 @@ docker run -d -p 8080:8080 \
 
 Authenticating *against the origin* (e.g. AWS credentials) uses the same environment variables as every other Micromegas service's `MICROMEGAS_OBJECT_STORE_URI` — standard `object_store` crate variables such as `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT`, `AWS_REGION`, `AWS_ALLOW_HTTP`.
 
+!!! warning "Give the cache its own directory — its contents can be wiped on startup"
+    The cache manages `MICROMEGAS_OBJECT_CACHE_DISK_PATH` exclusively. The on-disk store carries an internal format version, and when a build's format differs from the persisted store (a format-changing upgrade, or a first boot onto a pre-versioning store), the cache **deletes all contents** of this path on startup, then rewarms from origin. The directory/mount point itself is preserved; only its contents are removed. This is safe for cache data — the cache is a read-through layer over a write-once origin, so nothing but reconstructible cache blocks is lost (this is what "no data loss" means above) — but it means the path must be used **exclusively** by the cache. Never point it at a shared volume or a directory holding anything else, or that data will be erased on the next format bump. The wipe emits the `object_cache_disk_format_wiped` metric (see [Monitoring](#monitoring)).
+
 ## CLI flags
 
 | Flag | Default | Description |

--- a/rust/object-cache-srv/README.md
+++ b/rust/object-cache-srv/README.md
@@ -67,7 +67,7 @@ All flags can be set via the listed environment variables.
 | `--listen`                      | `MICROMEGAS_OBJECT_CACHE_LISTEN`     | `0.0.0.0:8080` | Listen address.                                                    |
 | `--origin-uri`                  | `MICROMEGAS_OBJECT_CACHE_ORIGIN_URI` | _(required)_   | Origin object store URI. Must be bucket-only with no path component. |
 | `--ram-mb`                      | `MICROMEGAS_OBJECT_CACHE_RAM_MB`     | `512`          | RAM cache size, in MB.                                             |
-| `--disk-path`                   | `MICROMEGAS_OBJECT_CACHE_DISK_PATH`  | _(required)_   | Directory for the on-disk cache.                                  |
+| `--disk-path`                   | `MICROMEGAS_OBJECT_CACHE_DISK_PATH`  | _(required)_   | Directory for the on-disk cache, used exclusively by the cache. Its contents are wiped on startup after a format-changing upgrade and rewarmed from origin (safe for cache data); point it at a dedicated volume, never a shared directory. |
 | `--disk-gb`                     | `MICROMEGAS_OBJECT_CACHE_DISK_GB`    | `50`           | Disk cache size, in GB.                                           |
 | `--block-size`                  | `MICROMEGAS_OBJECT_CACHE_BLOCK_SIZE` | `1048576`      | Cache block size, in bytes (must be > 0).                         |
 | `--namespace`                   | `MICROMEGAS_OBJECT_CACHE_NAMESPACE`  | _(derived)_    | Cache namespace. Defaults to the origin URI with the scheme stripped. |


### PR DESCRIPTION
The object cache wipes the contents of `MICROMEGAS_OBJECT_CACHE_DISK_PATH` on startup when the on-disk format version differs from the build's (a format-changing upgrade, or first boot onto a pre-versioning store). The behavior is safe — the cache is a read-through layer over a write-once origin, so wiped blocks just rewarm from origin — but it was only documented in two table cells of the admin guide, with no prominent callout, and not at all in the docker or crate READMEs where a "persistent volume" framing could mislead an operator.

## Changes
- **`mkdocs/docs/admin/object-cache.md`**: add a `!!! warning` admonition after the env-var table — the path is cache-exclusive, contents are wiped on a format change (mount point preserved), why it's safe, and never point it at a shared volume.
- **`docker/README.md`**: expand the `DISK_PATH` row so operators reading only the docker docs learn contents can be wiped.
- **`rust/object-cache-srv/README.md`**: same one-line note on the `--disk-path` row.

Docs only — no behavior change.