### PR TITLE
Fix 2 Dependabot alerts: bump immutable to 5.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This file documents the historical progress of the Micromegas project. For curre
   * Pin the transitive `websocket-driver` dev dependency to `^0.7.5` via yarn `resolutions` to resolve Dependabot alerts #339/#340
   * Bump `js-yaml` to `^4.3.0`, `protobufjs` to `^7.6.5`, and `brace-expansion` to `^5.0.7`/`^2.1.2` via yarn `resolutions` across the root, `welcome/`, and `analytics-web-app/` workspaces to resolve Dependabot alerts #341-#347
   * Bump `tar` to `^7.5.19` (resolving to 7.5.20) across all yarn workspaces (root, `welcome/`, `analytics-web-app/`, and the `doc/*` sites) to resolve 24 Dependabot alerts (#348-371)
+  * Bump `immutable` to `^5.1.8` (resolving to 5.1.9) in the root yarn workspace to resolve 2 Dependabot alerts (#374, #375)
   * Delete the unused `uri-handler` crate, and route `analytics-web-srv` and `object-cache-srv` through the public `micromegas` facade (`micromegas::auth`/`micromegas::object_cache`/`micromegas::tracing`) instead of depending on internal crates directly (#1256)
 * **Caching:**
   * Fix a benign but observable write race in `FoyerBackend::get`: replace foyer's `HybridCache::get` with a two-step read (RAM lookup, then direct disk load) whose disk→RAM promotion is gated on a caller-supplied expected length, plus a per-key single-flight around the disk load to keep read-coalescing parity; this makes foyer's inflight decoy-close-flag path unreachable and adds `object_cache_ram_tier_hit`/`object_cache_disk_tier_hit`, `range_cache_load_coalesced`, and `range_cache_promotion_len_mismatch` metrics (#1318)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint/ajv": "6.14.0",
     "fast-uri": "^3.1.2",
     "flatted": "^3.4.2",
-    "immutable": "^5.1.5",
+    "immutable": "^5.1.8",
     "js-cookie": "^3.0.7",
     "js-yaml": "^4.3.0",
     "lodash": "^4.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6692,10 +6692,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:^5.1.5":
-  version: 5.1.5
-  resolution: "immutable@npm:5.1.5"
-  checksum: 10c0/8017ece1578e3c5939ba3305176aee059def1b8a90c7fa2a347ef583ebbd38cbe77ce1bbd786a5fab57e2da00bbcb0493b92e4332cdc4e1fe5cfb09a4688df31
+"immutable@npm:^5.1.8":
+  version: 5.1.9
+  resolution: "immutable@npm:5.1.9"
+  checksum: 10c0/ae7032b60b81b682f3e7e4df13e1ec9a401a603eb81b15bb3e37331ed6666e318c71994c6936e1462eb443d32d04769396562a7e2669da22457c8ba279c03ad2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bump `immutable` from `^5.1.5` to `^5.1.8` (resolving to 5.1.9) in the root yarn workspace, fixing 2 GHSA advisories: a hash-collision algorithmic complexity DoS and a 32-bit trie overflow DoS in `Immutable.Map`/`List`/`Set`
- Resolves Dependabot alerts [#374](https://github.com/madesroches/micromegas/security/dependabot/374) and [#375](https://github.com/madesroches/micromegas/security/dependabot/375)
- Checked all other yarn/npm lockfiles in the repo (`welcome/`, `analytics-web-app/`, the `doc/*` sites) — none of them pull in `immutable`, so only the root `yarn.lock` needed the bump

## Test plan
- [x] `yarn install` regenerates the lockfile with a single resolved `immutable@5.1.9` and no other drift
- [x] `yarn lint:fix` in `grafana/` passes clean with no changes
- [x] `yarn build` in `grafana/` compiles successfully
