### PR TITLE
Unreal: add external-profiler bridge and global-context console commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents the historical progress of the Micromegas project. For curre
 
 ## Unreleased
 
+* **Unreal:**
+  * Add external-profiler bridge (`MicromegasExternalProfiler`): when Unreal's external profiler is set to Micromegas, scoped profiler events are forwarded as named spans instead of going through the regular thread-span queue
+  * Add `telemetry.global_context_print` and `telemetry.global_context_set_property` console commands to inspect and modify the telemetry global context at runtime
+
 ## v0.29.0 - 2026-08-12
 
 * **Analytics:**

--- a/unreal/CLAUDE.md
+++ b/unreal/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md — unreal/
+
+This folder mirrors Unreal Engine source that normally lives in a private
+Perforce workspace: `MicromegasTracing` (from `Engine/Source/Runtime/Core`)
+and `MicromegasTelemetrySink` (from a game/plugin module). Perforce is the
+place these files are actually edited day-to-day; this git repo is the public
+mirror.
+
+## Perforce → git (pulling changes in)
+
+1. Set two env vars pointing at the local P4 workspace:
+   - `MICROMEGAS_UNREAL_ROOT_DIR` — root of the Unreal Engine source tree
+     (e.g. `F:\p4\UE`)
+   - `MICROMEGAS_UNREAL_TELEMETRY_MODULE_DIR` — directory containing the
+     `MicromegasTelemetrySink` module (may be inside a plugin folder)
+2. From the repo root, run:
+   ```
+   python3 build/copy_unreal_from_workspace.py
+   ```
+   This copies the three source directories from the P4 workspace into
+   `unreal/`, converting CRLF → LF for known text extensions. It refuses to
+   overwrite a destination that has untracked or locally modified files —
+   commit or stash those first.
+3. Review `git diff unreal/` before committing:
+   - Check for stray encoding artifacts (e.g. a UTF-8 BOM added by an editor)
+     on files that shouldn't have actually changed — strip these, they're
+     noise, not real edits.
+   - Scan for anything that shouldn't leave the internal Perforce tree:
+     internal project/codenames, absolute workspace paths, usernames,
+     internal URLs, credentials/tokens. None of that belongs in the public
+     repo — if you find any, edit it out (or ask before committing) rather
+     than publishing it.
+4. Commit only the real, reviewed changes.
+
+`build/unreal_hard_link_windows.py` is deprecated (it used junctions instead
+of copying) — don't use it.
+
+## git → Perforce (pushing changes back out)
+
+There's no script for this direction; it's manual:
+
+1. In the P4 workspace, check out for edit (or add) the corresponding files
+   under `$MICROMEGAS_UNREAL_ROOT_DIR/Engine/Source/Runtime/Core/{Public,Private}/MicromegasTracing`
+   and `$MICROMEGAS_UNREAL_TELEMETRY_MODULE_DIR/MicromegasTelemetrySink`.
+2. Copy the changed files from `unreal/` over them, matching Perforce's own
+   line-ending convention for that tree (don't fight the P4 typemap).
+3. Review the P4 diff, then submit with a changelist description that
+   references the git commit(s) being ported.
+
+## General
+
+- Both directories carry their own `README.md` noting they're mirrored from
+  https://github.com/madesroches/micromegas/ and require authorization
+  before contributing changes — leave those in place.
+- Treat this as a one-way-tooled, two-way-maintained mirror: automate
+  Perforce → git with the copy script, but review every sync for leaked
+  internal details before it's committed, since the source of truth lives
+  in a private, internal tree.

--- a/unreal/MicromegasTelemetrySink/Private/MicromegasTelemetrySinkModule.cpp
+++ b/unreal/MicromegasTelemetrySink/Private/MicromegasTelemetrySinkModule.cpp
@@ -3,9 +3,11 @@
 #include "Containers/Map.h"
 #include "HAL/IConsoleManager.h"
 #include "MicromegasTelemetrySink/HttpEventSink.h"
+#include "MicromegasTelemetrySink/Log.h"
 #include "MicromegasTelemetrySink/LogInterop.h"
 #include "MicromegasTelemetrySink/MetricPublisher.h"
 #include "MicromegasTelemetrySink/TelemetryAuthenticator.h"
+#include "MicromegasTracing/DefaultContext.h"
 #include "MicromegasTracing/Dispatch.h"
 #include "Misc/CoreDelegates.h"
 #include "SamplingController.h"
@@ -20,6 +22,65 @@
 #else
 	#define MICROMEGAS_CRASH_REPORTING 0
 #endif
+
+namespace {
+
+void TelemetryGlobalContextPrint()
+{
+	MicromegasTracing::DefaultContext* Ctx = MicromegasTracing::Dispatch::GetDefaultContext();
+	if (!Ctx)
+	{
+		UE_LOG(LogMicromegasTelemetrySink, Warning, TEXT("telemetry.global_context_print: no global context available"));
+		return;
+	}
+
+	TMap<FName, FName> Properties;
+	Ctx->Copy(Properties);
+	UE_LOG(LogMicromegasTelemetrySink, Display, TEXT("telemetry.global_context_print: %d entries"), Properties.Num());
+	for (const TPair<FName, FName>& Entry : Properties)
+	{
+		UE_LOG(LogMicromegasTelemetrySink, Display, TEXT("  %s=%s"), *Entry.Key.ToString(), *Entry.Value.ToString());
+	}
+}
+
+void TelemetryGlobalContextSetProperty(const TArray<FString>& InArgs)
+{
+	MicromegasTracing::DefaultContext* Ctx = MicromegasTracing::Dispatch::GetDefaultContext();
+	if (!Ctx)
+	{
+		UE_LOG(LogMicromegasTelemetrySink, Warning, TEXT("telemetry.global_context_set_property: no global context available"));
+		return;
+	}
+
+	if (InArgs.Num() > 1)
+	{
+		Ctx->Set(FName{ *InArgs[0] }, FName{ *InArgs[1] });
+		UE_LOG(LogMicromegasTelemetrySink, Display, TEXT("telemetry.global_context_set_property: %s=%s"), *InArgs[0], *InArgs[1]);
+	}
+	else if (InArgs.Num() > 0)
+	{
+		Ctx->Unset(FName{ *InArgs[0] });
+		UE_LOG(LogMicromegasTelemetrySink, Display, TEXT("telemetry.global_context_set_property: unset %s"), *InArgs[0]);
+	}
+	else
+	{
+		UE_LOG(LogMicromegasTelemetrySink, Warning, TEXT("telemetry.global_context_set_property: missing property name, usage: <name> [value]"));
+	}
+}
+
+FAutoConsoleCommand GCmdTelemetryGlobalContextPrint(
+	TEXT("telemetry.global_context_print"),
+	TEXT("Prints the telemetry global context key-value pairs"),
+	FConsoleCommandDelegate::CreateStatic(&TelemetryGlobalContextPrint)
+);
+
+FAutoConsoleCommand GCmdTelemetryGlobalContextSetProperty(
+	TEXT("telemetry.global_context_set_property"),
+	TEXT("Sets or unsets a property in the telemetry global context: telemetry.global_context_set_property <name> [value] (omit value to unset)"),
+	FConsoleCommandWithArgsDelegate::CreateStatic(&TelemetryGlobalContextSetProperty)
+);
+
+} // namespace
 
 //================================================================================
 class FMicromegasTelemetrySinkModule : public IMicromegasTelemetrySinkModule

--- a/unreal/MicromegasTracing/Private/Dispatch.cpp
+++ b/unreal/MicromegasTracing/Private/Dispatch.cpp
@@ -21,6 +21,8 @@
 
 namespace MicromegasTracing
 {
+	std::atomic<bool> Dispatch::bProfilerEnabled = false;
+
 	Dispatch* GDispatch = nullptr;
 
 	Dispatch::Dispatch(NewGuid InAllocNewGuid,
@@ -412,22 +414,50 @@ namespace MicromegasTracing
 
 	void Dispatch::BeginScope(const BeginThreadSpanEvent& Event)
 	{
-		QueueThreadEvent(Event);
+		if (!bProfilerEnabled.load(std::memory_order_relaxed))
+		{
+			QueueThreadEvent(Event);
+		}
 	}
 
 	void Dispatch::EndScope(const EndThreadSpanEvent& Event)
 	{
-		QueueThreadEvent(Event);
+		if (!bProfilerEnabled.load(std::memory_order_relaxed))
+		{
+			QueueThreadEvent(Event);
+		}
 	}
 
 	void Dispatch::BeginNamedSpan(const BeginThreadNamedSpanEvent& Event)
 	{
-		QueueThreadEvent(Event);
+		if (!bProfilerEnabled.load(std::memory_order_relaxed))
+		{
+			QueueThreadEvent(Event);
+		}
+	}
+
+	void Dispatch::BeginNamedSpan(const BeginThreadNamedSpanEvent& Event, FProfilerNamedSpanTag)
+	{
+		if (bProfilerEnabled.load(std::memory_order_relaxed))
+		{
+			QueueThreadEvent(Event);
+		}
 	}
 
 	void Dispatch::EndNamedSpan(const EndThreadNamedSpanEvent& Event)
 	{
-		QueueThreadEvent(Event);
+		if (!bProfilerEnabled.load(std::memory_order_relaxed))
+		{
+			QueueThreadEvent(Event);
+		}
+	}
+
+	void Dispatch::EndNamedSpan(const EndThreadNamedSpanEvent& Event, FProfilerNamedSpanTag)
+	{
+		if (bProfilerEnabled.load(std::memory_order_relaxed))
+		{
+			QueueThreadEvent(Event);
+		}
 	}
 
 	void Dispatch::ForEachThreadStream(ThreadStreamCallback Callback)

--- a/unreal/MicromegasTracing/Private/Profiler/MicromegasExternalProfiler.cpp
+++ b/unreal/MicromegasTracing/Private/Profiler/MicromegasExternalProfiler.cpp
@@ -1,0 +1,149 @@
+//
+//  MicromegasTracing/Profiler/MicromegasExternalProfiler.cpp
+//
+#include "CoreTypes.h"
+#include "ProfilingDebugging/ExternalProfiler.h"
+#include "Features/IModularFeatures.h"
+#include "Math/Color.h"
+#include "HAL/PlatformTime.h"
+#include "Logging/LogMacros.h"
+#include "Containers/Array.h"
+#include "Templates/UniquePtr.h"
+#include "UObject/NameTypes.h"
+#include "MicromegasTracing/Dispatch.h"
+#include "MicromegasTracing/Macros.h"
+#include "MicromegasTracing/SpanEvents.h"
+#include "MicromegasTracing/strings.h"
+
+#if UE_EXTERNAL_PROFILING_ENABLED
+
+DEFINE_LOG_CATEGORY_STATIC(LogMicromegasProfiler, Log, All);
+
+namespace MicromegasTracing {
+
+CORE_API extern const TCHAR MicromegasProfilerName[] = TEXT("Micromegas");
+
+/**
+* Micromegas implementation of FExternalProfiler
+*/
+class FMicromegasExternalProfiler : public FExternalProfiler
+{
+public:
+	FMicromegasExternalProfiler();
+	~FMicromegasExternalProfiler() override;
+
+	//~ Begin FExternalProfiler interface
+	const TCHAR* GetProfilerName() const final;
+	void FrameSync() final;
+	void ProfilerPauseFunction() final;
+	void ProfilerResumeFunction() final;
+	void Register() final;
+	void StartScopedEvent(const FColor& Color, const TCHAR* Text) final;
+	void StartScopedEvent(const FColor& Color, const ANSICHAR* Text) final;
+	void EndScopedEvent() final;
+	//~ End FExternalProfiler interface
+
+private:
+	using FProfilerNamedSpanTag = Dispatch::FProfilerNamedSpanTag;
+	void StartScopedEventImpl(const StaticStringRef& Name);
+	void EndScopedEventImpl();
+
+	static const SpanLocation MicromegasProfilerSpanLoc;
+
+	// Per-thread stack of active span names, used to pair each EndScopedEvent with its BeginScopedEvent
+	static thread_local TArray<StaticStringRef> ScopeStack;
+};
+
+const SpanLocation FMicromegasExternalProfiler::MicromegasProfilerSpanLoc("ExternalProfiler", __FILE__, __LINE__);
+thread_local TArray<StaticStringRef> FMicromegasExternalProfiler::ScopeStack;
+
+FMicromegasExternalProfiler::FMicromegasExternalProfiler()
+{
+	// Register as a modular feature
+	IModularFeatures::Get().RegisterModularFeature(FExternalProfiler::GetFeatureName(), this);
+}
+
+FMicromegasExternalProfiler::~FMicromegasExternalProfiler()
+{
+	IModularFeatures::Get().UnregisterModularFeature(FExternalProfiler::GetFeatureName(), this);
+}
+
+const TCHAR* FMicromegasExternalProfiler::GetProfilerName() const
+{
+	return MicromegasProfilerName;
+}
+
+void FMicromegasExternalProfiler::FrameSync()
+{
+}
+
+void FMicromegasExternalProfiler::ProfilerPauseFunction()
+{
+}
+
+void FMicromegasExternalProfiler::ProfilerResumeFunction()
+{
+}
+
+void FMicromegasExternalProfiler::Register()
+{
+	if (GDispatch == nullptr)
+	{
+		Dispatch::bProfilerEnabled.store(false, std::memory_order_relaxed);
+		UE_LOG(LogMicromegasProfiler, Warning,
+			TEXT("Micromegas external profiler selected but telemetry is not initialized; scoped events will be dropped."));
+	}
+	else
+	{
+		Dispatch::bProfilerEnabled.store(true, std::memory_order_relaxed);
+	}
+}
+
+void FMicromegasExternalProfiler::StartScopedEvent(const FColor& /*Color*/, const TCHAR* Text)
+{
+	StartScopedEventImpl(StaticStringRef(FName(Text)));
+}
+
+void FMicromegasExternalProfiler::StartScopedEvent(const FColor& /*Color*/, const ANSICHAR* Text)
+{
+	StartScopedEventImpl(StaticStringRef(FName(Text)));
+}
+
+FORCEINLINE void FMicromegasExternalProfiler::StartScopedEventImpl(const StaticStringRef& Name)
+{
+	ScopeStack.Push(Name);
+	Dispatch::BeginNamedSpan(
+		BeginThreadNamedSpanEvent(&MicromegasProfilerSpanLoc, FPlatformTime::Cycles64(), Name), FProfilerNamedSpanTag{});
+}
+
+FORCEINLINE void FMicromegasExternalProfiler::EndScopedEvent()
+{
+	EndScopedEventImpl();
+}
+
+void FMicromegasExternalProfiler::EndScopedEventImpl()
+{
+	if (ScopeStack.Num() > 0)
+	{
+		const StaticStringRef Name = ScopeStack.Pop(EAllowShrinking::No);
+		Dispatch::EndNamedSpan(
+			EndThreadNamedSpanEvent(&MicromegasProfilerSpanLoc, FPlatformTime::Cycles64(), Name), FProfilerNamedSpanTag{});
+	}
+}
+
+namespace MicromegasProfilerPrivate {
+
+struct FAtModuleInit
+{
+	FAtModuleInit()
+	{
+		static TUniquePtr<FMicromegasExternalProfiler> Profiler = MakeUnique<FMicromegasExternalProfiler>();
+	}
+};
+
+static FAtModuleInit AtModuleInit;
+
+} // namespace MicromegasProfilerPrivate
+} // namespace MicromegasTracing
+
+#endif // UE_EXTERNAL_PROFILING_ENABLED

--- a/unreal/MicromegasTracing/Public/MicromegasTracing/Dispatch.h
+++ b/unreal/MicromegasTracing/Public/MicromegasTracing/Dispatch.h
@@ -88,6 +88,15 @@ namespace MicromegasTracing
 		static ProcessInfoConstPtr GetCurrentProcessInfo();
 
 	private:
+		//~ Begin FMicromegasExternalProfiler
+		friend class FMicromegasExternalProfiler;
+		static std::atomic<bool> bProfilerEnabled;
+
+		struct FProfilerNamedSpanTag {};
+		static void BeginNamedSpan(const BeginThreadNamedSpanEvent& Event, FProfilerNamedSpanTag);
+		static void EndNamedSpan(const EndThreadNamedSpanEvent& Event, FProfilerNamedSpanTag);
+		//~ End FMicromegasExternalProfiler
+
 		Dispatch(NewGuid AllocNewGuid,
 			const ProcessInfoPtr& ProcessInfo,
 			const TSharedPtr<EventSink, ESPMode::ThreadSafe>& Sink,


### PR DESCRIPTION
## Summary
* Add an external-profiler bridge (`MicromegasExternalProfiler`) that, when Unreal's external profiler is set to Micromegas, forwards scoped profiler events as named spans instead of routing them through the regular thread-span queue
* Add `telemetry.global_context_print` and `telemetry.global_context_set_property` console commands to inspect and modify the telemetry global context at runtime
* Add `unreal/CLAUDE.md` documenting the Perforce-to-git sync process for this mirrored source tree

## Test plan
- [ ] In an Unreal project with this plugin, select "Micromegas" as the external profiler and confirm scoped profiler events show up as named spans in the telemetry backend
- [ ] Run `telemetry.global_context_print` and confirm it prints the current global context entries
- [ ] Run `telemetry.global_context_set_property <name> <value>` and re-run `telemetry.global_context_print` to confirm the property was set; omit the value to confirm it unsets the property