### PR TITLE
Fix 2 Dependabot alerts: fflate unzipSync infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file documents the historical progress of the Micromegas project. For curre
 
 ## Unreleased
 
+* **Dependencies:** Bump `fflate` (transitive, via `three-stdlib` and `@types/three`) to `^0.6.11` and `~0.8.3` via scoped yarn `resolutions` in `analytics-web-app` to resolve Dependabot alerts 473 and 474 (GHSA-px8p-9vwx-vf98 — `unzipSync` infinite loop on malformed ZIP64 archives).
 * **Dependencies:** Bump `fast-uri` (transitive, via `ajv`) to `^3.1.6` via yarn `resolutions` at the repo root to resolve Dependabot alerts 469, 470, 471, 472 (GHSA-jqff-g426-hqxp, GHSA-fph4-wmhf-6fwf, GHSA-f65p-4m7j-42xc, GHSA-5jgf-p345-68v8 — host confusion and SSRF via IDN/IPv6/percent-decoding normalization bugs).
 
 ## v0.30.0 - 2026-09-02

--- a/analytics-web-app/package.json
+++ b/analytics-web-app/package.json
@@ -48,6 +48,7 @@
     "uplot": "^1.6.32"
   },
   "resolutions": {
+    "@types/three/fflate": "~0.8.3",
     "ajv": "6.14.0",
     "brace-expansion": "^5.0.9",
     "flatted": "^3.4.2",
@@ -55,6 +56,7 @@
     "postcss": "^8.5.18",
     "rollup": "^4.59.0",
     "tar": "^7.5.21",
+    "three-stdlib/fflate": "^0.6.11",
     "undici": ">=8.9.0",
     "ws": "^8.21.0"
   },

--- a/analytics-web-app/yarn.lock
+++ b/analytics-web-app/yarn.lock
@@ -3290,17 +3290,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fflate@npm:^0.6.9":
-  version: 0.6.10
-  resolution: "fflate@npm:0.6.10"
-  checksum: 10c0/c452f720e4cb404b300fceb8ef0bdf345f18fbfd3f57f7d0974dce5f5e2ac0e8dd4b6ff4bb7061ae74fd919b9c707172f9dbd44d91149b1137199b8c705768f1
+"fflate@npm:^0.6.11":
+  version: 0.6.11
+  resolution: "fflate@npm:0.6.11"
+  checksum: 10c0/5bbf4a7557db6f65b25c7bb12621008c400a116ec1cc65bea78abd75c0c049d8a22fb92f0a59fbf9a7ad1a24a47d2112ce10fd817d08db0e1bf7dc82e780faa1
   languageName: node
   linkType: hard
 
-"fflate@npm:~0.8.2":
-  version: 0.8.2
-  resolution: "fflate@npm:0.8.2"
-  checksum: 10c0/03448d630c0a583abea594835a9fdb2aaf7d67787055a761515bf4ed862913cfd693b4c4ffd5c3f3b355a70cf1e19033e9ae5aedcca103188aaff91b8bd6e293
+"fflate@npm:~0.8.3":
+  version: 0.8.3
+  resolution: "fflate@npm:0.8.3"
+  checksum: 10c0/eab181ca37f5348ae76d4b6f840e0026e30220e33153289ac942222d8b9638237d486507dbcc09878d724095bd354993a2ee48bbee99c8f2c6440d4448719aa7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
* Bump `fflate` to patched releases via scoped yarn `resolutions` in `analytics-web-app`, fixing [Dependabot alert 473](https://github.com/madesroches/micromegas/security/dependabot/473) and [alert 474](https://github.com/madesroches/micromegas/security/dependabot/474) (both GHSA-px8p-9vwx-vf98, `unzipSync` infinite loop on malformed ZIP64 archives).
* The advisory hits two separate transitive copies in the lockfile, so a single unscoped resolution can't cover both majors: `three-stdlib/fflate` goes `^0.6.9` → `^0.6.11` (0.6.10 → 0.6.11) and `@types/three/fflate` goes `~0.8.2` → `~0.8.3` (0.8.2 → 0.8.3).
* Both patched versions fall inside the dependents' existing ranges, so nothing else in `yarn.lock` moved.

## Test plan
- [x] `yarn install` in `analytics-web-app`: resolves `fflate` to `0.6.11` and `0.8.3`, the only lockfile changes.
- [x] `yarn build` — succeeds.
- [x] `yarn test` — 1570 tests across 88 files pass.
- [x] `yarn lint` — 0 errors (6 pre-existing warnings, unchanged).
