### PR TITLE
Make the API-key admin page size injectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file documents the historical progress of the Micromegas project. For curre
 ## Unreleased
 
 * **Web App:**
+  * Make the Analytics/Ingestion API Keys admin page's row-per-page count an injectable `pageSize` prop, defaulting to the server's max list limit.
   * Require and pre-fill the audience field in the ingestion API key mint dialog: it now defaults to `public` instead of hinting that a blank value falls back to a server-side default audience, and the Mint button is gated on a non-blank value.
   * Hide the per-cell **Query Time Range** field, and ignore any saved override, for a notebook cell whose data source resolves to `notebook` (local WASM execution) — a WASM-registered table has no designated time column to bound a `begin`/`end` against, so the screen's global range now applies there unconditionally, at execution, at render, and in macro substitution. This is a behaviour change for any cell already carrying a saved override under that data source: it silently reverts to the screen's global range instead of the override the next time the screen loads. The same field is now also offered on horizontal-group children whose query runs server-side, hidden there under the identical rule (#1513).
 * **Analytics:**

--- a/analytics-web-app/src/components/ApiKeysAdminPage.tsx
+++ b/analytics-web-app/src/components/ApiKeysAdminPage.tsx
@@ -1,8 +1,9 @@
 // Shared content for the analytics/ingestion API-key admin pages
 // (`AnalyticsApiKeysPage.tsx` and `IngestionApiKeysPage.tsx`). Both pages are
 // identical in markup and behavior apart from copy (title/subtitle/
-// placeholder/revoke-confirm wording), the max page-size constant, and which
-// API-client functions/error class they call — all supplied via `config`.
+// placeholder/revoke-confirm wording) and which API-client functions/error
+// class they call — all supplied via `config` — plus the `pageSize` prop each
+// page defaults to its own server max limit.
 // Each page keeps its own outer `<Suspense fallback={<AuthGuard>...}>`
 // wrapper (see `AnalyticsApiKeysPage.tsx`); this component owns the
 // `<AuthGuard><PageLayout>` wrapping for the loaded content itself, since
@@ -41,9 +42,8 @@ export interface ApiKeysAdminPageConfig {
   loadErrorMessage: string
   /** `revokeConfirmMessage(name)` — the target key's name may be undefined while the dialog is closing. */
   revokeConfirmMessage: (name: string | undefined) => string
-  maxListLimit: number
   ErrorClass: ApiKeyErrorConstructor
-  listKeys: (includeRevoked: boolean, offset: number) => Promise<ApiKeyListEntry[]>
+  listKeys: (includeRevoked: boolean, offset: number, limit: number) => Promise<ApiKeyListEntry[]>
   mintKey: (name: string, audience?: string) => Promise<MintApiKeyResponse>
   revokeKey: (keyId: string) => Promise<unknown>
   /**
@@ -54,7 +54,22 @@ export interface ApiKeysAdminPageConfig {
   showAudience?: boolean
 }
 
-export function ApiKeysAdminPage({ config }: { config: ApiKeysAdminPageConfig }) {
+export interface ApiKeysAdminPageProps {
+  config: ApiKeysAdminPageConfig
+  /**
+   * Rows per page: the `limit` sent on every list call, the step the
+   * Previous/Next buttons move `offset` by, and the row count a full page is
+   * recognized by. One value for all three — a list call that asked for a
+   * different limit than the paging UI compares against would show a Next
+   * button onto a page that doesn't exist (or hide one that does).
+   *
+   * Each page defaults it to the server's max limit; it's a prop so callers
+   * (tests included) can page at a size that doesn't mean rendering 500 rows.
+   */
+  pageSize: number
+}
+
+export function ApiKeysAdminPage({ config, pageSize }: ApiKeysAdminPageProps) {
   usePageTitle(config.title)
 
   const [keys, setKeys] = useState<ApiKeyListEntry[]>([])
@@ -76,21 +91,21 @@ export function ApiKeysAdminPage({ config }: { config: ApiKeysAdminPageConfig })
     setIsLoading(true)
     setError(null)
     try {
-      const data = await config.listKeys(true, offset)
+      const data = await config.listKeys(true, offset, pageSize)
       setKeys(data)
     } catch (err) {
       setError(err instanceof config.ErrorClass ? err.message : config.loadErrorMessage)
     } finally {
       setIsLoading(false)
     }
-  }, [offset, config])
+  }, [offset, pageSize, config])
 
   const goToPreviousPage = () => {
-    setOffset((current) => Math.max(0, current - config.maxListLimit))
+    setOffset((current) => Math.max(0, current - pageSize))
   }
 
   const goToNextPage = () => {
-    setOffset((current) => current + config.maxListLimit)
+    setOffset((current) => current + pageSize)
   }
 
   useEffect(() => {
@@ -357,7 +372,7 @@ export function ApiKeysAdminPage({ config }: { config: ApiKeysAdminPageConfig })
                   ))}
                 </tbody>
               </table>
-              {(offset > 0 || keys.length === config.maxListLimit) && (
+              {(offset > 0 || keys.length === pageSize) && (
                 <div className="flex items-center justify-between border-t border-theme-border bg-app-panel px-4 py-2.5">
                   {offset > 0 ? (
                     <Button variant="outline" size="sm" onClick={goToPreviousPage}>
@@ -366,7 +381,7 @@ export function ApiKeysAdminPage({ config }: { config: ApiKeysAdminPageConfig })
                   ) : (
                     <span />
                   )}
-                  {keys.length === config.maxListLimit ? (
+                  {keys.length === pageSize ? (
                     <Button variant="outline" size="sm" onClick={goToNextPage}>
                       Next
                     </Button>

--- a/analytics-web-app/src/components/__tests__/ApiKeysAdminPage.test.tsx
+++ b/analytics-web-app/src/components/__tests__/ApiKeysAdminPage.test.tsx
@@ -32,7 +32,6 @@ function makeConfig(overrides: Partial<ApiKeysAdminPageConfig>): ApiKeysAdminPag
     emptyStateText: 'No test keys yet.',
     loadErrorMessage: 'Failed to load test keys',
     revokeConfirmMessage: (name) => `Revoke "${name}"?`,
-    maxListLimit: 20,
     ErrorClass: TestApiKeyError,
     listKeys: vi.fn().mockResolvedValue([]),
     mintKey: vi.fn(),
@@ -44,7 +43,7 @@ function makeConfig(overrides: Partial<ApiKeysAdminPageConfig>): ApiKeysAdminPag
 function renderPage(config: ApiKeysAdminPageConfig) {
   return render(
     <MemoryRouter>
-      <ApiKeysAdminPage config={config} />
+      <ApiKeysAdminPage config={config} pageSize={20} />
     </MemoryRouter>
   )
 }

--- a/analytics-web-app/src/lib/__tests__/analytics-api-keys-api.test.ts
+++ b/analytics-web-app/src/lib/__tests__/analytics-api-keys-api.test.ts
@@ -1,9 +1,10 @@
 /**
- * `listAnalyticsApiKeys` must explicitly request the server's max limit
- * (500) rather than omitting `limit` (which falls back to the server's
- * lower `DEFAULT_LIMIT` of 100) — omitting it silently truncates the list on
- * any deployment with more than 100 lifetime keys, with no indication
- * anything is missing. It must also thread `offset` through so the page can
+ * `listAnalyticsApiKeys` must send the caller's `limit` explicitly rather than
+ * omitting it (which falls back to the server's lower `DEFAULT_LIMIT` of
+ * 100) — omitting it silently truncates the list on any deployment with more
+ * than 100 lifetime keys, with no indication anything is missing. The page
+ * passes `MAX_ANALYTICS_API_KEYS_LIST_LIMIT` (the server's max), so that's what
+ * goes on the wire. `offset` must be threaded through too, so the page can
  * page past the first 500 lifetime keys.
  */
 import { listAnalyticsApiKeys, MAX_ANALYTICS_API_KEYS_LIST_LIMIT } from '../analytics-api-keys-api'
@@ -13,19 +14,20 @@ describe('analytics-api-keys-api', () => {
     vi.restoreAllMocks()
   })
 
-  it('listAnalyticsApiKeys requests the server max limit and offset 0 by default', async () => {
+  it('listAnalyticsApiKeys sends the given limit and offset 0 on the first page', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve([]),
     } as unknown as Response)
     global.fetch = fetchMock as unknown as typeof fetch
 
-    await listAnalyticsApiKeys()
+    await listAnalyticsApiKeys(true, 0, MAX_ANALYTICS_API_KEYS_LIST_LIMIT)
 
     const [url] = fetchMock.mock.calls[0]
     expect(url).toBe(
       `/api/analytics-api-keys?limit=${MAX_ANALYTICS_API_KEYS_LIST_LIMIT}&offset=0&include_revoked=true`
     )
+    // The page's default page size is the server's own `MAX_LIMIT`.
     expect(MAX_ANALYTICS_API_KEYS_LIST_LIMIT).toBe(500)
   })
 
@@ -36,7 +38,7 @@ describe('analytics-api-keys-api', () => {
     } as unknown as Response)
     global.fetch = fetchMock as unknown as typeof fetch
 
-    await listAnalyticsApiKeys(true, MAX_ANALYTICS_API_KEYS_LIST_LIMIT)
+    await listAnalyticsApiKeys(true, MAX_ANALYTICS_API_KEYS_LIST_LIMIT, MAX_ANALYTICS_API_KEYS_LIST_LIMIT)
 
     const [url] = fetchMock.mock.calls[0]
     expect(url).toBe(

--- a/analytics-web-app/src/lib/__tests__/ingestion-api-keys-api.test.ts
+++ b/analytics-web-app/src/lib/__tests__/ingestion-api-keys-api.test.ts
@@ -1,9 +1,10 @@
 /**
- * `listIngestionApiKeys` must explicitly request the server's max limit
- * (500) rather than omitting `limit` (which falls back to the server's
- * lower `DEFAULT_LIMIT` of 100) — omitting it silently truncates the list on
- * any deployment with more than 100 lifetime keys, with no indication
- * anything is missing. It must also thread `offset` through so the page can
+ * `listIngestionApiKeys` must send the caller's `limit` explicitly rather than
+ * omitting it (which falls back to the server's lower `DEFAULT_LIMIT` of
+ * 100) — omitting it silently truncates the list on any deployment with more
+ * than 100 lifetime keys, with no indication anything is missing. The page
+ * passes `MAX_INGESTION_API_KEYS_LIST_LIMIT` (the server's max), so that's what
+ * goes on the wire. `offset` must be threaded through too, so the page can
  * page past the first 500 lifetime keys.
  */
 import { listIngestionApiKeys, MAX_INGESTION_API_KEYS_LIST_LIMIT } from '../ingestion-api-keys-api'
@@ -13,19 +14,20 @@ describe('ingestion-api-keys-api', () => {
     vi.restoreAllMocks()
   })
 
-  it('listIngestionApiKeys requests the server max limit and offset 0 by default', async () => {
+  it('listIngestionApiKeys sends the given limit and offset 0 on the first page', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve([]),
     } as unknown as Response)
     global.fetch = fetchMock as unknown as typeof fetch
 
-    await listIngestionApiKeys()
+    await listIngestionApiKeys(true, 0, MAX_INGESTION_API_KEYS_LIST_LIMIT)
 
     const [url] = fetchMock.mock.calls[0]
     expect(url).toBe(
       `/api/ingestion-api-keys?limit=${MAX_INGESTION_API_KEYS_LIST_LIMIT}&offset=0&include_revoked=true`
     )
+    // The page's default page size is the server's own `MAX_LIMIT`.
     expect(MAX_INGESTION_API_KEYS_LIST_LIMIT).toBe(500)
   })
 
@@ -36,7 +38,7 @@ describe('ingestion-api-keys-api', () => {
     } as unknown as Response)
     global.fetch = fetchMock as unknown as typeof fetch
 
-    await listIngestionApiKeys(true, MAX_INGESTION_API_KEYS_LIST_LIMIT)
+    await listIngestionApiKeys(true, MAX_INGESTION_API_KEYS_LIST_LIMIT, MAX_INGESTION_API_KEYS_LIST_LIMIT)
 
     const [url] = fetchMock.mock.calls[0]
     expect(url).toBe(

--- a/analytics-web-app/src/lib/analytics-api-keys-api.ts
+++ b/analytics-web-app/src/lib/analytics-api-keys-api.ts
@@ -15,14 +15,14 @@ import {
   MintApiKeyResponse,
 } from './api-keys-shared'
 
-// The server's own hard cap (`MAX_LIMIT` in `rust/analytics-web-srv/src/analytics_keys.rs`),
-// used here as the page size for offset-based paging. Requested explicitly on
-// every list call — omitting `limit` falls back to the server's lower
-// `DEFAULT_LIMIT` (100), which silently truncates the list on any deployment
-// with more than 100 *lifetime* keys (revoked keys are never deleted, and
-// `include_revoked` defaults to true) with zero indication anything is
-// missing. Exported so the page can detect "there may be another page" by
-// comparing the returned row count against this same value.
+// The server's own hard cap (`MAX_LIMIT` in
+// `rust/analytics-web-srv/src/analytics_keys.rs`), used as the default page size for
+// offset-based paging. The page passes it to every list call — omitting `limit`
+// falls back to the server's lower `DEFAULT_LIMIT` (100), which silently
+// truncates the list on any deployment with more than 100 *lifetime* keys
+// (revoked keys are never deleted, and `include_revoked` defaults to true) with
+// zero indication anything is missing. The page also compares the returned row
+// count against its page size to detect "there may be another page".
 export const MAX_ANALYTICS_API_KEYS_LIST_LIMIT = 500
 
 export type AnalyticsApiKeyListEntry = ApiKeyListEntry
@@ -41,7 +41,6 @@ export interface AnalyticsApiKeyErrorResponse {
 const api = createApiKeysApi<AnalyticsApiKeyErrorResponse, RevokeAnalyticsApiKeyResponse>({
   basePath: '/analytics-api-keys',
   errorName: 'AnalyticsApiKeyError',
-  maxListLimit: MAX_ANALYTICS_API_KEYS_LIST_LIMIT,
 })
 
 export const AnalyticsApiKeyError = api.ErrorClass

--- a/analytics-web-app/src/lib/api-keys-shared.ts
+++ b/analytics-web-app/src/lib/api-keys-shared.ts
@@ -61,13 +61,11 @@ export interface ApiKeysApiConfig {
   basePath: string
   /** `.name` of the per-module error class, e.g. 'AnalyticsApiKeyError'. */
   errorName: string
-  /** The server's hard cap on `limit`, used as the page size for offset-based paging. */
-  maxListLimit: number
 }
 
 export interface ApiKeysApi<TRevokeResponse> {
   ErrorClass: ApiKeyErrorConstructor
-  list: (includeRevoked?: boolean, offset?: number) => Promise<ApiKeyListEntry[]>
+  list: (includeRevoked: boolean, offset: number, limit: number) => Promise<ApiKeyListEntry[]>
   mint: (name: string, audience?: string) => Promise<MintApiKeyResponse>
   revoke: (keyId: string) => Promise<TRevokeResponse>
 }
@@ -95,9 +93,19 @@ export function createApiKeysApi<
     return response.json()
   }
 
-  async function list(includeRevoked = true, offset = 0): Promise<ApiKeyListEntry[]> {
+  // `limit` is the caller's page size rather than a module constant: the admin
+  // page owns the value (it also drives the offset arithmetic and the
+  // "is there a next page?" row-count comparison), so a single number has to
+  // reach both the query string and the paging UI. All three args are
+  // required — a defaulted `limit` here could silently disagree with the page
+  // size the UI is comparing against.
+  async function list(
+    includeRevoked: boolean,
+    offset: number,
+    limit: number
+  ): Promise<ApiKeyListEntry[]> {
     const response = await authenticatedFetch(
-      `${getApiBase()}${config.basePath}?limit=${config.maxListLimit}&offset=${offset}&include_revoked=${includeRevoked}`
+      `${getApiBase()}${config.basePath}?limit=${limit}&offset=${offset}&include_revoked=${includeRevoked}`
     )
     return handleResponse<ApiKeyListEntry[]>(response)
   }

--- a/analytics-web-app/src/lib/ingestion-api-keys-api.ts
+++ b/analytics-web-app/src/lib/ingestion-api-keys-api.ts
@@ -19,14 +19,13 @@ import {
 } from './api-keys-shared'
 
 // The server's own hard cap (`MAX_LIMIT` in
-// `rust/analytics-web-srv/src/ingestion_keys.rs`), used here as the page size
-// for offset-based paging. Requested explicitly on every list call — omitting
-// `limit` falls back to the server's lower `DEFAULT_LIMIT` (100), which
-// silently truncates the list on any deployment with more than 100 *lifetime*
-// keys (revoked keys are never deleted, and `include_revoked` defaults to
-// true) with zero indication anything is missing. Exported so the page can
-// detect "there may be another page" by comparing the returned row count
-// against this same value.
+// `rust/analytics-web-srv/src/ingestion_keys.rs`), used as the default page size for
+// offset-based paging. The page passes it to every list call — omitting `limit`
+// falls back to the server's lower `DEFAULT_LIMIT` (100), which silently
+// truncates the list on any deployment with more than 100 *lifetime* keys
+// (revoked keys are never deleted, and `include_revoked` defaults to true) with
+// zero indication anything is missing. The page also compares the returned row
+// count against its page size to detect "there may be another page".
 export const MAX_INGESTION_API_KEYS_LIST_LIMIT = 500
 
 export type IngestionApiKeyListEntry = ApiKeyListEntry
@@ -45,7 +44,6 @@ export interface IngestionApiKeyErrorResponse {
 const api = createApiKeysApi<IngestionApiKeyErrorResponse, RevokeIngestionApiKeyResponse>({
   basePath: '/ingestion-api-keys',
   errorName: 'IngestionApiKeyError',
-  maxListLimit: MAX_INGESTION_API_KEYS_LIST_LIMIT,
 })
 
 export const IngestionApiKeyError = api.ErrorClass

--- a/analytics-web-app/src/routes/AnalyticsApiKeysPage.tsx
+++ b/analytics-web-app/src/routes/AnalyticsApiKeysPage.tsx
@@ -22,14 +22,24 @@ const analyticsApiKeysPageConfig: ApiKeysAdminPageConfig = {
   loadErrorMessage: 'Failed to load analytics API keys',
   revokeConfirmMessage: (name) =>
     `Are you sure you want to revoke "${name}"? Any client using this key will lose access.`,
-  maxListLimit: MAX_ANALYTICS_API_KEYS_LIST_LIMIT,
   ErrorClass: AnalyticsApiKeyError,
   listKeys: listAnalyticsApiKeys,
   mintKey: mintAnalyticsApiKey,
   revokeKey: revokeAnalyticsApiKey,
 }
 
-export default function AnalyticsApiKeysPage() {
+export interface AnalyticsApiKeysPageProps {
+  /**
+   * Rows per page. Defaults to the server's max list limit; the route renders
+   * this component with no props, so only tests ever pass a smaller size (to
+   * exercise paging without rendering a full page of rows).
+   */
+  pageSize?: number
+}
+
+export default function AnalyticsApiKeysPage({
+  pageSize = MAX_ANALYTICS_API_KEYS_LIST_LIMIT,
+}: AnalyticsApiKeysPageProps = {}) {
   return (
     <Suspense
       fallback={
@@ -44,7 +54,7 @@ export default function AnalyticsApiKeysPage() {
         </AuthGuard>
       }
     >
-      <ApiKeysAdminPage config={analyticsApiKeysPageConfig} />
+      <ApiKeysAdminPage config={analyticsApiKeysPageConfig} pageSize={pageSize} />
     </Suspense>
   )
 }

--- a/analytics-web-app/src/routes/AnalyticsApiKeysPage.tsx
+++ b/analytics-web-app/src/routes/AnalyticsApiKeysPage.tsx
@@ -39,7 +39,7 @@ export interface AnalyticsApiKeysPageProps {
 
 export default function AnalyticsApiKeysPage({
   pageSize = MAX_ANALYTICS_API_KEYS_LIST_LIMIT,
-}: AnalyticsApiKeysPageProps = {}) {
+}: AnalyticsApiKeysPageProps) {
   return (
     <Suspense
       fallback={

--- a/analytics-web-app/src/routes/IngestionApiKeysPage.tsx
+++ b/analytics-web-app/src/routes/IngestionApiKeysPage.tsx
@@ -40,7 +40,7 @@ export interface IngestionApiKeysPageProps {
 
 export default function IngestionApiKeysPage({
   pageSize = MAX_INGESTION_API_KEYS_LIST_LIMIT,
-}: IngestionApiKeysPageProps = {}) {
+}: IngestionApiKeysPageProps) {
   return (
     <Suspense
       fallback={

--- a/analytics-web-app/src/routes/IngestionApiKeysPage.tsx
+++ b/analytics-web-app/src/routes/IngestionApiKeysPage.tsx
@@ -22,7 +22,6 @@ const ingestionApiKeysPageConfig: ApiKeysAdminPageConfig = {
   loadErrorMessage: 'Failed to load ingestion API keys',
   revokeConfirmMessage: (name) =>
     `Are you sure you want to revoke "${name}"? Any client using this key will lose access once the revocation propagates.`,
-  maxListLimit: MAX_INGESTION_API_KEYS_LIST_LIMIT,
   ErrorClass: IngestionApiKeyError,
   listKeys: listIngestionApiKeys,
   mintKey: mintIngestionApiKey,
@@ -30,7 +29,18 @@ const ingestionApiKeysPageConfig: ApiKeysAdminPageConfig = {
   showAudience: true,
 }
 
-export default function IngestionApiKeysPage() {
+export interface IngestionApiKeysPageProps {
+  /**
+   * Rows per page. Defaults to the server's max list limit; the route renders
+   * this component with no props, so only tests ever pass a smaller size (to
+   * exercise paging without rendering a full page of rows).
+   */
+  pageSize?: number
+}
+
+export default function IngestionApiKeysPage({
+  pageSize = MAX_INGESTION_API_KEYS_LIST_LIMIT,
+}: IngestionApiKeysPageProps = {}) {
   return (
     <Suspense
       fallback={
@@ -45,7 +55,7 @@ export default function IngestionApiKeysPage() {
         </AuthGuard>
       }
     >
-      <ApiKeysAdminPage config={ingestionApiKeysPageConfig} />
+      <ApiKeysAdminPage config={ingestionApiKeysPageConfig} pageSize={pageSize} />
     </Suspense>
   )
 }

--- a/analytics-web-app/src/routes/__tests__/AnalyticsApiKeysPage.test.tsx
+++ b/analytics-web-app/src/routes/__tests__/AnalyticsApiKeysPage.test.tsx
@@ -41,10 +41,16 @@ vi.mock('@/components/layout', () => ({
   PageLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 
-function renderPage() {
+// Page size for the pagination tests. Small on purpose: a "full page" case
+// has to return exactly `pageSize` rows for the Next button to appear, and
+// rendering the real default (the server's 500-row max) in jsdom took ~5s —
+// enough to trip vitest's default test timeout on a loaded CI runner.
+const TEST_PAGE_SIZE = 3
+
+function renderPage(pageSize?: number) {
   return render(
     <MemoryRouter>
-      <AnalyticsApiKeysPage />
+      <AnalyticsApiKeysPage pageSize={pageSize} />
     </MemoryRouter>
   )
 }
@@ -65,6 +71,22 @@ describe('AnalyticsApiKeysPage', () => {
     await waitFor(() =>
       expect(screen.getByText(/No analytics API keys yet/i)).toBeInTheDocument()
     )
+  })
+
+  it('lists at the server max limit by default', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    } as unknown as Response)
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    // No `pageSize` prop — the route renders the page this way, and it must
+    // ask for the server's max rather than letting `limit` fall back to the
+    // server's lower `DEFAULT_LIMIT` of 100, which silently truncates.
+    renderPage()
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    expect(fetchMock.mock.calls[0][0]).toContain(`limit=${MAX_ANALYTICS_API_KEYS_LIST_LIMIT}`)
   })
 
   it('lists existing keys from the list response', async () => {
@@ -190,26 +212,26 @@ describe('AnalyticsApiKeysPage', () => {
     expect(screen.getByText(/won't be shown again/i)).toBeInTheDocument()
   })
 
-  it('shows a Next button when the list returns exactly the max limit', async () => {
+  it('shows a Next button when the list returns exactly one full page', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve(makeKeys(MAX_ANALYTICS_API_KEYS_LIST_LIMIT)),
+      json: () => Promise.resolve(makeKeys(TEST_PAGE_SIZE)),
     } as unknown as Response) as unknown as typeof fetch
 
-    renderPage()
+    renderPage(TEST_PAGE_SIZE)
 
     await waitFor(() => expect(screen.getByText('key-0')).toBeInTheDocument())
     expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Previous' })).not.toBeInTheDocument()
   })
 
-  it('shows no Next button when the list returns fewer than the max limit', async () => {
+  it('shows no Next button when the list returns fewer than a full page', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve(makeKeys(1)),
+      json: () => Promise.resolve(makeKeys(TEST_PAGE_SIZE - 1)),
     } as unknown as Response) as unknown as typeof fetch
 
-    renderPage()
+    renderPage(TEST_PAGE_SIZE)
 
     await waitFor(() => expect(screen.getByText('key-0')).toBeInTheDocument())
     expect(screen.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument()
@@ -220,7 +242,7 @@ describe('AnalyticsApiKeysPage', () => {
       .fn()
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(makeKeys(MAX_ANALYTICS_API_KEYS_LIST_LIMIT)),
+        json: () => Promise.resolve(makeKeys(TEST_PAGE_SIZE)),
       } as unknown as Response)
       .mockResolvedValueOnce({
         ok: true,
@@ -228,14 +250,14 @@ describe('AnalyticsApiKeysPage', () => {
       } as unknown as Response)
     global.fetch = fetchMock as unknown as typeof fetch
 
-    renderPage()
+    renderPage(TEST_PAGE_SIZE)
 
     const nextButton = await screen.findByRole('button', { name: 'Next' })
     fireEvent.click(nextButton)
 
     await waitFor(() => {
       const [url] = fetchMock.mock.calls[1]
-      expect(url).toContain(`offset=${MAX_ANALYTICS_API_KEYS_LIST_LIMIT}`)
+      expect(url).toContain(`offset=${TEST_PAGE_SIZE}`)
     })
 
     expect(await screen.findByRole('button', { name: 'Previous' })).toBeInTheDocument()
@@ -247,7 +269,7 @@ describe('AnalyticsApiKeysPage', () => {
       // Initial load: page 1, full page (so Next is shown).
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(makeKeys(MAX_ANALYTICS_API_KEYS_LIST_LIMIT)),
+        json: () => Promise.resolve(makeKeys(TEST_PAGE_SIZE)),
       } as unknown as Response)
       // Load after clicking Next: page 2.
       .mockResolvedValueOnce({
@@ -272,7 +294,7 @@ describe('AnalyticsApiKeysPage', () => {
       } as unknown as Response)
     global.fetch = fetchMock as unknown as typeof fetch
 
-    renderPage()
+    renderPage(TEST_PAGE_SIZE)
 
     const nextButton = await screen.findByRole('button', { name: 'Next' })
     fireEvent.click(nextButton)

--- a/analytics-web-app/src/routes/__tests__/AnalyticsApiKeysPage.test.tsx
+++ b/analytics-web-app/src/routes/__tests__/AnalyticsApiKeysPage.test.tsx
@@ -43,8 +43,9 @@ vi.mock('@/components/layout', () => ({
 
 // Page size for the pagination tests. Small on purpose: a "full page" case
 // has to return exactly `pageSize` rows for the Next button to appear, and
-// rendering the real default (the server's 500-row max) in jsdom took ~5s —
-// enough to trip vitest's default test timeout on a loaded CI runner.
+// rendering the real default (the server's 500-row max) in jsdom is
+// noticeably slower — using a small page size here keeps this file's test
+// time roughly 6x faster.
 const TEST_PAGE_SIZE = 3
 
 function renderPage(pageSize?: number) {

--- a/analytics-web-app/src/routes/__tests__/IngestionApiKeysPage.test.tsx
+++ b/analytics-web-app/src/routes/__tests__/IngestionApiKeysPage.test.tsx
@@ -43,8 +43,9 @@ vi.mock('@/components/layout', () => ({
 
 // Page size for the pagination tests. Small on purpose: a "full page" case
 // has to return exactly `pageSize` rows for the Next button to appear, and
-// rendering the real default (the server's 500-row max) in jsdom took ~5s —
-// enough to trip vitest's default test timeout on a loaded CI runner.
+// rendering the real default (the server's 500-row max) in jsdom is
+// noticeably slower — using a small page size here keeps this file's test
+// time roughly 6x faster.
 const TEST_PAGE_SIZE = 3
 
 function renderPage(pageSize?: number) {

--- a/analytics-web-app/src/routes/__tests__/IngestionApiKeysPage.test.tsx
+++ b/analytics-web-app/src/routes/__tests__/IngestionApiKeysPage.test.tsx
@@ -41,10 +41,16 @@ vi.mock('@/components/layout', () => ({
   PageLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 
-function renderPage() {
+// Page size for the pagination tests. Small on purpose: a "full page" case
+// has to return exactly `pageSize` rows for the Next button to appear, and
+// rendering the real default (the server's 500-row max) in jsdom took ~5s —
+// enough to trip vitest's default test timeout on a loaded CI runner.
+const TEST_PAGE_SIZE = 3
+
+function renderPage(pageSize?: number) {
   return render(
     <MemoryRouter>
-      <IngestionApiKeysPage />
+      <IngestionApiKeysPage pageSize={pageSize} />
     </MemoryRouter>
   )
 }
@@ -65,6 +71,22 @@ describe('IngestionApiKeysPage', () => {
     await waitFor(() =>
       expect(screen.getByText(/No ingestion API keys yet/i)).toBeInTheDocument()
     )
+  })
+
+  it('lists at the server max limit by default', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    } as unknown as Response)
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    // No `pageSize` prop — the route renders the page this way, and it must
+    // ask for the server's max rather than letting `limit` fall back to the
+    // server's lower `DEFAULT_LIMIT` of 100, which silently truncates.
+    renderPage()
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    expect(fetchMock.mock.calls[0][0]).toContain(`limit=${MAX_INGESTION_API_KEYS_LIST_LIMIT}`)
   })
 
   it('lists existing keys from the list response', async () => {
@@ -239,26 +261,26 @@ describe('IngestionApiKeysPage', () => {
     expect(screen.getByText(/won't be shown again/i)).toBeInTheDocument()
   })
 
-  it('shows a Next button when the list returns exactly the max limit', async () => {
+  it('shows a Next button when the list returns exactly one full page', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve(makeKeys(MAX_INGESTION_API_KEYS_LIST_LIMIT)),
+      json: () => Promise.resolve(makeKeys(TEST_PAGE_SIZE)),
     } as unknown as Response) as unknown as typeof fetch
 
-    renderPage()
+    renderPage(TEST_PAGE_SIZE)
 
     await waitFor(() => expect(screen.getByText('key-0')).toBeInTheDocument())
     expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Previous' })).not.toBeInTheDocument()
   })
 
-  it('shows no Next button when the list returns fewer than the max limit', async () => {
+  it('shows no Next button when the list returns fewer than a full page', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve(makeKeys(1)),
+      json: () => Promise.resolve(makeKeys(TEST_PAGE_SIZE - 1)),
     } as unknown as Response) as unknown as typeof fetch
 
-    renderPage()
+    renderPage(TEST_PAGE_SIZE)
 
     await waitFor(() => expect(screen.getByText('key-0')).toBeInTheDocument())
     expect(screen.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument()
@@ -269,7 +291,7 @@ describe('IngestionApiKeysPage', () => {
       .fn()
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(makeKeys(MAX_INGESTION_API_KEYS_LIST_LIMIT)),
+        json: () => Promise.resolve(makeKeys(TEST_PAGE_SIZE)),
       } as unknown as Response)
       .mockResolvedValueOnce({
         ok: true,
@@ -277,14 +299,14 @@ describe('IngestionApiKeysPage', () => {
       } as unknown as Response)
     global.fetch = fetchMock as unknown as typeof fetch
 
-    renderPage()
+    renderPage(TEST_PAGE_SIZE)
 
     const nextButton = await screen.findByRole('button', { name: 'Next' })
     fireEvent.click(nextButton)
 
     await waitFor(() => {
       const [url] = fetchMock.mock.calls[1]
-      expect(url).toContain(`offset=${MAX_INGESTION_API_KEYS_LIST_LIMIT}`)
+      expect(url).toContain(`offset=${TEST_PAGE_SIZE}`)
     })
 
     expect(await screen.findByRole('button', { name: 'Previous' })).toBeInTheDocument()
@@ -296,7 +318,7 @@ describe('IngestionApiKeysPage', () => {
       // Initial load: page 1, full page (so Next is shown).
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(makeKeys(MAX_INGESTION_API_KEYS_LIST_LIMIT)),
+        json: () => Promise.resolve(makeKeys(TEST_PAGE_SIZE)),
       } as unknown as Response)
       // Load after clicking Next: page 2.
       .mockResolvedValueOnce({
@@ -321,7 +343,7 @@ describe('IngestionApiKeysPage', () => {
       } as unknown as Response)
     global.fetch = fetchMock as unknown as typeof fetch
 
-    renderPage()
+    renderPage(TEST_PAGE_SIZE)
 
     const nextButton = await screen.findByRole('button', { name: 'Next' })
     fireEvent.click(nextButton)


### PR DESCRIPTION
## Summary

* Thread the API-key admin page size through one place instead of a module constant.
  `ApiKeysAdminPage` now takes a `pageSize` prop that drives the `limit` on each list call, the
  Previous/Next offset step, and the full-page row count used to decide whether a Next button
  appears.
* `createApiKeysApi`'s `list` takes `limit` as a required argument rather than baking in
  `MAX_*_API_KEYS_LIST_LIMIT`, so callers must state the page size they want.
* Each route page (`AnalyticsApiKeysPage`, `IngestionApiKeysPage`) defaults `pageSize` to its own
  server max list limit. No behavior change in the app — the default is the same 500.
* The motivation is the pagination tests: to make a Next button appear they had to render a full
  default page — 500 rows — in jsdom, which was slow enough under CI load to trip vitest's 5000ms
  default timeout on `IngestionApiKeysPage` (the `AnalyticsApiKeysPage` twin passed the same run at
  4893ms). Those tests now page at 3 rows, and a new test on each page keeps the production 500
  default covered on the wire.

## Test plan

* `yarn lint` in `analytics-web-app/` — 0 errors (6 pre-existing `react-refresh` warnings).
* `yarn type-check` — clean.
* `yarn test` — 79 files, 1474 tests pass.
* The two new "lists at the server max limit by default" tests assert the route pages still request
  `limit: 500`, so the production page size stays covered even though the pagination tests use a
  small one.
* Manually: the Analytics and Ingestion API Keys admin pages paginate as before.
