### PR TITLE
Fix 4 Dependabot alerts: fast-uri host confusion/SSRF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents the historical progress of the Micromegas project. For current focus, please see the main [README.md](./README.md).
 
+## Unreleased
+
+* **Dependencies:** Bump `fast-uri` (transitive, via `ajv`) to `^3.1.6` via yarn `resolutions` at the repo root to resolve Dependabot alerts 469, 470, 471, 472 (GHSA-jqff-g426-hqxp, GHSA-fph4-wmhf-6fwf, GHSA-f65p-4m7j-42xc, GHSA-5jgf-p345-68v8 — host confusion and SSRF via IDN/IPv6/percent-decoding normalization bugs).
+
 ## v0.30.0 - 2026-09-02
 
 * **Auth:**

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "diff": "^8.0.3",
     "dompurify": "^3.4.13",
     "eslint/ajv": "6.14.0",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.6",
     "flatted": "^3.4.2",
     "immutable": "^5.1.8",
     "js-cookie": "^3.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6348,10 +6348,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.1.5":
-  version: 3.1.5
-  resolution: "fast-uri@npm:3.1.5"
-  checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
+"fast-uri@npm:^3.1.6":
+  version: 3.1.7
+  resolution: "fast-uri@npm:3.1.7"
+  checksum: 10c0/ca2baa4bde48fc7322bdc692c6636975943ebe4f6dd97e07d70b14e0ab85af2ff30de90f550f5ec2956684fe208e150d85d6cb5f3c74438c8ac1bf86bd435c13
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
* Bump `fast-uri` (transitive, via `ajv`) to `^3.1.6` via yarn `resolutions` at the repo root, fixing [Dependabot alert 469](https://github.com/madesroches/micromegas/security/dependabot/469) (GHSA-jqff-g426-hqxp, host confusion via percent-encoded scheme normalization), [alert 470](https://github.com/madesroches/micromegas/security/dependabot/470) (GHSA-fph4-wmhf-6fwf, SSRF via repeated hostname percent-decoding), [alert 471](https://github.com/madesroches/micromegas/security/dependabot/471) (GHSA-f65p-4m7j-42xc, SSRF via malformed IPv6 normalization), and [alert 472](https://github.com/madesroches/micromegas/security/dependabot/472) (GHSA-5jgf-p345-68v8, host confusion via skipped IDN canonicalization on scheme-relative references).
* The existing `fast-uri` resolution override was pinned to `^3.1.5`, one patch behind the fixed `3.1.6` release; `yarn install` now resolves it to `3.1.7`.

## Test plan
- [x] `yarn install` at repo root: resolves `fast-uri` to `3.1.7`, no other lockfile changes.
