### PR TITLE
Fix stale Go version prereq, document covdata/mage coverage gotcha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This file documents the historical progress of the Micromegas project. For curre
   * Add `--version` to `micromegas-query`, `micromegas-logout`, and `micromegas-screens`, and expose `micromegas.__version__`, so it's easy to tell which installed wheel (and which interpreter) backs a console script; `--version` reports the package version plus the interpreter version and path (e.g. `micromegas-query 0.29.0 (Python 3.11.9 at /usr/bin/python3.11)`), reading the package version from `importlib.metadata.version("micromegas")` via a shared `micromegas.cli.version` helper, falling back to `"unknown"` if the package isn't installed. Also fix `micromegas-query`'s and `micromegas-logout`'s `prog=` value (previously `query` / `micromegas_logout`) to match their actual console-script names (#1416)
 * **Security:**
   * Bump `undici` to `8.10.0` via yarn `resolutions`/`overrides` across all yarn workspaces (root, `analytics-web-app`, `welcome`, `doc/intro-micromegas`, `doc/notebooks`, `doc/unified-observability-for-games`) to resolve Dependabot alerts 403-433 (GHSA-m8rv-5g2x-5cg5, GHSA-jr45-8vmc-qm54, GHSA-v3r7-h72x-cjcm, GHSA-8xcm-r25x-g524, GHSA-4cwx-7wf7-3272), and bump `fast-uri` to `3.1.5` to resolve Dependabot alert 428 (GHSA-7p8r-x3mc-p8w7)
+* **Docs:**
+  * Fix the Grafana plugin's Go prerequisite in `CONTRIBUTING.md`/`mkdocs/docs/contributing.md` (stale "Go 1.23+", but `grafana/go.mod` and the `grafana-plugin` CI workflow both require 1.25) and document why `mage coverage` can fail with `go: no such tool "covdata"` on a fresh setup, plus the one-time fix (building `cmd/covdata` into `GOROOT`'s tool directory)
 
 ## v0.28.0 - 2026-08-02
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -362,9 +362,28 @@ The Grafana plugin requires both Node.js and Go:
 
 **Prerequisites:**
 - Node.js 22+ (matches `grafana/.nvmrc` and the `grafana-plugin` CI workflow; Yarn 4 requires ≥18.12)
-- Go 1.23+ (for backend plugin)
+- Go 1.25+ (matches `grafana/go.mod` and the `grafana-plugin` CI workflow's `go-version: '1.25'`)
 - Yarn 4 (Berry) — installed automatically via `corepack enable` once on a new machine
 - mage (for Go builds): `go install github.com/magefile/mage@latest`
+
+!!! note "`mage coverage` needs a `covdata` binary in GOROOT"
+    If your system Go is older than `grafana/go.mod`'s version, `GOTOOLCHAIN=auto`
+    downloads a matching toolchain automatically — but that auto-downloaded
+    toolchain ships a trimmed tool set (`asm cgo compile cover link preprofile
+    vet` only) and omits `covdata`, `pprof`, `trace`, and others. `go test
+    -coverpkg ./...` (which `mage coverage` runs) needs `covdata` to merge
+    coverage across packages, and unlike the interactive `go tool covdata`
+    command, its internal invocation does not fall back to building the tool
+    on demand — it fails with `go: no such tool "covdata"` even though every
+    individual test passes. Installing a Go SDK that already satisfies
+    `go.mod` (so no toolchain auto-download is needed) doesn't fully fix this
+    either, since even the official `go1.25.x` tarball omits a prebuilt
+    `covdata`. Build it once into your GOROOT:
+    ```bash
+    GOROOT=$(go env GOROOT)
+    cd "$GOROOT/src/cmd/covdata"
+    go build -o "$GOROOT/pkg/tool/$(go env GOOS)_$(go env GOARCH)/covdata" .
+    ```
 
 **Development workflow:**
 ```bash

--- a/mkdocs/docs/contributing.md
+++ b/mkdocs/docs/contributing.md
@@ -242,9 +242,28 @@ The Grafana plugin requires both Node.js and Go:
 
 **Prerequisites:**
 - Node.js 22+ (matches `grafana/.nvmrc` and the `grafana-plugin` CI workflow; Yarn 4 requires ≥18.12)
-- Go 1.23+ (for backend plugin)
+- Go 1.25+ (matches `grafana/go.mod` and the `grafana-plugin` CI workflow's `go-version: '1.25'`)
 - `corepack enable` — activates the pinned Yarn version (run once per machine)
 - mage (for Go builds): `go install github.com/magefile/mage@latest`
+
+!!! note "`mage coverage` needs a `covdata` binary in GOROOT"
+    If your system Go is older than `grafana/go.mod`'s version, `GOTOOLCHAIN=auto`
+    downloads a matching toolchain automatically — but that auto-downloaded
+    toolchain ships a trimmed tool set (`asm cgo compile cover link preprofile
+    vet` only) and omits `covdata`, `pprof`, `trace`, and others. `go test
+    -coverpkg ./...` (which `mage coverage` runs) needs `covdata` to merge
+    coverage across packages, and unlike the interactive `go tool covdata`
+    command, its internal invocation does not fall back to building the tool
+    on demand — it fails with `go: no such tool "covdata"` even though every
+    individual test passes. Installing a Go SDK that already satisfies
+    `go.mod` (so no toolchain auto-download is needed) doesn't fully fix this
+    either, since even the official `go1.25.x` tarball omits a prebuilt
+    `covdata`. Build it once into your GOROOT:
+    ```bash
+    GOROOT=$(go env GOROOT)
+    cd "$GOROOT/src/cmd/covdata"
+    go build -o "$GOROOT/pkg/tool/$(go env GOOS)_$(go env GOARCH)/covdata" .
+    ```
 
 **Development workflow:**
 ```bash


### PR DESCRIPTION
## Summary

* Fix a stale prerequisite in the contributor guide: `CONTRIBUTING.md` / `mkdocs/docs/contributing.md` said "Go 1.23+" for the Grafana plugin, but `grafana/go.mod` and the `grafana-plugin` CI workflow both require Go 1.25.
* Document a real gotcha found while verifying a fresh local setup against CI: `mage coverage` (`go test -coverpkg ./...`) can fail with `go: no such tool "covdata"` even though every individual test passes, because Go's auto-downloaded toolchain (and even the official `go1.25.x` tarball) ships a trimmed tool set that omits a prebuilt `covdata` binary, and the internal invocation used for cross-package coverage merging doesn't fall back to building it on demand the way the interactive `go tool covdata` command does. The note includes the one-time fix (building `cmd/covdata` into `GOROOT`'s tool directory).
* Add a changelog entry under `## Unreleased`.

No code changes — this is a docs-only fix following a full local run of the CI scripts (`rust_ci.py`, `python_ci.py`, `grafana_ci.py`, `analytics_web_ci.py`) to verify the contributor guide's prerequisites are complete and accurate.

## Test plan

- [x] `cd mkdocs && python build-docs.py` — confirms the new `!!! note` admonition renders without errors
- [x] `python3 build/rust_ci.py`, `python3 build/python_ci.py`, `python3 build/grafana_ci.py`, `python3 build/analytics_web_ci.py` all pass locally
