### PR TITLE
Release v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file documents the historical progress of the Micromegas project. For curre
 
 ## Unreleased
 
+## v0.28.0 - 2026-08-02
+
 * **Claude Code Plugin:**
   * Fix the `micromegas-query` skill failing to load outright whenever `micromegas-query` isn't installed or its connection isn't configured yet — precisely the two cases its own `## Setup` section exists to repair. Replace the load-time `!`-prefixed shell probes (which aborted the whole skill load on a non-zero exit) with an ordinary first-use check the agent runs and reacts to, and switch persistent configuration from a `~/.micromegas_env` file sourced by the shell profile (which never reached the agent's own subsequent tool calls) to `~/.micromegas/config.json`, already read by the library on every invocation; also tighten `allowed-tools` to the minimum the skill needs (#1404)
 * **Python:**

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ Building from source or contributing code? See the [Build Guide](https://microme
 
 ## Recent Releases
 
+### v0.28.0 (August 2026)
+* Audience-based Access Control: the five mutating lakehouse SQL functions (`retire_partitions`, `materialize_partitions`, `regenerate_partitions`, `retire_partition_by_file`, `retire_partition_by_metadata`) are now gated on the caller's admin status via a new gRPC header, matched against `MICROMEGAS_ADMINS`/`MICROMEGAS_ANALYTICS_ADMINS`
+* CloudWatch Firehose ingestion: new endpoints let CloudWatch Metric Streams and CloudWatch Logs reach micromegas via Kinesis Data Firehose HTTP Endpoint Delivery with no Lambda or collector in between, partitioned per CloudWatch namespace
+* Order-preserving k-way merge for `SqlBatchView`s and `blocks_view` via a new per-file scan mode, collapsing sorted partitions in one pass instead of buffering a full sort
+* Python client: raised the minimum supported Python version to 3.11, enabling native RFC 3339 `Z`-suffixed timestamp parsing across the FlightSQL client and `micromegas-query` CLI
+* Screens folders: folder organization for saved screens (list/create/rename/move/delete), sidebar tree, and a Save-dialog folder picker
+* Observability: per-query FlightSQL audit log, a `pg_stat_*` self-observability collector on the maintenance daemon, process RSS/jemalloc gauges on every service, and per-view failure isolation in the materialization pass
+* Object-cache hardening: client-side circuit breaker, a two-step read replacing a foyer race, disk→RAM promotion metrics, and graceful-shutdown drain fixes
+* DataFusion 54.1; Rust toolchain 1.97.1; Grafana plugin SDK 12.4.6; `analytics-web-app` migrated from Jest to Vitest; assorted Dependabot fixes
+
 ### v0.27.0 (July 2026)
 * Tiered object read cache: new `micromegas-object-cache` engine powering a standalone range-aware S3 read cache service (`micromegas-object-cache-srv`, Foyer RAM+disk) and an in-process L1 cache; single-flight coalescing, priority budgeting, memory-bounded prefetch, NDJSON-streamed `/prefetch`, streamed range responses, write-time cache warming, and extensive performance telemetry
 * Removed the Postgres `partition_metadata` table (schema v6): partition Parquet metadata is now read solely from the Parquet footer via the object-cache-backed reader, eliminating TOAST and write-path overhead

--- a/analytics-web-app/package.json
+++ b/analytics-web-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytics-web-app",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/blender/micromegas_blender/blender_manifest.toml
+++ b/blender/micromegas_blender/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "micromegas_blender"
-version = "0.28.0"
+version = "0.29.0"
 name = "Micromegas Telemetry"
 tagline = "Captures Blender session telemetry and ships it to a Micromegas server"
 maintainer = "Micromegas"

--- a/grafana/CHANGELOG.md
+++ b/grafana/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.28.0 (2026-08-02)
+
+Version sync release. Grafana plugin SDK upgraded from 11.6.7 to 12.4.6, replacing the frozen `@grafana/experimental` with `@grafana/plugin-ui` (#848). Security fix: `google.golang.org/grpc` bumped to 1.82.1 (Dependabot alert #381, GHSA-hrxh-6v49-42gf).
+
 ## 0.27.0 (2026-07-12)
 
 Version sync release. Security fix from Dependabot dependency bump: `golang.org/x/net` 0.55.0 (#338).

--- a/grafana/package.json
+++ b/grafana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micromegas-micromegas-datasource",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",

--- a/python/micromegas/pyproject.toml
+++ b/python/micromegas/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "micromegas"
-version = "0.28.0"
+version = "0.29.0"
 description = "Python analytics client for the Micromegas observability platform"
 authors = ["Marc-Antoine Desroches <madesroches@gmail.com>"]
 homepage = "https://micromegas.info/"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "analytics-web-srv"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "arrow-ipc",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "flight-sql-srv"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "clap",
  "micromegas",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "http-gateway"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "arrow-flight",
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-analytics"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "arrow-flight",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-auth"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3747,7 +3747,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-capi"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "micromegas-telemetry-sink",
  "micromegas-tracing",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-datafusion-extensions"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-derive-transit"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "quote",
  "syn",
@@ -3776,7 +3776,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-ingestion"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-monolith"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "analytics-web-srv",
  "anyhow",
@@ -3809,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-object-cache"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-object-cache-srv"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-otel-ingestion"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-perfetto"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-proc-macros"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3901,7 +3901,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-telemetry"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3919,7 +3919,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-telemetry-sink"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-tracing"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-tracing-proc-macros"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-transit"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -6090,7 +6090,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "telemetry-ingestion-srv"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -6101,7 +6101,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry-maintenance-srv"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -7275,7 +7275,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "write-perfetto"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 
 [workspace.package]
-version = "0.28.0"
+version = "0.29.0"
 edition = "2024"
 license = "Apache-2.0"
 homepage = "https://micromegas.info/"
@@ -16,20 +16,20 @@ keywords = ["observability", "telemetry", "analytics"]
 
 
 [workspace.dependencies]
-micromegas-analytics = { path = "analytics", version = "0.28.0" }
-micromegas-auth = { path = "auth", version = "0.28.0" }
-micromegas-datafusion-extensions = { path = "datafusion-extensions", version = "0.28.0" }
-micromegas-ingestion = { path = "ingestion", version = "0.28.0" }
-micromegas-object-cache = { path = "object-cache", version = "0.28.0" }
-micromegas-object-cache-srv = { path = "object-cache-srv", version = "0.28.0" }
-micromegas-otel-ingestion = { path = "otel-ingestion", version = "0.28.0" }
-micromegas-perfetto = { path = "perfetto", version = "0.28.0" }
-micromegas-proc-macros = { path = "micromegas-proc-macros", version = "0.28.0" }
-micromegas-telemetry = { path = "telemetry", version = "0.28.0" }
-micromegas-telemetry-sink = { path = "telemetry-sink", version = "0.28.0" }
-micromegas-tracing = { path = "tracing", version = "0.28.0", default-features = false }
-micromegas-transit = { path = "transit", version = "0.28.0" }
-micromegas = { path = "public", version = "0.28.0" }
+micromegas-analytics = { path = "analytics", version = "0.29.0" }
+micromegas-auth = { path = "auth", version = "0.29.0" }
+micromegas-datafusion-extensions = { path = "datafusion-extensions", version = "0.29.0" }
+micromegas-ingestion = { path = "ingestion", version = "0.29.0" }
+micromegas-object-cache = { path = "object-cache", version = "0.29.0" }
+micromegas-object-cache-srv = { path = "object-cache-srv", version = "0.29.0" }
+micromegas-otel-ingestion = { path = "otel-ingestion", version = "0.29.0" }
+micromegas-perfetto = { path = "perfetto", version = "0.29.0" }
+micromegas-proc-macros = { path = "micromegas-proc-macros", version = "0.29.0" }
+micromegas-telemetry = { path = "telemetry", version = "0.29.0" }
+micromegas-telemetry-sink = { path = "telemetry-sink", version = "0.29.0" }
+micromegas-tracing = { path = "tracing", version = "0.29.0", default-features = false }
+micromegas-transit = { path = "transit", version = "0.29.0" }
+micromegas = { path = "public", version = "0.29.0" }
 
 anyhow = "1.0"
 arrow-flight = { version = "58.0", features = ["flight-sql-experimental"] }

--- a/rust/datafusion-wasm/Cargo.lock
+++ b/rust/datafusion-wasm/Cargo.lock
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-datafusion-extensions"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-datafusion-wasm"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-derive-transit"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "quote",
  "syn",
@@ -2433,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-telemetry"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-telemetry-sink"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2475,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-tracing"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-tracing-proc-macros"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "micromegas-transit"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "bumpalo",

--- a/rust/datafusion-wasm/Cargo.toml
+++ b/rust/datafusion-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micromegas-datafusion-wasm"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2024"
 license = "Apache-2.0"
 homepage = "https://micromegas.info/"
@@ -19,9 +19,9 @@ arrow = { version = "58.0", default-features = false, features = ["ipc"] }
 chrono = { version = "0.4", default-features = false, features = ["wasmbind"] }
 datafusion = { version = "54.1", default-features = false, features = ["nested_expressions", "sql"] }
 getrandom = { version = "0.3", features = ["wasm_js"] }
-micromegas-datafusion-extensions = { path = "../datafusion-extensions", version = "0.28.0" }
-micromegas-telemetry-sink = { path = "../telemetry-sink", version = "0.28.0", default-features = false }
-micromegas-tracing = { path = "../tracing", version = "0.28.0", default-features = false }
+micromegas-datafusion-extensions = { path = "../datafusion-extensions", version = "0.29.0" }
+micromegas-telemetry-sink = { path = "../telemetry-sink", version = "0.29.0", default-features = false }
+micromegas-tracing = { path = "../tracing", version = "0.29.0", default-features = false }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 

--- a/rust/monolith/Cargo.toml
+++ b/rust/monolith/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 authors.workspace = true
 
 [dependencies]
-analytics-web-srv = { path = "../analytics-web-srv", version = "0.28.0" }
+analytics-web-srv = { path = "../analytics-web-srv", version = "0.29.0" }
 micromegas = { workspace = true, features = ["server", "jemalloc-metrics"] }
 
 anyhow.workspace = true

--- a/rust/tracing/Cargo.toml
+++ b/rust/tracing/Cargo.toml
@@ -14,7 +14,7 @@ authors.workspace = true
 anyhow.workspace = true
 chrono = { workspace = true, features = ["wasmbind"] }
 lazy_static.workspace = true
-micromegas-tracing-proc-macros = { path = "./proc-macros", version = "^0.28" }
+micromegas-tracing-proc-macros = { path = "./proc-macros", version = "^0.29" }
 pin-project.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/rust/transit/Cargo.toml
+++ b/rust/transit/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 authors.workspace = true
 
 [dependencies]
-micromegas-derive-transit = { path = "derive", version = "^0.28" }
+micromegas-derive-transit = { path = "derive", version = "^0.29" }
 
 anyhow.workspace = true
 bumpalo.workspace = true

--- a/tasks/completed/release_v0.28_plan.md
+++ b/tasks/completed/release_v0.28_plan.md
@@ -39,24 +39,24 @@ Checked `git diff --name-status v0.27.0..HEAD -- rust/` for added `Cargo.toml` f
 ### 1. Code Quality & Testing
 
 #### Rust Workspace (from `rust/` directory)
-- [ ] Run full CI pipeline: `python3 ../build/rust_ci.py` (native + WASM, fmt, clippy, tests, `cargo audit`/`cargo deny`)
+- [x] Run full CI pipeline: `python3 ../build/rust_ci.py` (native + WASM, fmt, clippy, tests, `cargo audit`/`cargo deny`) — all green
 
 #### Python Package (from `python/micromegas/` directory)
-- [ ] `poetry run black . --check`
-- [ ] `poetry run pytest` (integration test failures due to missing server are expected)
+- [x] `poetry run black . --check` — clean
+- [x] `poetry run pytest` — 112 passed, 71 failed (all connection-refused to analytics/ingestion servers not running locally, expected), 6 skipped
 
 #### Grafana Plugin (from `grafana/` directory)
-- [ ] `yarn install`
-- [ ] `yarn lint:fix`
-- [ ] `yarn test:ci`
-- [ ] `yarn build`
+- [x] `yarn install`
+- [x] `yarn lint:fix`
+- [x] `yarn test:ci` — 47/47 passed
+- [x] `yarn build` — succeeded (pre-existing `immutable`/react-awesome-query-builder warnings only)
 
 #### Analytics Web App (from `analytics-web-app/` directory)
-- [ ] `yarn install`
-- [ ] `yarn lint`
-- [ ] `yarn type-check`
-- [ ] `yarn test`
-- [ ] `yarn build`
+- [x] `yarn install`
+- [x] `yarn lint` — clean (pre-existing fast-refresh warnings only)
+- [x] `yarn type-check`
+- [x] `yarn test` — 1244/1244 passed
+- [x] `yarn build`
 
 ### 2. Version Verification (all should already be 0.28.0)
 
@@ -69,25 +69,25 @@ Checked `git diff --name-status v0.27.0..HEAD -- rust/` for added `Cargo.toml` f
 
 ### 3. Documentation Updates
 
-- [ ] Review git log: `git log --oneline v0.27.0..HEAD`
-- [ ] Update `CHANGELOG.md` — rename `## Unreleased` to `## v0.28.0 - 2026-08-02`, add a fresh empty `## Unreleased` above it
-- [ ] Update `grafana/CHANGELOG.md` — add a `## 0.28.0 (2026-08-02)` version-sync entry
-- [ ] Update `README.md` roadmap — add a `### v0.28.0 (August 2026)` block under "Recent Releases"
+- [x] Review git log: `git log --oneline v0.27.0..HEAD`
+- [x] Update `CHANGELOG.md` — renamed `## Unreleased` to `## v0.28.0 - 2026-08-02`, added a fresh empty `## Unreleased` above it
+- [x] Update `grafana/CHANGELOG.md` — added a `## 0.28.0 (2026-08-02)` version-sync entry
+- [x] Update `README.md` roadmap — added a `### v0.28.0 (August 2026)` block under "Recent Releases"
 
 ### 4. Grafana Plugin Preparation
 
-- [ ] Build plugin archive: `./build-plugin.sh` (from `grafana/`) → `grafana/micromegas-micromegas-datasource.zip`
+- [x] Build plugin archive: `./build-plugin.sh` (from `grafana/`) → `grafana/micromegas-micromegas-datasource.zip`
 
 ### 5. Git Preparation
 
 All four tags must point to the same release commit (workspace at 0.28.0, before the Phase 4 bump):
 
-- [ ] Commit the changelog/doc updates ("Release v0.28.0")
-- [ ] Create release tags:
+- [x] Commit the changelog/doc updates ("Release v0.28.0")
+- [x] Create release tags:
   ```bash
   git tag v0.28.0 grafana-v0.28.0 capi-v0.28.0 blender-v0.28.0
   ```
-- [ ] Push release branch and all tags:
+- [x] Push release branch and all tags:
   ```bash
   git push origin release && git push origin v0.28.0 grafana-v0.28.0 capi-v0.28.0 blender-v0.28.0
   ```
@@ -148,13 +148,13 @@ docker buildx imagetools inspect marcantoinedesroches/micromegas-monolith:0.28.0
 
 ### Phase 5: Cleanup
 
-- Move this plan from `tasks/` to `tasks/completed/release_v0.28_plan.md`
-- Update `tasks/release_plan_template.md` "Lessons Learned" if anything new came up
+- [x] Move this plan from `tasks/` to `tasks/completed/release_v0.28_plan.md`
+- [x] Update `tasks/release_plan_template.md` "Lessons Learned"
 
 ### Phase 6: Merge to Main
 
-- Open PR from `release` → `main`
-- Merge after review
+- [ ] Open PR from `release` → `main`
+- [ ] Merge after review
 
 ## Rollback Plan
 

--- a/tasks/release_plan_template.md
+++ b/tasks/release_plan_template.md
@@ -1,7 +1,19 @@
 # Release Plan Template for Micromegas
 
 This template is updated after each release with lessons learned.
-Last updated: v0.27.0 (2026-07-13)
+Last updated: v0.28.0 (2026-08-02)
+
+---
+
+## Lessons Learned from v0.28.0
+
+### `cargo release` refuses to run with ANY untracked file, not just dirty tracked files
+
+Phase 1 failed immediately on the first crate (`micromegas-derive-transit`) with "uncommitted changes detected" because the freshly-written `tasks/release_v0.28_plan.md` was untracked — it had never been committed. `cargo release`'s clean-tree check rejects untracked files just like modified ones. **Commit the release plan doc itself (along with the changelog/doc updates) before running Phase 1**, not just the tracked-file changes.
+
+### Docker phase estimate revised: budget ~2–2.5h, not ~1h
+
+The prior template said "~1h of real compute" for 7 services × 2 arches. This cycle, 5 of 7 services (both arches) were done at 87 minutes elapsed; the last two services (`analytics-web`, `monolith`) are the heaviest — `analytics-web` bundles the wasm/frontend build on top of the Rust binary, and `monolith` links every service's code into one binary — so they take noticeably longer per-arch than the thin single-binary services. Total wall-clock this cycle was well over 2 hours. Plan accordingly when scheduling this phase; it is not a "run it and check back in an hour" step.
 
 ---
 

--- a/tasks/release_v0.28_plan.md
+++ b/tasks/release_v0.28_plan.md
@@ -1,0 +1,169 @@
+# Release Plan: Micromegas v0.28.0
+
+## Overview
+
+Release version 0.28.0 of Micromegas. This is an access-control + ingestion-surface release. Highlights:
+
+- **Audience-based Access Control** — the five mutating lakehouse SQL functions (`retire_partitions`, `materialize_partitions`, `regenerate_partitions`, `retire_partition_by_file`, `retire_partition_by_metadata`) are now gated on the caller's admin status via a new `x-auth-is-admin` gRPC header; only OIDC callers matched against `MICROMEGAS_ADMINS`/`MICROMEGAS_ANALYTICS_ADMINS` can call them (breaking API: `is_admin: bool` required param threaded through `query`/`make_session_context`/etc.) (#1384).
+- **CloudWatch Firehose ingestion** — new `POST /ingestion/otlp/v1/metrics/firehose` and `.../logs/firehose/cloudwatch` endpoints let CloudWatch Metric Streams / CloudWatch Logs reach micromegas via Kinesis Data Firehose HTTP Endpoint Delivery with no Lambda/collector in between; metrics are partitioned per CloudWatch namespace and length-delimited record batches are decoded correctly (#1299, #1381, #1387, #1300, #1388).
+- **Lakehouse merge ordering** — order-preserving k-way merge for `SqlBatchView`s and `blocks_view` via a new `ScanOrdering::PerFile` scan mode (breaking API: `View::get_scan_output_ordering`, `PartitionedTableProvider::with_scan_ordering`, `QueryMerger::with_merge_scan_ordering`, `fetch_sql_partition_spec` signatures changed) (#1392, #1336).
+- **Python 3.11 minimum + RFC 3339 timestamps** — breaking change raising the minimum supported Python from 3.10 to 3.11, enabling native `Z`-suffixed RFC 3339 parsing across the FlightSQL client and `micromegas-query` CLI (#1405).
+- **Screens folders** — folder organization for saved screens (list/create/rename/move/delete), sidebar tree, Save dialog picker, TOCTOU-safe via Postgres advisory locks (#1159).
+- **Observability** — per-query FlightSQL audit log (`flightsql_query_audit`), `pg_stat_*` self-observability collector on the maintenance daemon, process RSS/jemalloc gauges on every service, materialization-pass failure isolation so one broken view no longer starves the rest (#1288, #1292, #1319, #1393).
+- **Object-cache hardening** — client-side circuit breaker, two-step read replacing a foyer race, disk→RAM promotion metrics, graceful-shutdown drain fixes (#1380, #1360, #1318, #1291).
+- **Dependencies/toolchain** — Rust 1.97.1, DataFusion 54.1, Grafana plugin SDK 12.4.6, `analytics-web-app` Jest→Vitest migration, assorted Dependabot fixes.
+
+73 commits since v0.27.0.
+
+## Current Status
+
+- **Version**: 0.28.0 (already bumped during v0.27.0 post-release — verified across all packages)
+- **Last Release**: v0.27.0 (2026-07-12)
+- **Branch**: `release`
+- **Commits since v0.27.0**: 73
+
+## New Crates & Services Since v0.27.0
+
+Checked `git diff --name-status v0.27.0..HEAD -- rust/` for added `Cargo.toml` files and diffed the current `rust/*/Cargo.toml` member list against `build/release.py`'s `-p` list and `build/build_docker_images.py`'s `SERVICES` dict.
+
+**Result: no new publishable crate and no new Docker service this cycle.** `release.py`'s 16-crate dependency-ordered list and the 7-service `SERVICES` dict (`ingestion`, `flight-sql`, `maintenance`, `object-cache`, `http-gateway`, `analytics-web`, `monolith`) both already match the workspace. `rust/public/Cargo.toml` gained a `jemalloc-metrics` feature and new dev-dependencies/tests, but no new crate directory.
+
+## Pre-Release Checklist
+
+### 0. Fix release.py (if new crates or services were added)
+
+- [x] Verified no new published crates are missing from `build/release.py`
+- [x] Verified no new crates in the wasm workspace
+- [x] Verified no new server binary needs adding to `SERVICES` in `build/build_docker_images.py`
+
+### 1. Code Quality & Testing
+
+#### Rust Workspace (from `rust/` directory)
+- [ ] Run full CI pipeline: `python3 ../build/rust_ci.py` (native + WASM, fmt, clippy, tests, `cargo audit`/`cargo deny`)
+
+#### Python Package (from `python/micromegas/` directory)
+- [ ] `poetry run black . --check`
+- [ ] `poetry run pytest` (integration test failures due to missing server are expected)
+
+#### Grafana Plugin (from `grafana/` directory)
+- [ ] `yarn install`
+- [ ] `yarn lint:fix`
+- [ ] `yarn test:ci`
+- [ ] `yarn build`
+
+#### Analytics Web App (from `analytics-web-app/` directory)
+- [ ] `yarn install`
+- [ ] `yarn lint`
+- [ ] `yarn type-check`
+- [ ] `yarn test`
+- [ ] `yarn build`
+
+### 2. Version Verification (all should already be 0.28.0)
+
+- [x] `rust/Cargo.toml` workspace version = 0.28.0
+- [x] `rust/datafusion-wasm/Cargo.toml` version = 0.28.0
+- [x] `python/micromegas/pyproject.toml` version = 0.28.0
+- [x] `grafana/package.json` version = 0.28.0
+- [x] `analytics-web-app/package.json` version = 0.28.0
+- [x] `blender/micromegas_blender/blender_manifest.toml` version = 0.28.0
+
+### 3. Documentation Updates
+
+- [ ] Review git log: `git log --oneline v0.27.0..HEAD`
+- [ ] Update `CHANGELOG.md` — rename `## Unreleased` to `## v0.28.0 - 2026-08-02`, add a fresh empty `## Unreleased` above it
+- [ ] Update `grafana/CHANGELOG.md` — add a `## 0.28.0 (2026-08-02)` version-sync entry
+- [ ] Update `README.md` roadmap — add a `### v0.28.0 (August 2026)` block under "Recent Releases"
+
+### 4. Grafana Plugin Preparation
+
+- [ ] Build plugin archive: `./build-plugin.sh` (from `grafana/`) → `grafana/micromegas-micromegas-datasource.zip`
+
+### 5. Git Preparation
+
+All four tags must point to the same release commit (workspace at 0.28.0, before the Phase 4 bump):
+
+- [ ] Commit the changelog/doc updates ("Release v0.28.0")
+- [ ] Create release tags:
+  ```bash
+  git tag v0.28.0 grafana-v0.28.0 capi-v0.28.0 blender-v0.28.0
+  ```
+- [ ] Push release branch and all tags:
+  ```bash
+  git push origin release && git push origin v0.28.0 grafana-v0.28.0 capi-v0.28.0 blender-v0.28.0
+  ```
+
+## Release Process
+
+### Phase 1: Rust Crates Release
+
+```bash
+cd /home/mad/micromegas/build
+python3 release.py
+```
+
+### Phase 2: Python Library Release
+
+From `python/micromegas/`:
+```bash
+poetry build
+poetry publish
+```
+
+### Phase 3: Grafana Plugin Release
+
+```bash
+gh release create v0.28.0 \
+  --title "Micromegas v0.28.0 - <tagline>" \
+  --notes "..." \
+  grafana/micromegas-micromegas-datasource.zip
+```
+
+### Phase 3.5: Docker Images (run BEFORE Phase 4)
+
+```bash
+python3 build/build_docker_images.py \
+  ingestion flight-sql maintenance object-cache http-gateway analytics-web monolith \
+  --all-arches --push --version 0.28.0
+```
+
+Verify both platforms pushed:
+```bash
+docker buildx imagetools inspect marcantoinedesroches/micromegas-monolith:0.28.0
+```
+
+### Phase 4: Post-Release Version Bump to 0.29.0
+
+> **WARNING**: Do not start until Phase 1 (all Rust publishes) is complete.
+
+- `rust/Cargo.toml`: workspace version → 0.29.0; all `micromegas-*` path-dep versions → 0.29.0
+- `rust/tracing/Cargo.toml`: proc-macros dep → `^0.29`
+- `rust/transit/Cargo.toml`: derive-transit dep → `^0.29`
+- `rust/datafusion-wasm/Cargo.toml`: version → 0.29.0, all micromegas deps → `^0.29`
+- `python/micromegas/pyproject.toml` → 0.29.0
+- `grafana/package.json` → 0.29.0
+- `analytics-web-app/package.json` → 0.29.0
+- `blender/micromegas_blender/blender_manifest.toml` → 0.29.0
+- Lock files: `cargo update` (from `rust/`), `yarn install` (grafana + analytics-web-app), `python3 build.py --test` (from `rust/datafusion-wasm/`)
+- Commit the bump on the `release` branch
+
+### Phase 5: Cleanup
+
+- Move this plan from `tasks/` to `tasks/completed/release_v0.28_plan.md`
+- Update `tasks/release_plan_template.md` "Lessons Learned" if anything new came up
+
+### Phase 6: Merge to Main
+
+- Open PR from `release` → `main`
+- Merge after review
+
+## Rollback Plan
+
+- Yank problematic Rust crates: `cargo yank --vers 0.28.0 <crate-name>`
+- Update GitHub release notes with issue documentation
+- Prepare patch release v0.28.1 if critical issues found
+
+## Decisions
+
+1. **Release date — 2026-08-02.**
+2. **Release tagline — "Audience-based access control + CloudWatch Firehose ingestion."**
+3. **No new crates/services this cycle** — `release.py` and `SERVICES` unchanged.


### PR DESCRIPTION
## Summary
- Release v0.28.0: version bump, CHANGELOG/README updates, and the v0.28.0 release plan.
- All Rust crates published to crates.io, Python package published to PyPI, Docker images (7 services × amd64/arm64) built and pushed, GitHub release created with the Grafana plugin archive attached.
- Post-release version bump to 0.29.0 on all packages.

See the [v0.28.0 GitHub release](https://github.com/madesroches/micromegas/releases/tag/v0.28.0) and `CHANGELOG.md` for full details.

## Test plan
- [x] `rust_ci.py` (fmt, clippy, cargo audit/deny, native + WASM tests) — all green
- [x] Python: `black --check` clean, `pytest` (only expected server-connection failures)
- [x] Grafana plugin: lint, 47/47 tests, build
- [x] Analytics web app: lint, type-check, 1244/1244 tests, build