### PR TITLE
Blender public log api

### DIFF
--- a/blender/micromegas_blender/__init__.py
+++ b/blender/micromegas_blender/__init__.py
@@ -27,6 +27,15 @@ import re
 import sys
 import uuid
 
+from .binding import (
+    LEVEL_FATAL,
+    LEVEL_ERROR,
+    LEVEL_WARN,
+    LEVEL_INFO,
+    LEVEL_DEBUG,
+    LEVEL_TRACE,
+)
+
 try:
     from . import _build_info
 
@@ -280,13 +289,14 @@ def _telemetry_excepthook(exc_type, exc_value, exc_tb):
             _prev_excepthook(exc_type, exc_value, exc_tb)
 
 
-def log(level: int, target: str, msg: str) -> None:
+def log(level: int, target: str, msg: object) -> None:
     """Public API: log a message via the active telemetry session, if any.
 
     No-ops silently if the add-on isn't registered/initialized, so other
     add-ons can call this unconditionally without checking for our presence
-    first. `level` uses the LEVEL_* constants from binding.py (mirrors the
-    Rust log crate): FATAL=1, ERROR=2, WARN=3, INFO=4, DEBUG=5, TRACE=6.
+    first. `level` uses the LEVEL_* constants re-exported from this module
+    (mirrors the Rust log crate): LEVEL_FATAL=1, LEVEL_ERROR=2, LEVEL_WARN=3,
+    LEVEL_INFO=4, LEVEL_DEBUG=5, LEVEL_TRACE=6.
     """
     if _lib and _handle:
         try:

--- a/blender/micromegas_blender/__init__.py
+++ b/blender/micromegas_blender/__init__.py
@@ -280,6 +280,21 @@ def _telemetry_excepthook(exc_type, exc_value, exc_tb):
             _prev_excepthook(exc_type, exc_value, exc_tb)
 
 
+def log(level: int, target: str, msg: str) -> None:
+    """Public API: log a message via the active telemetry session, if any.
+
+    No-ops silently if the add-on isn't registered/initialized, so other
+    add-ons can call this unconditionally without checking for our presence
+    first. `level` uses the LEVEL_* constants from binding.py (mirrors the
+    Rust log crate): FATAL=1, ERROR=2, WARN=3, INFO=4, DEBUG=5, TRACE=6.
+    """
+    if _lib and _handle:
+        try:
+            _lib.log(_handle, level, target, str(msg))
+        except Exception:
+            pass
+
+
 def register():
     global _lib, _handle, _session_id, _prefs_registered
 

--- a/blender/micromegas_blender/tests/test_public_log_api.py
+++ b/blender/micromegas_blender/tests/test_public_log_api.py
@@ -1,0 +1,46 @@
+"""Tests for the public log() API in __init__.py."""
+
+import micromegas_blender as mm
+
+
+def test_log_forwards_to_active_session(rec_lib):
+    mm._lib = rec_lib
+    mm._handle = object()
+    try:
+        mm.log(4, "other_addon.target", "hello")
+        assert rec_lib.logs == [(4, "other_addon.target", "hello")]
+    finally:
+        mm._lib = None
+        mm._handle = None
+
+
+def test_log_stringifies_non_string_msg(rec_lib):
+    mm._lib = rec_lib
+    mm._handle = object()
+    try:
+        mm.log(4, "other_addon.target", 12345)
+        assert rec_lib.logs[-1][2] == "12345"
+    finally:
+        mm._lib = None
+        mm._handle = None
+
+
+def test_log_is_noop_without_active_session(rec_lib):
+    mm._lib = None
+    mm._handle = None
+    mm.log(4, "other_addon.target", "should not raise or log")
+    assert rec_lib.logs == []
+
+
+def test_log_swallows_exceptions_from_lib():
+    class RaisingLib:
+        def log(self, handle, level, target, msg):
+            raise RuntimeError("native call failed")
+
+    mm._lib = RaisingLib()
+    mm._handle = object()
+    try:
+        mm.log(2, "other_addon.target", "boom")  # must not raise
+    finally:
+        mm._lib = None
+        mm._handle = None


### PR DESCRIPTION
## Summary

Adds `micromegas_blender.log(level, target, msg)` as a small public API so other add-ons in the same Blender process can log through this add-on's active telemetry session without needing their own ingestion setup.

No-ops silently if the add-on isn't registered/initialized, so callers don't need to check for our presence first. `level` uses the same `LEVEL_*` constants as `binding.py` (mirrors the Rust `log` crate): FATAL=1, ERROR=2, WARN=3, INFO=4, DEBUG=5, TRACE=6.

## Test plan

- [x] Added `tests/test_public_log_api.py` covering forwarding to the active session, non-string message stringification, no-op when no session is active, and swallowing exceptions from the native lib call