### PR TITLE
Docs: keep the OTLP idempotency note about the current state

### DIFF
--- a/mkdocs/docs/otlp/index.md
+++ b/mkdocs/docs/otlp/index.md
@@ -231,20 +231,17 @@ Block IDs are content-addressed: `block_id = uuid_v5(NS_OTEL_BLOCK_V1, payload_b
     produce byte-identical records for genuinely distinct events, which then collide on
     `block_id` and get discarded as duplicates: the producer gets no error and its event
     is simply dropped, indistinguishable from a harmless retry of the same event. As
-    described above, this is visible to operators today via the `block_object_duplicate`
-    metric and a server-side warning log — it isn't silent from that side. It was silent
-    when [issue #1462](https://github.com/madesroches/micromegas/issues/1462) hit,
-    though: at the time, the dedup-drop path only logged at `debug!` with no metric, so
-    the loss went unnoticed until traced back after the fact — 72 distinct EventBridge
-    events lost in a single measured 2-day window (the loss itself ran undetected for
-    about two months). Declaring
-    [`aws.event.id`](#event-identity-awseventid-awseventtime) breaks the collision by
-    making every record's bytes depend on the source event's own identity. Once
-    [issue #1466](https://github.com/madesroches/micromegas/issues/1466) — an open design
-    proposal for dedup on a producer-declared idempotency key, rather than a content hash
-    — lands, `aws.event.id` would be a concrete example of the kind of declared key it's
-    asking for; today it only avoids the collision, since dedup is still purely
-    content-hash based.
+    described above, this is visible to operators via the `block_object_duplicate` metric
+    and a server-side warning log — it isn't silent from that side. It was silent when
+    [issue #1462](https://github.com/madesroches/micromegas/issues/1462) hit, though: at
+    the time, the dedup-drop path only logged at `debug!` with no metric, so the loss went
+    unnoticed until traced back after the fact — 72 distinct EventBridge events lost in a
+    single measured 2-day window (the loss itself ran undetected for about two months).
+    Declaring [`aws.event.id`](#event-identity-awseventid-awseventtime) is the fix: it
+    makes every record's bytes depend on the source event's own identity, so distinct
+    events never collide while genuine retries still dedup exactly. Ingestion identity is
+    the content hash, and carrying per-occurrence identity in the payload is how a
+    producer gets idempotent ingestion out of it.
 
 ## Client recipes
 

--- a/mkdocs/docs/otlp/index.md
+++ b/mkdocs/docs/otlp/index.md
@@ -230,13 +230,10 @@ Block IDs are content-addressed: `block_id = uuid_v5(NS_OTEL_BLOCK_V1, payload_b
     no per-event identity in the projected fields and a constant/null message body — can
     produce byte-identical records for genuinely distinct events, which then collide on
     `block_id` and get discarded as duplicates: the producer gets no error and its event
-    is simply dropped, indistinguishable from a harmless retry of the same event. As
-    described above, this is visible to operators via the `block_object_duplicate` metric
-    and a server-side warning log — it isn't silent from that side. It was silent when
-    [issue #1462](https://github.com/madesroches/micromegas/issues/1462) hit, though: at
-    the time, the dedup-drop path only logged at `debug!` with no metric, so the loss went
-    unnoticed until traced back after the fact — 72 distinct EventBridge events lost in a
-    single measured 2-day window (the loss itself ran undetected for about two months).
+    is simply dropped, indistinguishable from a harmless retry of the same event. Such a
+    drop is visible server-side, via the `block_object_duplicate` metric and a warning
+    log as described above, but the producer has no way to detect it.
+
     Declaring [`aws.event.id`](#event-identity-awseventid-awseventtime) is the fix: it
     makes every record's bytes depend on the source event's own identity, so distinct
     events never collide while genuine retries still dedup exactly. Ingestion identity is


### PR DESCRIPTION
## Summary

The `## Idempotency` warning in `mkdocs/docs/otlp/index.md` had drifted into two things reference docs shouldn't be: a roadmap and a postmortem. It told the reader that `aws.event.id` "would be a concrete example of the kind of declared key" #1466 was asking for, "once" that issue landed — and then recounted the #1462 incident, complete with the `debug!`-only log path that no longer exists, the 72 events lost in a 2-day window, and the two months undetected.

Neither belongs in a page someone reads while configuring a producer.

The forward-looking half can't be acted on and goes stale on its own: the moment the proposal changes shape or gets declined the paragraph is wrong without anyone touching it, which is what happened — #1466 is now closed as not planned, since content-hash dedup plus a documented per-occurrence attribute *is* the design, not an interim state. Roadmap belongs in issues, where it stays accurate by construction.

The history half describes a version of the server that no longer exists. A reader doesn't need to know what the dedup path used to log to configure their transformer correctly, and past-tense detail about a fixed system invites the reader to wonder which parts still apply. What survives from that incident is the behavior it produced — the metric and warning log — which the section already documents in the present tense.

What's left states the current state only: content-hash dedup can drop genuinely distinct events when a producer's transformed payload doesn't vary per event; the drop is visible server-side via `block_object_duplicate` and a warning log, though the producer can't detect it; declaring `aws.event.id` fixes it by making each record's bytes depend on the source event's identity, so distinct events never collide and genuine retries still dedup exactly. It closes on the general rule — ingestion identity is the content hash, and carrying per-occurrence identity in the payload is how a producer gets idempotent ingestion out of it. No issue links either way.

Docs-only; `mkdocs/docs/otlp/index.md` is the only file touched, and no behavior, schema, or attribute name changes. No specific-issue links remain anywhere in the reference docs after this.

## Test plan

- [x] `python mkdocs/build-docs.py` — builds clean, no errors or warnings
- [x] The surviving intra-page link (`#event-identity-awseventid-awseventtime`) verified to resolve against the rendered heading id
- [x] Admonition indentation preserved across the new paragraph break, so the block still renders as one `!!! warning`
