### PR TITLE
Redis exporter - additional fixes

### DIFF
--- a/mkdocs/docs/admin/redis-exporter.md
+++ b/mkdocs/docs/admin/redis-exporter.md
@@ -26,6 +26,15 @@ Presets are cumulative; select with `--metrics` / `MICROMEGAS_REDIS_EXPORTER_MET
 | `extended` | core + `SLOWLOG LEN` (`redis_slowlog_length`) |
 | `full` (default) | extended + per-command stats (`redis_command_*` tagged `command=`) + `LATENCY LATEST` (`redis_latency_*` tagged `event=`) |
 
+At the default settings (`full`, 1s interval), a busy server with many
+distinct commands and latency events can emit several hundred measures per
+second per exporter — roughly 50M rows/day. Drop to `extended`/`core` or
+widen `--sample-interval-seconds` to trade detail for volume. On managed
+Redis offerings that restrict `SLOWLOG`/`LATENCY` via ACLs, `extended`
+and/or `full` will report `redis_up=0` on every tick (the exporter fails
+the whole sample if a required command is denied) — drop to `core`, or to
+`extended` if only `LATENCY` is restricted, on such deployments.
+
 Every metric carries an `instance` property (from `--target-name`, default
 `host:port`) plus any user-supplied properties, so several exporters can share
 one stack:

--- a/rust/redis-exporter/src/cli.rs
+++ b/rust/redis-exporter/src/cli.rs
@@ -127,9 +127,18 @@ pub fn derive_target_name(info: &ConnectionInfo) -> String {
     }
 }
 
-/// Parses `key=value` pairs; `instance` is reserved for the target name.
+/// Property keys reserved for tags the exporter attaches itself; `property_get`
+/// is case-insensitive in SQL, so the check below is too.
+const RESERVED_PROPERTY_KEYS: &[&str] = &["instance", "command", "db", "event"];
+
+/// Parses `key=value` pairs; reserved keys (see [`RESERVED_PROPERTY_KEYS`])
+/// are rejected case-insensitively to avoid colliding with tags the exporter
+/// attaches itself. Empty entries are dropped first: clap's `value_delimiter`
+/// turns an empty `MICROMEGAS_REDIS_EXPORTER_PROPERTIES=""` env var into one
+/// empty item, which k8s templates commonly produce for an unset optional var.
 pub fn parse_properties(raw: &[String]) -> Result<Vec<(String, String)>> {
     raw.iter()
+        .filter(|entry| !entry.is_empty())
         .map(|entry| {
             let (key, value) = entry
                 .split_once('=')
@@ -137,8 +146,14 @@ pub fn parse_properties(raw: &[String]) -> Result<Vec<(String, String)>> {
             if key.is_empty() {
                 bail!("invalid --property {entry:?}: empty key");
             }
-            if key == "instance" {
-                bail!("property key 'instance' is reserved (use --target-name)");
+            if RESERVED_PROPERTY_KEYS
+                .iter()
+                .any(|reserved| key.eq_ignore_ascii_case(reserved))
+            {
+                bail!(
+                    "property key {key:?} is reserved (reserved keys: {})",
+                    RESERVED_PROPERTY_KEYS.join(", ")
+                );
             }
             Ok((key.to_string(), value.to_string()))
         })

--- a/rust/redis-exporter/src/main.rs
+++ b/rust/redis-exporter/src/main.rs
@@ -21,7 +21,7 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -51,6 +51,26 @@ async fn main() -> Result<()> {
     let props = build_base_properties(&config.target_name, &config.properties);
     let mut shutdown = Box::pin(wait_for_shutdown());
 
+    // Constraint: redis-rs's ConnectionManager must never block a tick for
+    // longer than this. Without it, connecting to a blackholed address hangs
+    // for the OS TCP connect timeout (~1-2 min) and a query on a half-open
+    // connection can stall for TCP retransmission timescales — during which
+    // no redis_up=0 would be emitted, breaking the "unreachable -> redis_up=0
+    // every tick" contract. A few seconds is generous for a healthy LAN/DC
+    // link and short enough to keep the per-tick contract; it applies to
+    // both the initial connect and every query made through the manager.
+    //
+    // `number_of_retries` is set to 0 (default is 6, with exponential
+    // backoff) so a failed connect returns after a single bounded attempt
+    // instead of retrying internally for tens of seconds: our own loop
+    // already provides the "retry every tick" behavior, one bounded attempt
+    // per tick at a time.
+    let redis_io_timeout = Duration::from_secs(5);
+    let manager_config = redis::aio::ConnectionManagerConfig::new()
+        .set_connection_timeout(Some(redis_io_timeout))
+        .set_response_timeout(Some(redis_io_timeout))
+        .set_number_of_retries(0);
+
     // Persistent connection: one ConnectionManager for the process
     // lifetime, reconnecting on its own after drops. Creation needs an
     // initial connection, so retry here — the exporter must start (and
@@ -69,7 +89,7 @@ async fn main() -> Result<()> {
         }
         if conn.is_none() {
             tokio::select! {
-                result = redis::aio::ConnectionManager::new(client.clone()) => {
+                result = redis::aio::ConnectionManager::new_with_config(client.clone(), manager_config.clone()) => {
                     match result {
                         Ok(manager) => {
                             info!("connected to redis at {}", config.target_name);
@@ -99,12 +119,6 @@ async fn main() -> Result<()> {
                 match result {
                     Ok(()) => {
                         imetric!("redis_up", "count", props, 1u64);
-                        fmetric!(
-                            "redis_scrape_duration_ms",
-                            "ms",
-                            props,
-                            start.elapsed().as_secs_f64() * 1000.0
-                        );
                     }
                     Err(e) => {
                         // The ConnectionManager reconnects on its own; keep it.
@@ -112,6 +126,12 @@ async fn main() -> Result<()> {
                         imetric!("redis_up", "count", props, 0u64);
                     }
                 }
+                fmetric!(
+                    "redis_scrape_duration_ms",
+                    "ms",
+                    props,
+                    start.elapsed().as_secs_f64() * 1000.0
+                );
             }
             _ = &mut shutdown => {
                 info!("shutdown signal received, exiting");

--- a/rust/redis-exporter/src/main.rs
+++ b/rust/redis-exporter/src/main.rs
@@ -121,9 +121,17 @@ async fn main() -> Result<()> {
                         imetric!("redis_up", "count", props, 1u64);
                     }
                     Err(e) => {
-                        // The ConnectionManager reconnects on its own; keep it.
+                        // Don't rely on the ConnectionManager's own background
+                        // reconnect: with number_of_retries(0) it has been
+                        // observed to wedge permanently after a mid-run
+                        // outage (its internal shared-future swap never
+                        // recovers, and no further errors or connects are
+                        // ever attempted again). Drop it and let the top of
+                        // the loop rebuild a fresh manager next tick through
+                        // our own bounded connect path instead.
                         warn!("redis sample failed: {e:#}");
                         imetric!("redis_up", "count", props, 0u64);
+                        conn = None;
                     }
                 }
                 fmetric!(

--- a/rust/redis-exporter/src/sampler.rs
+++ b/rust/redis-exporter/src/sampler.rs
@@ -148,6 +148,9 @@ pub fn emit_info_metrics(info: &ParsedInfo, props: &'static PropertySet, now_uni
         imetric!("redis_rdb_changes_since_last_save", "count", props, v);
     }
     if let Some(t) = info.get_u64("rdb_last_save_time") {
+        // Mixes the server's clock (rdb_last_save_time) with the exporter's
+        // clock (now_unix_secs): clock skew between the two distorts this
+        // age; saturating_sub only guards against underflow, not skew.
         imetric!(
             "redis_rdb_last_save_age_seconds",
             "seconds",

--- a/rust/redis-exporter/tests/cli_tests.rs
+++ b/rust/redis-exporter/tests/cli_tests.rs
@@ -70,6 +70,39 @@ fn instance_property_is_reserved() {
 }
 
 #[test]
+fn reserved_properties_are_rejected_case_insensitively() {
+    for entry in ["Instance=x", "COMMAND=x", "Db=0", "eVeNt=x"] {
+        parse_properties(&[entry.into()]).expect_err(&format!("{entry} must be reserved"));
+    }
+}
+
+#[test]
+fn command_db_event_properties_are_reserved() {
+    for key in ["command", "db", "event"] {
+        let entry = format!("{key}=x");
+        let err = parse_properties(&[entry]).expect_err(&format!("{key} must be reserved"));
+        assert!(err.to_string().contains(key), "got: {err}");
+    }
+}
+
+#[test]
+fn empty_property_entries_are_ignored() {
+    let pairs = parse_properties(&["".into()]).expect("empty entry must be dropped, not an error");
+    assert!(pairs.is_empty());
+}
+
+#[test]
+fn empty_properties_env_value_does_not_fail_cli_parse() {
+    // clap's value_delimiter turns an empty env value into one empty item;
+    // this must not fail startup (k8s templates render unset optional vars
+    // as empty strings).
+    let cli = Cli::try_parse_from(["micromegas-redis-exporter", "--property", ""])
+        .expect("parsing empty --property value");
+    let config = cli.into_config(None).expect("building config");
+    assert!(config.properties.is_empty());
+}
+
+#[test]
 fn password_override_applies() {
     let cli = Cli::try_parse_from(["micromegas-redis-exporter"]).expect("parsing empty args");
     let config = cli


### PR DESCRIPTION
## Summary

Three follow-up fixes to the Redis exporter, found by exercising outage scenarios against a real Redis instance:

- **Bounded connect/response timeouts.** `ConnectionManager` had no timeout, so a blackholed address hung for OS-level TCP timescales (~1-2 min) before a tick could report `redis_up=0`. Sets a 5s connect/response timeout and disables the manager's internal retries (`number_of_retries(0)`) so our own per-tick loop handles retries instead.
- **Rebuild the connection manager on sample failure.** With retries disabled, the manager's internal reconnect was observed to wedge permanently after a mid-run outage — verified by stopping/starting a real Redis container: the exporter stopped producing any output even after Redis came back and was answering `PING`. Now any sample failure drops the manager so the next tick reconnects through our own bounded path.
- **Reserve more property keys, ignore empty entries.** `command`, `db`, and `event` are now reserved alongside `instance` (case-insensitively, matching `property_get`'s SQL semantics), preventing collisions with tags the exporter attaches itself. Empty `--property` entries are dropped instead of erroring, since clap's `value_delimiter` turns an unset `MICROMEGAS_REDIS_EXPORTER_PROPERTIES=""` (common from k8s templates) into one empty item.

Also fixes `redis_scrape_duration_ms` to be emitted on both the `Ok` and `Err` arms (previously only on success), and documents two operational caveats: expected metric volume at `full`/1s (~50M rows/day on a busy server) and ACL-restricted managed Redis offerings causing `extended`/`full` to report `redis_up=0` if `SLOWLOG`/`LATENCY` are denied.

## Test plan

- [x] `cli_tests.rs`: case-insensitive reserved-key rejection, `command`/`db`/`event` reserved, empty `--property` entries dropped, empty env value doesn't fail startup
- [x] Manually verified against a blackholed address (bounded `redis_up=0` instead of a multi-minute hang) and a stop/start Redis container cycle (recovers instead of wedging)
