### PR TITLE
Fix Dependabot alerts: bump dompurify to 3.4.13

### DIFF
--- a/doc/high-frequency-observability/package-lock.json
+++ b/doc/high-frequency-observability/package-lock.json
@@ -1640,9 +1640,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/doc/high-frequency-observability/package.json
+++ b/doc/high-frequency-observability/package.json
@@ -20,7 +20,7 @@
     "vite": "^7.1.3"
   },
   "overrides": {
-    "dompurify": "^3.4.12",
+    "dompurify": "^3.4.13",
     "esbuild": "0.28.1",
     "lodash-es": "^4.17.23",
     "postcss": "^8.5.18",

--- a/doc/intro-micromegas/package.json
+++ b/doc/intro-micromegas/package.json
@@ -23,7 +23,7 @@
     "vite": "^7.3.5"
   },
   "resolutions": {
-    "dompurify": "^3.4.12",
+    "dompurify": "^3.4.13",
     "esbuild": "0.28.1",
     "lodash-es": "^4.17.23",
     "postcss": "^8.5.18",

--- a/doc/intro-micromegas/yarn.lock
+++ b/doc/intro-micromegas/yarn.lock
@@ -1184,15 +1184,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.4.12":
-  version: 3.4.12
-  resolution: "dompurify@npm:3.4.12"
+"dompurify@npm:^3.4.13":
+  version: 3.4.13
+  resolution: "dompurify@npm:3.4.13"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
+  checksum: 10c0/9c2a1a71e1a1d8b77953db7a39ffc935ef4ed4f10fe40770232128c2cbfd4c3dc677d3d7bae51eb24cc52d9ff3548612dc540ecb4343e89b26e809d2be2e0cfe
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@remix-run/router": "^1.23.3",
     "brace-expansion": "^5.0.9",
     "diff": "^8.0.3",
-    "dompurify": "^3.4.12",
+    "dompurify": "^3.4.13",
     "eslint/ajv": "6.14.0",
     "fast-uri": "^3.1.5",
     "flatted": "^3.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5594,15 +5594,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.4.12":
-  version: 3.4.12
-  resolution: "dompurify@npm:3.4.12"
+"dompurify@npm:^3.4.13":
+  version: 3.4.13
+  resolution: "dompurify@npm:3.4.13"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
+  checksum: 10c0/9c2a1a71e1a1d8b77953db7a39ffc935ef4ed4f10fe40770232128c2cbfd4c3dc677d3d7bae51eb24cc52d9ff3548612dc540ecb4343e89b26e809d2be2e0cfe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

* Bump `dompurify` to `3.4.13` at the repo root and in `doc/intro-micromegas` and `doc/high-frequency-observability` to resolve Dependabot alerts #447-449 (GHSA-55q2-fjhq-7xh7, `IN_PLACE` hook removal leaves a detached subtree executable, causing XSS)

## Test plan

- [x] `npm install && npm run build` in `doc/high-frequency-observability`
- [x] `yarn install && yarn build` in `doc/intro-micromegas`
- [x] `yarn install` at repo root resolves cleanly (grafana/typescript workspaces)
