### PR TITLE
Require and pre-fill audience in the ingestion key mint dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file documents the historical progress of the Micromegas project. For curre
 
 ## Unreleased
 
+* **Web App:**
+  * Require and pre-fill the audience field in the ingestion API key mint dialog: it now defaults to `public` instead of hinting that a blank value falls back to a server-side `MICROMEGAS_DEFAULT_KEY_AUDIENCE` default, and the Mint button is gated on a non-blank value.
 * **Analytics:**
   * Merges (`QueryMerger`, the path every non-ordering-declaring view uses -- `measures`,
     `log_entries`, `async_events`, `images`, `net_spans`, `otel_spans`, `export_log`, `blocks`'

--- a/analytics-web-app/src/components/ApiKeysAdminPage.tsx
+++ b/analytics-web-app/src/components/ApiKeysAdminPage.tsx
@@ -102,7 +102,7 @@ export function ApiKeysAdminPage({ config }: { config: ApiKeysAdminPageConfig })
 
   const openMintForm = () => {
     setMintName('')
-    setMintAudience('')
+    setMintAudience(config.showAudience ? 'public' : '')
     setMintError(null)
     setShowMintForm(true)
   }
@@ -253,7 +253,8 @@ export function ApiKeysAdminPage({ config }: { config: ApiKeysAdminPageConfig })
                         onChange={(e) => setMintAudience(e.target.value)}
                       />
                       <p className="mt-1 text-xs text-theme-text-muted">
-                        Leave blank to use MICROMEGAS_DEFAULT_KEY_AUDIENCE.
+                        The write audience this key is scoped to. "public" is readable by every
+                        authenticated principal; use a named audience to restrict it.
                       </p>
                     </div>
                   )}
@@ -262,7 +263,14 @@ export function ApiKeysAdminPage({ config }: { config: ApiKeysAdminPageConfig })
                   <Button variant="outline" onClick={() => setShowMintForm(false)} disabled={isMinting}>
                     Cancel
                   </Button>
-                  <Button onClick={handleMint} disabled={isMinting || !mintName.trim()}>
+                  <Button
+                    onClick={handleMint}
+                    disabled={
+                      isMinting ||
+                      !mintName.trim() ||
+                      (config.showAudience && !mintAudience.trim())
+                    }
+                  >
                     {isMinting ? (
                       <span className="flex items-center gap-2">
                         <span className="w-4 h-4 animate-spin rounded-full border-2 border-current border-t-transparent" />

--- a/analytics-web-app/src/components/__tests__/ApiKeysAdminPage.test.tsx
+++ b/analytics-web-app/src/components/__tests__/ApiKeysAdminPage.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Covers the mint-dialog validation added for ingestion-key audiences
+ * (#1372 follow-up): `openMintForm` pre-filling `mintAudience` with
+ * "public" only when `config.showAudience` is set, and the Mint button's
+ * `disabled` expression gating on a blank/whitespace audience in that case.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { ApiKeysAdminPage, ApiKeysAdminPageConfig } from '../ApiKeysAdminPage'
+
+// Force useAuth to report an admin user so AuthGuard renders the page.
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({
+    status: 'authenticated',
+    user: { sub: 'admin', is_admin: true },
+    error: null,
+  }),
+}))
+
+vi.mock('@/components/layout', () => ({
+  PageLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+class TestApiKeyError extends Error {}
+
+function makeConfig(overrides: Partial<ApiKeysAdminPageConfig>): ApiKeysAdminPageConfig {
+  return {
+    title: 'Test Keys',
+    subtitle: 'subtitle',
+    mintDialogTitle: 'Mint Test Key',
+    namePlaceholder: 'e.g. test-client',
+    emptyStateText: 'No test keys yet.',
+    loadErrorMessage: 'Failed to load test keys',
+    revokeConfirmMessage: (name) => `Revoke "${name}"?`,
+    maxListLimit: 20,
+    ErrorClass: TestApiKeyError,
+    listKeys: vi.fn().mockResolvedValue([]),
+    mintKey: vi.fn(),
+    revokeKey: vi.fn(),
+    ...overrides,
+  }
+}
+
+function renderPage(config: ApiKeysAdminPageConfig) {
+  return render(
+    <MemoryRouter>
+      <ApiKeysAdminPage config={config} />
+    </MemoryRouter>
+  )
+}
+
+async function openMintDialog(config: ApiKeysAdminPageConfig) {
+  await waitFor(() => expect(screen.getByText(config.emptyStateText)).toBeInTheDocument())
+  fireEvent.click(screen.getAllByRole('button', { name: /Mint Key/i })[0])
+  return screen.findByRole('button', { name: 'Mint' })
+}
+
+describe('ApiKeysAdminPage mint dialog', () => {
+  it('pre-fills audience with "public" and keeps Mint disabled until name and audience are both set (showAudience: true)', async () => {
+    const config = makeConfig({ showAudience: true })
+    renderPage(config)
+
+    const mintButton = await openMintDialog(config)
+
+    const audienceInput = screen.getByPlaceholderText('team-alpha')
+    expect(audienceInput).toHaveValue('public')
+
+    // Name still blank -> disabled regardless of the pre-filled audience.
+    expect(mintButton).toBeDisabled()
+
+    const nameInput = screen.getByPlaceholderText(config.namePlaceholder)
+    fireEvent.change(nameInput, { target: { value: 'new-key' } })
+    // Name set, audience pre-filled with "public" -> enabled.
+    expect(mintButton).not.toBeDisabled()
+
+    fireEvent.change(audienceInput, { target: { value: '' } })
+    expect(mintButton).toBeDisabled()
+
+    fireEvent.change(audienceInput, { target: { value: '   ' } })
+    expect(mintButton).toBeDisabled()
+
+    fireEvent.change(audienceInput, { target: { value: 'team-alpha' } })
+    expect(mintButton).not.toBeDisabled()
+  })
+
+  it('has no audience field and enables Mint from just a name (showAudience: false)', async () => {
+    const config = makeConfig({ showAudience: false })
+    renderPage(config)
+
+    const mintButton = await openMintDialog(config)
+
+    expect(screen.queryByPlaceholderText('team-alpha')).not.toBeInTheDocument()
+    expect(screen.queryByText('Audience', { selector: 'label' })).not.toBeInTheDocument()
+
+    expect(mintButton).toBeDisabled()
+
+    const nameInput = screen.getByPlaceholderText(config.namePlaceholder)
+    fireEvent.change(nameInput, { target: { value: 'new-key' } })
+    expect(mintButton).not.toBeDisabled()
+  })
+})

--- a/analytics-web-app/src/lib/api-keys-shared.ts
+++ b/analytics-web-app/src/lib/api-keys-shared.ts
@@ -102,9 +102,9 @@ export function createApiKeysApi<
     const response = await authenticatedFetch(`${getApiBase()}${config.basePath}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      // `audience` is sent only when set: `JSON.stringify` drops an `undefined` value
-      // entirely, so an unset audience omits the field rather than sending `null` --
-      // the server then applies its own default (`MICROMEGAS_DEFAULT_KEY_AUDIENCE`).
+      // `audience` is only ever unset for callers that don't ask for one (analytics
+      // keys never carry an audience). `JSON.stringify` drops an `undefined` value
+      // entirely, so that case omits the field rather than sending `null`.
       body: JSON.stringify({ name, audience }),
     })
     return handleResponse<MintApiKeyResponse>(response)

--- a/analytics-web-app/src/routes/__tests__/IngestionApiKeysPage.test.tsx
+++ b/analytics-web-app/src/routes/__tests__/IngestionApiKeysPage.test.tsx
@@ -192,6 +192,7 @@ describe('IngestionApiKeysPage', () => {
             name: 'new-key',
             created_at: '2026-01-01T00:00:00Z',
             key: 'mmk_test_cleartext',
+            audience: 'public',
           }),
       } as unknown as Response)
       .mockResolvedValueOnce({
@@ -206,6 +207,7 @@ describe('IngestionApiKeysPage', () => {
               last_used_at: null,
               revoked_at: null,
               revoked_by: null,
+              audience: 'public',
             },
           ]),
       } as unknown as Response)
@@ -230,7 +232,7 @@ describe('IngestionApiKeysPage', () => {
       const postCall = fetchMock.mock.calls.find((c) => c[1]?.method === 'POST')
       expect(postCall).toBeDefined()
       expect(postCall![0]).toBe('/mmlocal/api/ingestion-api-keys')
-      expect(JSON.parse(postCall![1].body)).toEqual({ name: 'new-key' })
+      expect(JSON.parse(postCall![1].body)).toEqual({ name: 'new-key', audience: 'public' })
     })
 
     await waitFor(() => expect(screen.getByText('mmk_test_cleartext')).toBeInTheDocument())


### PR DESCRIPTION
## Summary

* The ingestion API key mint dialog now pre-fills the audience field with `public` and requires a non-empty value, instead of hinting that it can be left blank to fall back to a server-side `MICROMEGAS_DEFAULT_KEY_AUDIENCE` default.
* Adds component tests covering the mint dialog's audience validation (pre-fill, Mint button gating) and fixes a stale expected mint-request body in an existing test.

## Test plan

- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm run test`
