### PR TITLE
Bump rust.yml build timeouts from 30m to 2h

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
   native:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner }}
-    timeout-minutes: 30
+    timeout-minutes: 120
     env:
       # On dev-worker: empty string → unset by shell guard → cargo uses all CPUs.
       # On GitHub-hosted: '2' to avoid OOM during linking on 2-core runners.
@@ -85,7 +85,7 @@ jobs:
   wasm:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner }}
-    timeout-minutes: 30
+    timeout-minutes: 120
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
## Summary
- Increase `timeout-minutes` for the `native` and `wasm` jobs in `rust.yml` from 30 to 120

## Test plan
- CI runs on this branch